### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Core/Smartmobile/Url.php
+++ b/lib/Horde/Core/Smartmobile/Url.php
@@ -81,7 +81,7 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
             $baseUrl = $this->_baseUrl->copy();
             $baseUrl->parameters = array_merge($baseUrl->parameters,
                                                $this->parameters);
-            if (strlen($this->pathInfo)) {
+            if (strlen(is_null($this->pathInfo) ? "" : $this->pathInfo)) {
                 $baseUrl->pathInfo = $this->pathInfo;
             }
             return $baseUrl->toString($raw, $full);
@@ -89,7 +89,7 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
 
         $url = $this->_baseUrl->toString($raw, $full);
 
-        if (strlen($this->pathInfo)) {
+        if (strlen(is_null($this->pathInfo) ? "" : $this->pathInfo)) {
             $url = rtrim($url, '/');
             $url .= '/' . $this->pathInfo;
         }

--- a/lib/Horde/Registry/Hordeconfig.php
+++ b/lib/Horde/Registry/Hordeconfig.php
@@ -87,6 +87,7 @@ implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         $this->_load($offset);
@@ -95,6 +96,7 @@ implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         $this->_load($offset);
@@ -103,6 +105,7 @@ implements ArrayAccess, Countable, IteratorAggregate
             : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->_load($offset);
@@ -111,6 +114,7 @@ implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->_load($offset);
@@ -121,6 +125,7 @@ implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         /* Return non-zero to ensure a count() calls returns true. */
@@ -131,6 +136,7 @@ implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         $this->toArray();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Core/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Core/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Core Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Core/ActiveSyncTests.php
+++ b/test/Horde/Core/ActiveSyncTests.php
@@ -22,7 +22,7 @@ class Horde_Core_ActiveSyncTests extends Horde_Test_Case
     protected $_mailboxes;
     protected $_special;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_auth = $this->getMockSkipConstructor('Horde_Auth_Auto');
         $this->_state = $this->getMockSkipConstructor('Horde_ActiveSync_State_Sql');

--- a/test/Horde/Core/Factory/GroupTest.php
+++ b/test/Horde/Core/Factory/GroupTest.php
@@ -23,7 +23,7 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Core_Factory_GroupTest extends PHPUnit_Framework_TestCase
+class Horde_Core_Factory_GroupTest extends Horde_Test_Case
 {
     public function testMock()
     {

--- a/test/Horde/Core/Factory/KolabServerTest.php
+++ b/test/Horde/Core/Factory/KolabServerTest.php
@@ -23,9 +23,9 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Core_Factory_KolabServerTest extends PHPUnit_Framework_TestCase
+class Horde_Core_Factory_KolabServerTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Needs some love');
         $GLOBALS['conf']['kolab']['server']['basedn'] = 'test';

--- a/test/Horde/Core/Factory/KolabSessionTest.php
+++ b/test/Horde/Core/Factory/KolabSessionTest.php
@@ -23,9 +23,9 @@
  * @author   Gunnar Wrobel <wrobel@pardus.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
-class Horde_Core_Factory_KolabSessionTest extends PHPUnit_Framework_TestCase
+class Horde_Core_Factory_KolabSessionTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Needs some love');
     }

--- a/test/Horde/Core/NlsconfigTest.php
+++ b/test/Horde/Core/NlsconfigTest.php
@@ -18,6 +18,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
  */
+#[\AllowDynamicProperties]
 class Horde_Core_NlsconfigTest extends Horde_Test_Case
 {
     public function setUp(): void

--- a/test/Horde/Core/NlsconfigTest.php
+++ b/test/Horde/Core/NlsconfigTest.php
@@ -20,7 +20,7 @@
  */
 class Horde_Core_NlsconfigTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
         $GLOBALS['session'] = new Horde_Session();
         $GLOBALS['session']->sessionHandler = new Horde_Support_Stub();
@@ -58,6 +58,8 @@ class Horde_Core_NlsconfigTest extends Horde_Test_Case
      */
     public function testGet($key, $expected)
     {
+        $this->expectNotToPerformAssertions();
+
         $nls = new Horde_Registry_Nlsconfig();
     }
 

--- a/test/Horde/Core/RegistryTest.php
+++ b/test/Horde/Core/RegistryTest.php
@@ -18,11 +18,11 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
  */
-class Horde_Core_RegistryTest extends PHPUnit_Framework_TestCase
+class Horde_Core_RegistryTest extends Horde_Test_Case
 {
     protected $_tmpdir;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (is_dir($this->_tmpdir)) {
             rmdir($this->_tmpdir);

--- a/test/Horde/Core/RegistryTest.php
+++ b/test/Horde/Core/RegistryTest.php
@@ -24,7 +24,7 @@ class Horde_Core_RegistryTest extends Horde_Test_Case
 
     public function tearDown(): void
     {
-        if (is_dir($this->_tmpdir)) {
+        if (is_dir(is_null($this->_tmpdir) ? "" : $this->_tmpdir)) {
             rmdir($this->_tmpdir);
             rmdir(dirname($this->_tmpdir));
         }

--- a/test/Horde/Core/SmartmobileUrlTest.php
+++ b/test/Horde/Core/SmartmobileUrlTest.php
@@ -8,11 +8,9 @@
  */
 class Horde_Core_SmartmobileUrlTest extends Horde_Test_Case
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidParamter()
     {
+        $this->expectException('InvalidArgumentException');
         new Horde_Core_Smartmobile_Url('test');
     }
 

--- a/test/Horde/Core/UrlTest.php
+++ b/test/Horde/Core/UrlTest.php
@@ -6,7 +6,7 @@
  * @package    Core
  * @subpackage UnitTests
  */
-class Horde_Core_UrlTest extends PHPUnit_Framework_TestCase
+class Horde_Core_UrlTest extends Horde_Test_Case
 {
     public function testUrl()
     {

--- a/test/Horde/Core/phpunit.xml
+++ b/test/Horde/Core/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-core/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: 1011_php8.1.patch https://salsa.debian.org/horde-team/php-horde-core/-/blob/debian-sid/debian/patches/1011_php8.1.patch
- Debian changes: Fix PHP 8.2 deprecation warnings. https://salsa.debian.org/horde-team/php-horde-core/-/blob/debian-sid/debian/patches/1012_php8.2.patch
