### PR TITLE
fix selection of mode on login

### DIFF
--- a/lib/Horde/Core/Auth/Application.php
+++ b/lib/Horde/Core/Auth/Application.php
@@ -666,16 +666,16 @@ class Horde_Core_Auth_Application extends Horde_Auth_Base
             return false;
         }
 
+        /* Only set the view mode on initial authentication */
+        if (!$GLOBALS['session']->exists('horde', 'view')) {
+            $this->_setView();
+        }
+
         $registry->setAuth($userId, $credentials, array(
             'app' => $this->_app,
             'change' => $this->getCredential('change'),
             'language' => $language
         ));
-
-        /* Only set the view mode on initial authentication */
-        if (!$GLOBALS['session']->exists('horde', 'view')) {
-            $this->_setView();
-        }
 
         if ($this->_base &&
             isset($GLOBALS['notification']) &&


### PR DESCRIPTION
When the User selects a mode on the login form (ie. setting horde_select_view),
it gets always overwritten by 'auto'. The reason is that during login there is
a cycle that leads to authentication being triggered twice.

The culprit is the call to setAuth at
https://github.com/horde/Core/blob/master/lib/Horde/Core/Auth/Application.php#L669
which ends up triggering a second authentication through

    $this->loadPrefs($this->getApp());

which in turn does not have access to the original $credentials array and then
sets the view to the default value.

This patch breaks the cycle, by preventing the second auth when the first one
did not finish.