### PR TITLE
Add support for autoloading of *_Ui_VarRenderer_* classes

### DIFF
--- a/lib/Horde/Core/Ui/VarRenderer.php
+++ b/lib/Horde/Core/Ui/VarRenderer.php
@@ -58,15 +58,24 @@ class Horde_Core_Ui_VarRenderer
         if (is_array($driver)) {
             $app = $driver[0];
             $driver = $driver[1];
+        } else {
+            $app = '';
         }
 
         $driver = Horde_String::ucfirst(basename($driver));
-        if (!empty($app)) {
+        $class = (empty($app) ? 'Horde_Core' : $app) .  '_Ui_VarRenderer_' . $driver;
+
+        $ok = class_exists($class);
+
+        // TODO: Eliminate after renaming Horde_Ui_VarRenderer_* classes in other apps to {app}_Ui_VarRenderer_*
+        if (!$ok && !empty($app)) {
+            // fallback to legacy method (manual load)
+            $class = __CLASS__ . '_' . $driver;
             include_once $GLOBALS['registry']->get('fileroot', $app) . '/lib/Ui/VarRenderer/' . $driver . '.php';
+            $ok = class_exists($class);
         }
 
-        $class = __CLASS__ . '_' . $driver;
-        if (!class_exists($class)) {
+        if (!$ok) {
             throw new LogicException('Class definition of ' . $class . ' not found.');
         }
 


### PR DESCRIPTION
To utilize it we just need to rename `Horde_Core_Ui_VarRenderer_*` classes in other apps (except Core).

For example, in Turba app class `Horde_Core_Ui_VarRenderer_Turba` should be renamed to `Turba_Core_Ui_VarRenderer_Turba`.

To provide a seamless transition a fallback to the original loading method is implemented. Once it is done, it can be removed:
```php
// TODO: Eliminate after renaming Horde_Ui_VarRenderer_* classes in other apps to {app}_Ui_VarRenderer_*
if (!$ok && !empty($app)) {
    // fallback to legacy method (manual load)
    $class = __CLASS__ . '_' . $driver;
    include_once $GLOBALS['registry']->get('fileroot', $app) . '/lib/Ui/VarRenderer/' . $driver . '.php';
    $ok = class_exists($class);
}
```
