### PR TITLE
fix: Horde_Registry_Loadconfig - do not load same file more than once

### DIFF
--- a/lib/Horde/Registry/Loadconfig.php
+++ b/lib/Horde/Registry/Loadconfig.php
@@ -56,10 +56,7 @@ class Horde_Registry_Loadconfig
         /* Load defaults from the vendor dir */
         $appConstant = strtoupper($app) . '_BASE';
         if (defined($appConstant)) {
-            $filename = constant($appConstant) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . $conf_file;
-            if (is_file($filename)) {
-                $flist[] = $filename;
-            }
+            $flist[] = constant($appConstant) . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . $conf_file;
         }
         /* Load global configuration file. */
         if (defined('HORDE_CONFIG_BASE')) {
@@ -69,10 +66,7 @@ class Horde_Registry_Loadconfig
                 ? HORDE_BASE . '/config/'
                 : $registry->get('fileroot', $app) . '/config/';
         }
-        $pathname = $conf_dir . $conf_file;
-        if (is_file($pathname)) {
-            $flist[] = $pathname;
-        }
+        $flist[] = $conf_dir . $conf_file;
 
         /* Load global configuration stanzas in '.d' directory. */
         $dir = $conf_dir . $pinfo['filename'] . '.d';
@@ -88,9 +82,9 @@ class Horde_Registry_Loadconfig
 
         $k = 0;
         for ($v = reset($flist); $v; $v = next($flist)) {
-            if (file_exists($v)) {
+            if (is_file($v)) {
                 Horde::startBuffer();
-                $success = include $v;
+                $success = include_once $v;
                 $this->output .= Horde::endBuffer();
 
                 if (!$success) {


### PR DESCRIPTION
After the recent change c329b92, the Horde_Registry_Loadconfig may end up loading the same file twice (for example from `var/config/$app` and `vendor/horde/$app/config` folders if there are symbolic links).

While this can be resolved by introducing additional checks, the easiest solution is to use `include_once` instead of `include`. This works because `include_once` checks file's real path internally.

While there, I also slightly simplified the code by removing redundant checks and making sure `is_file` is used instead of `file_exists` (the latter can return true if the file is a directory).

With this change the [b05084b](https://github.com/horde/imp/commit/b05084bac645b4b815c888fbd4b4b8142388af15) commit can probably be reverted.