### PR TITLE
Remove extraneous '=' in signUrl() and signQueryString()

### DIFF
--- a/lib/Horde.php
+++ b/lib/Horde.php
@@ -183,7 +183,7 @@ class Horde
             $url->add(
                 '_h',
                 Horde_Url::uriB64Encode(
-                    hash_hmac('sha1', $url . '=', $conf['secret_key'], true)
+                    hash_hmac('sha1', $url, $conf['secret_key'], true)
                 )
             );
             return $url;
@@ -283,8 +283,8 @@ class Horde
 
         if ($queryString instanceof Horde_Url) {
             $queryString->setRaw(true)->add(['_t' => $now, '_h' => '']);
-            $parse_url = parse_url($queryString);
-            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $parse_url['query'] . '=', $GLOBALS['conf']['secret_key'], true)));
+            $query = parse_url($queryString, PHP_URL_QUERY);
+            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query, $GLOBALS['conf']['secret_key'], true)));
             return $queryString;
         }
 


### PR DESCRIPTION
@ralflang: This PR is opened instead of #27 (to utilize a different source branch).

The verification code in `verifySignedUrl` and `verifySignedQueryString` methods expects the `$data` string to be in the following format:  `{url_with_timestamp}&_h={hash}`. The supplied hash is checked against the hash computed on `{url_with_timestamp}&_h=` part.

However, both `signUrl` and `signQueryString` add an extra `=` (only in case if the supplied parameter is an instance of `Horde_Url` class), i.e. a hash is computed on `{url_with_timestamp}&_h==`, and the subsequent verification fails.

This is required (but not enough) in order to resolve https://github.com/horde/base/issues/12.
