### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/lib/Horde/Core/Tagger.php
+++ b/lib/Horde/Core/Tagger.php
@@ -69,7 +69,7 @@ abstract class Horde_Core_Tagger
             $types = $injector->getInstance('Content_Types_Manager')
                 ->ensureTypes($this->_types);
             foreach ($this->_types as $k => $v) {
-                $this->_type_ids[$v] = intval($types[$k]);
+                $this->_type_ids[$v] = intval($types ? $types[$k] : 0);
             }
             $cache->set($key, serialize($this->_type_ids));
         }


### PR DESCRIPTION
Running kronolith test suite with 7.4

```
There were 2 errors:
1) Kronolith_Integration_Driver_Sql_Pdo_SqliteTest::testRecurrence
Trying to access array offset on value of type null
/usr/share/pear/Horde/Core/Tagger.php:72
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Kronolith.php:2875
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver.php:630
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver/Sql.php:710
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver.php:373
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/test/Kronolith/Integration/Driver/Base.php:94
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/test/Kronolith/Integration/Driver/Base.php:101
2) Kronolith_Integration_Driver_Sql_Pdo_SqliteTest::testRecurrenceException
Trying to access array offset on value of type null
/usr/share/pear/Horde/Core/Tagger.php:72
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Kronolith.php:2875
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver.php:630
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver/Sql.php:710
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/lib/Driver.php:373
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/test/Kronolith/Integration/Driver/Base.php:94
/builddir/build/BUILD/php-horde-kronolith-4.2.27/kronolith-4.2.27/test/Kronolith/Integration/Driver/Base.php:112

```

This trivial fix only fix the warning, with keeping previous version behavior (logic not reviewed)