### PR TITLE
Composer Based Setup and Improved Horde_Core_Controller routing

### DIFF
--- a/lib/Horde/Core/Controller/NotAuthorized.php
+++ b/lib/Horde/Core/Controller/NotAuthorized.php
@@ -1,7 +1,31 @@
 <?php
 /**
+ * Copyright 2019-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
  * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
+ */
+
+/**
+ * The Horde_Core_Controller_NotAuthorized class provides 
+ * a premade controller for scenarios where a requester
+ * has not provided sufficient authentication to access
+ * a resource
+ *
+ * Copyright 2019-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL-2). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @package  Package
+ * @license  http://www.horde.org/licenses/lgpl LGPL-2
  */
 class Horde_Core_Controller_NotAuthorized implements Horde_Controller
 {

--- a/lib/Horde/Core/Controller/NotAuthorized.php
+++ b/lib/Horde/Core/Controller/NotAuthorized.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @category Horde
+ * @package  Core
+ */
+class Horde_Core_Controller_NotAuthorized implements Horde_Controller
+{
+    /**
+     */
+    public function processRequest(Horde_Controller_Request $request,
+                                   Horde_Controller_Response $response)
+    {
+        $response->setHeader('HTTP/1.0 401 ', 'Not Authorized');
+        $response->setBody('<!DOCTYPE html><html><head><title>401 Not Authorized</title></head><body><h1>401 Not Authorized</h1></body></html>');
+    }
+}

--- a/lib/Horde/Core/Controller/NotFound.php
+++ b/lib/Horde/Core/Controller/NotFound.php
@@ -1,7 +1,30 @@
 <?php
 /**
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Chuck Hagenbuch <chuck@horde.org>
  * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
+ */
+
+/**
+ * The Horde_Core_Controller_NotFound class provides 
+ * a premade controller for scenarios where a resource
+ * either does not exist or is not visible to the requester
+ *
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL-2). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl.
+ *
+ * @author   Chuck Hagenbuch <chuck@horde.org>
+ * @category Horde
+ * @package  Package
+ * @license  http://www.horde.org/licenses/lgpl LGPL-2
  */
 class Horde_Core_Controller_NotFound implements Horde_Controller
 {

--- a/lib/Horde/Core/Controller/RequestConfiguration.php
+++ b/lib/Horde/Core/Controller/RequestConfiguration.php
@@ -1,10 +1,29 @@
 <?php
 /**
- * Object to contain request information as it relates to which controller to
- * create.
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
  *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Michael Slusarz <slusarz@horde.org>
  * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
+ */
+
+/**
+ * The Horde_Core_Controller_RequestConfiguration class provides 
+ * information from the request to identify the Controller.
+ * 
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL-2). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl.
+ *
+ * @author   Michael Slusarz <slusarz@horde.org>
+ * @category Horde
+ * @package  Package
+ * @license  http://www.horde.org/licenses/lgpl LGPL-2
  */
 class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_RequestConfiguration
 {
@@ -28,6 +47,11 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Store the application which should handle the request
+     *
+     * @param string $application The application identifier
+     *
+     * @return void
      */
     public function setApplication($application)
     {
@@ -35,6 +59,9 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Return the application which should handle the request
+     *
+     * @return string The application identifier
      */
     public function getApplication()
     {
@@ -42,6 +69,11 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Store the application which should handle the request
+     *
+     * @param string $controllerName The controller class name
+     *
+     * @return void
      */
     public function setControllerName($controllerName)
     {
@@ -49,6 +81,9 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Return the controller class name
+     *
+     * @return string The controller name
      */
     public function getControllerName()
     {
@@ -56,6 +91,11 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Store the settings exporter class name
+     *
+     * @param string $settingsName The exporter class name
+     *
+     * @return void
      */
     public function setSettingsExporterName($settingsName)
     {
@@ -63,6 +103,9 @@ class Horde_Core_Controller_RequestConfiguration implements Horde_Controller_Req
     }
 
     /**
+     * Return the settings exporter class name
+     *
+     * @return string The exporter class name
      */
     public function getSettingsExporterName()
     {

--- a/lib/Horde/Core/Controller/RequestMapper.php
+++ b/lib/Horde/Core/Controller/RequestMapper.php
@@ -15,23 +15,121 @@ class Horde_Core_Controller_RequestMapper
         $this->_mapper = $mapper;
     }
 
+    /**
+     * Check if an app is the relevant source of routes for a request
+     *
+     * The original approach was too specific for the default horde use
+     * setup of an app always living below horde root
+     * We also need to think about the case of different hosts
+     *
+     * @return array(string, string) app and  App path if the app fits
+     */
+    protected function _resolveApp(
+        $registry,
+        $app,
+        $request,
+        $requestServer,
+        $hordeRoot = ''
+    ) {
+        $webroot = parse_url($registry->get('webroot', $app));
+        // Filter out absolute urls with domains unless they fit
+        if (!empty($webroot['host']) && ($webroot['host'] != $requestServer)) {
+            return array('', '');
+        }
+        // Relative to webroot
+        // This might be the case if the webroot is a horde app
+        // horde is symlinked to /horde
+        // and the other apps are relative to horde
+        // Also path is absolute if domain is given
+        $normalized = $this->_normalize($webroot['path']);
+        if ($this->_beginsWith($request->getPath(), $normalized)) {
+            return array($app, $normalized);
+        }
+        // Relative to horde
+        $normalized = $this->_normalize($hordeRoot . $webroot['path']);
+        if ($this->_beginsWith($request->getPath(), $normalized)) {
+            return array($app, $normalized);
+        }
+        return array('', '');
+    }
+
+    protected function _beginsWith($subject, $prefix)
+    {
+        return substr($subject, 0, strlen($prefix)) == $prefix;
+    }
+
+    protected function _normalize($path)
+    {
+        $partsIn = explode('/', $path);
+        $partsOut = [];
+        foreach ($partsIn as $part) {
+            // useless slashes
+            if (empty($part)) {
+                continue;
+            }
+            // useless level
+            if ($part == '.') {
+                continue;
+            }
+            // one level up
+            if ($part == '..') {
+                array_pop($partsOut);
+                continue;
+            }
+            $partsOut[] = $part;
+        }
+        return '/' . implode('/', $partsOut);
+    }
+
     public function getRequestConfiguration(Horde_Injector $injector)
     {
         $request = $injector->getInstance('Horde_Controller_Request');
+        $requestServer = $_SERVER['SERVER_NAME'];
         $registry = $injector->getInstance('Horde_Registry');
         $settingsFinder = $injector->getInstance('Horde_Core_Controller_SettingsFinder');
 
         $config = $injector->createInstance('Horde_Core_Controller_RequestConfiguration');
-
-        $uri = substr($request->getPath(), strlen($registry->get('webroot', 'horde')));
-        $uri = trim($uri, '/');
-        if (strpos($uri, '/') === false) {
-            $app = $uri;
-        } else {
-            list($app,) = explode('/', $uri, 2);
+        // $registry->listApps() without params returns empty on unauthenticated access
+        $apps = $registry->listApps(null, false, null);
+        // reserve horde case for last
+        $hordeRoot = parse_url($registry->get('webroot', 'horde'));
+        foreach ($apps as $app) {
+            list($foundApp, $prefix) = $this->_resolveApp(
+                $registry,
+                $app,
+                $request,
+                $requestServer,
+                $hordeRoot['path']
+            );
+            if ($foundApp || $prefix) {
+                $foundApp = $app;
+                break;
+            }
         }
-        $config->setApplication($app);
+        // If we found no app
+        // Or found an app which lives in webroot
+        // we need to check if horde may fit
+        if (empty($foundApp) || empty($prefix) || $prefix == '/') {
+            list($foundHorde, $prefixHorde) =
+            $this->_resolveApp($registry, 'horde', $request, $requestServer);
+            if ($foundHorde) {
+                $foundApp = 'horde';
+                $prefix = $prefixHorde;
+            }
+        }
 
+        // If we still found no app, give up
+        if (empty($foundApp)) {
+            $config->setControllerName('Horde_Core_Controller_NotFound');
+            return $config;
+        }
+        // Route mapper doesn't like / as prefix
+        if ($prefix == '/') {
+            $prefix = '';
+        }
+
+        $config->setApplication($foundApp);
+        $app = $foundApp;
         // Check for route definitions.
         $fileroot = $registry->get('fileroot', $app);
         $routeFile = $fileroot . '/config/routes.php';
@@ -42,33 +140,65 @@ class Horde_Core_Controller_RequestMapper
 
         // Push $app onto the registry
         $registry->pushApp($app);
-
         // Application routes are relative only to the application. Let the
         // mapper know where they start.
-        $this->_mapper->prefix = $registry->get('webroot', $app);
-
+        $this->_mapper->prefix = $prefix;
         // Set the application controller directory
         $this->_mapper->directory = $registry->get('fileroot', $app) . '/app/controllers';
 
         // Load application routes.
         $mapper = $this->_mapper;
+        $mapper->environ = array('REQUEST_METHOD' => $request->getMethod());
         include $routeFile;
         if (file_exists($fileroot . '/config/routes.local.php')) {
             include $fileroot . '/config/routes.local.php';
         }
-
         // Match
         // @TODO Cache routes
         $path = $request->getPath();
         if (($pos = strpos($path, '?')) !== false) {
             $path = substr($path, 0, $pos);
         }
+
         $match = $this->_mapper->match($path);
         if (isset($match['controller'])) {
             $config->setControllerName(Horde_String::ucfirst($app) . '_' . Horde_String::ucfirst($match['controller']) . '_Controller');
             $config->setSettingsExporterName($settingsFinder->getSettingsExporterName($config->getControllerName()));
         } else {
             $config->setControllerName('Horde_Core_Controller_NotFound');
+        }
+        // TODO: Move to some ControllerAuthHelper and check perms and admin
+        if (!$registry->isAuthenticated()) {
+            $auth = $injector->getInstance('Horde_Core_Factory_Auth')->create();
+
+            // Default behaviour should be to authenticate as older controllers expect it. This should be overrideable
+            if (!isset($match['HordeAuthType'])) {
+                $match['HordeAuthType'] = 'DEFAULT';
+            }
+            // Keep unauthenticated
+            if ($match['HordeAuthType'] == 'NONE') {
+                return $config;
+            }
+            if ($match['HordeAuthType'] == 'DEFAULT') {
+                // Try to authenticate, otherwise redirect to login page
+                // Check for basic auth
+                if (isset($_SERVER['PHP_AUTH_USER']) and isset($_SERVER['PHP_AUTH_PW'])) {
+                    $res = $auth->authenticate($_SERVER['PHP_AUTH_USER'], ['password' => $_SERVER['PHP_AUTH_PW']]);
+                    if ($res) {
+                        return $config;
+                    }
+                }
+                $registry->getServiceLink('login');
+                Horde::url($registry->getInitialPage('horde'))->redirect();
+            }
+            // In API mode, either allow a request
+            if ($match['HordeAuthType'] == 'BASIC') {
+                if ($auth->authenticate($_SERVER['PHP_AUTH_USER'], ['password' => $_SERVER['PHP_AUTH_PW']])) {
+                    return $config;
+                }
+                $config->setControllerName('Horde_Core_Controller_NotAuthorized');
+                return $config;
+            }
         }
 
         return $config;

--- a/lib/Horde/Core/Controller/RequestMapper.php
+++ b/lib/Horde/Core/Controller/RequestMapper.php
@@ -159,7 +159,7 @@ class Horde_Core_Controller_RequestMapper
         $settingsFinder = $injector->getInstance('Horde_Core_Controller_SettingsFinder');
 
         $config = $injector->createInstance('Horde_Core_Controller_RequestConfiguration');
-        $found = $this->_identifyApp($scheme, $request, $requestServer, $GLOBALS['registry']);
+        $found = $this->_identifyApp($uriScheme, $request, $requestServer, $GLOBALS['registry']);
         $prefix = $found['path'];
 
         // If we still found no app, give up
@@ -179,7 +179,6 @@ class Horde_Core_Controller_RequestMapper
         $fileroot = $registry->get('fileroot', $app);
         $routeFile = $fileroot . '/config/routes.php';
         if (!file_exists($routeFile)) {
-            $scheme = $_SERVER['REQUEST_SCHEME'];
             $config->setControllerName('Horde_Core_Controller_NotFound');
             return $config;
         }

--- a/lib/Horde/Core/Controller/SettingsFinder.php
+++ b/lib/Horde/Core/Controller/SettingsFinder.php
@@ -1,10 +1,44 @@
 <?php
 /**
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Michael Slusarz <slusarz@horde.org>
  * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
+ */
+
+/**
+ * The Horde_Core_Controller_SettingsFinder class provides 
+ * logic to find the most appropriate SettingsExporter for a controller
+ *
+ * Copyright 2009-2020 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL-2). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl.
+ *
+ * @author   Michael Slusarz <slusarz@horde.org>
+ * @category Horde
+ * @package  Package
+ * @license  http://www.horde.org/licenses/lgpl LGPL-2
  */
 class Horde_Core_Controller_SettingsFinder
 {
+    /**
+     * Find the appropriate SettingsExporter's class name
+     *
+     * The default exporter is Horde_Controller_SettingsExporter_Default.
+     * If a SettingsExporter with the same base name as the controller is
+     * found, it is used instead. Direct and indirect parent classes of the
+     * controller are also checked.
+     *
+     * @param string $controllerName The controller's class name
+     *
+     * @return string The SettingsExporter's class name
+     */
     public function getSettingsExporterName($controllerName)
     {
         $current = $controllerName;
@@ -20,11 +54,25 @@ class Horde_Core_Controller_SettingsFinder
         return 'Horde_Controller_SettingsExporter_Default';
     }
 
+    /**
+     * Derive the SettingsExporter class name from the controller class name
+     *
+     * @param string $controllerName The controller class name
+     *
+     * @return string The most relevant SettingsExporter class name found
+     */
     private function _mapName($controllerName)
     {
         return str_replace('_Controller', '_SettingsExporter', $controllerName);
     }
 
+    /**
+     * Derive the parent class name from the controller class name
+     *
+     * @param string $controllerName The controller class name
+     *
+     * @return string|null The parent class name or null
+     */
     private function _getParentName($controllerName)
     {
         $klass = new ReflectionClass($controllerName);

--- a/lib/Horde/Core/Db/Migration.php
+++ b/lib/Horde/Core/Db/Migration.php
@@ -66,7 +66,7 @@ class Horde_Core_Db_Migration
         $pear = new PEAR_Config($pearconf);
 
         // Detect and handle the Composer use case
-        if (class_exists('Composer\Autoload\ClassLoader')) {
+        if (class_exists('Composer\Autoload\ClassLoader', false)) {
             /*
               This is a bit brittle. We know where migration
               is relative to the package root and that it should

--- a/lib/Horde/Core/Db/Migration.php
+++ b/lib/Horde/Core/Db/Migration.php
@@ -65,20 +65,59 @@ class Horde_Core_Db_Migration
         error_reporting($old_error_reporting & ~E_DEPRECATED);
         $pear = new PEAR_Config($pearconf);
 
-        // Loop through local framework checkouts.
-        if ($basedir) {
-            $path = $basedir . '/*/migration';
-            $packageFile = new PEAR_PackageFile($pear);
-            foreach (glob($path) as $dir) {
-                $package = $packageFile->fromPackageFile(
-                    dirname($dir) . '/package.xml', PEAR_VALIDATE_NORMAL
-                );
-                if ($package instanceof PEAR_Error) {
-                    Horde::log(sprintf('%s: %s', $package->getMessage(), print_r($package->getUserInfo(), true)), Horde_Log::ERR);
+        // Detect and handle the Composer use case
+        if (class_exists('Composer\Autoload\ClassLoader')) {
+            /*
+              This is a bit brittle. We know where migration
+              is relative to the package root and that it should
+              be in the vendor dir - wherever that is. We also
+              know migration files have a canonical place inside a package
+              So loop through vendors and packages to identify packages with a 
+              migration dir. We cannot hardcode the horde vendor, this would
+              break third party solutions using the horde framework.
+              Would be more fun to deduce from the package lock file
+            */
+            $vendorDir = dirname(__FILE__, 7);
+            // Loop over all vendors/packages in vendor dir
+            $vendorIterator = new DirectoryIterator("$vendorDir/");
+            foreach ($vendorIterator as $vendor) {
+                if (!is_dir("$vendorDir/$vendor/")) {
                     continue;
                 }
-                $this->apps[] = $package->getName();
-                $this->_lower[] = Horde_String::lower($package->getName());
+                $packageIterator = new DirectoryIterator("$vendorDir/$vendor/");
+                foreach ($packageIterator as $package) {
+                    if (!is_dir("$vendorDir/$vendor/$package/migration")) {
+                        continue;
+                    }
+                    // Apps don't go into vendor dir so it's always a lib.
+                    // hope this doesn't break for three part names
+                    $lcFullname = Horde_String::lower($vendor. '_' . $package);
+                    $parts = [];
+                    foreach (explode('_', $lcFullname) as $part) {
+                        $parts[] = ucfirst($part);
+                    }
+                    $ucFullname = implode('_', $parts);
+                    $this->apps[] = $ucFullname;
+                    $this->_lower[] = $lcFullname;
+                    $this->dirs[] = realpath("$vendorDir/$vendor/$package/migration");
+                }
+            }
+        }
+
+        // Loop through local framework checkouts.
+        elseif ($basedir) {
+            $path = $basedir . '/*/migration';
+            foreach (glob($path) as $dir) {
+                try {
+                    $package = Horde_Yaml::loadFile($dir . '/../.horde.yml');
+                } catch (Horde_Yaml_Exception $e) {
+                    Horde::log(sprintf('Horde DB Migration failed loading: %s', $e->getMessage()), Horde_Log::ERR);
+                    continue;
+                }
+                // Compat with pear style names. YAML library names do not include Horde_
+                $name = $package['type'] == 'library' ? 'Horde_' . $package['name'] : $package['name'];
+                $this->apps[] = $name;
+                $this->_lower[] = Horde_String::lower($name);
                 $this->dirs[] = realpath($dir);
             }
         }

--- a/lib/Horde/Core/Factory/DavServer.php
+++ b/lib/Horde/Core/Factory/DavServer.php
@@ -44,7 +44,7 @@ class Horde_Core_Factory_DavServer extends Horde_Core_Factory_Injector
         $principals->disableListing = $conf['auth']['list_users'] == 'input';
 
         $calendarBackend = new Horde_Dav_Calendar_Backend($registry, $injector->getInstance('Horde_Dav_Storage'));
-        $caldav = new CalDAV\CalendarRootNode($principalBackend, $calendarBackend);
+        $caldav = new CalDAV\CalendarRoot($principalBackend, $calendarBackend);
         $contactsBackend = new Horde_Dav_Contacts_Backend($registry);
         $carddav = new CardDAV\AddressBookRoot($principalBackend, $contactsBackend);
 

--- a/lib/Horde/Core/Factory/DavServer.php
+++ b/lib/Horde/Core/Factory/DavServer.php
@@ -79,7 +79,13 @@ class Horde_Core_Factory_DavServer extends Horde_Core_Factory_Injector
                 new Horde_Dav_Locks($registry, $injector->getInstance('Horde_Lock'))
             )
         );
-        $server->addPlugin(new DAVACL\Plugin());
+        /**
+         * Since SabreDAV 3.2, we need to explicitly handle access for unauthenticated
+         * Callers. For now, just disable unauthenticated calendar access altogether.
+         */
+        $aclPlugin = new DAVACL\Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
+        $server->addPlugin($aclPlugin);
         $server->addPlugin(new DAV\Browser\Plugin());
 
         return $server;


### PR DESCRIPTION
Supersedes PR#7 https://github.com/horde/Core/pull/7

To be used in conjunction with Horde Base PR 7 https://github.com/horde/base/pull/7

    Fix various scenarios for Horde_Core_Controller where $APP does not live below horde base app
    Add capabilities for Horde Controller based pages to have unauthenticated access or http basic auth
    Make the database migrator compatible with composer's distinct directory structure but do not 
    break pear or git-tools based installs

This has seen some closed-shop testing in the last year and proved stable.
Added phpdoc for the Horde Core Controller framework

This PR does not contain any downstream changes to composer.json or metadata (as opposed to PR#7)