### PR TITLE
Fix webroot detection for rampage controllers

### DIFF
--- a/lib/Horde/Core/Controller/RequestMapper.php
+++ b/lib/Horde/Core/Controller/RequestMapper.php
@@ -25,7 +25,14 @@ class Horde_Core_Controller_RequestMapper
 
         $uri = substr($request->getPath(), strlen($registry->get('webroot', 'horde')));
         $uri = trim($uri, '/');
-        if (strpos($uri, '/') === false) {
+        if (empty($uri)) {
+            foreach ($registry->listApps() as $app) {
+                $uri = substr($request->getPath(), strlen($registry->get('webroot', $app)));
+                if (!empty($uri)) {
+                    break;
+                }
+            }
+        } elseif (strpos($uri, '/') === false) {
             $app = $uri;
         } else {
             list($app,) = explode('/', $uri, 2);


### PR DESCRIPTION
Fix finding the correct app and rule file for apps which live outside the horde webroot as in https://tasks.domain.com rather than https://groupware.domain.com/nag/

Note this use case also needs an appropriate htdocs file or other forwarding rule to the horde rampage.php script  - this is outside the scope of this patch.