### PR TITLE
Fix use of undefined $filename in Loadconfig.php

### DIFF
--- a/lib/Horde/Registry/Loadconfig.php
+++ b/lib/Horde/Registry/Loadconfig.php
@@ -70,7 +70,7 @@ class Horde_Registry_Loadconfig
                 : $registry->get('fileroot', $app) . '/config/';
         }
         $pathname = $conf_dir . $conf_file;
-        if (is_file($filename)) {
+        if (is_file($pathname)) {
             $flist[] = $pathname;
         }
 


### PR DESCRIPTION
fix: Correct php warning : Undefined variable $filename on line 73