### PR TITLE
create a unique cache-file

### DIFF
--- a/lib/Horde/Core/Factory/Dns.php
+++ b/lib/Horde/Core/Factory/Dns.php
@@ -13,7 +13,7 @@ class Horde_Core_Factory_Dns extends Horde_Core_Factory_Injector
 
         if ($tmpdir = Horde::getTempDir()) {
             $config = array(
-                'cache_file' => $tmpdir . '/horde_dns.cache',
+                'cache_file' => $tmpdir . '/horde_dns.cache' . gethostname(),
                 'cache_size' => 100000,
                 'cache_type' => 'file',
             );


### PR DESCRIPTION
if one has a shared tmpdir, than several instances try to write into that file and bad things start to happen (segfaults)
as each instance has a unique hostname adding that to the filename solved that problem for us.