### PR TITLE
Use session name when setting SID parameter

### DIFF
--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -650,7 +650,16 @@ class Horde_PageOutput
         if ($this->ajax || $this->growler) {
             $this->addScriptFile(new Horde_Script_File_JsFramework('hordecore.js', 'horde'));
 
-            $session_id = session_id();
+            $session_name = session_name();
+            if (isset($_COOKIE[$session_name])) {
+                $SID = '';
+            } else {
+                $SID = session_id();
+                if ($SID) {
+                    $SID = $session_name . '=' . $SID;
+                }
+            }
+
             /* Configuration used in core javascript files. */
             $js_conf = array_filter([
                 /* URLs */
@@ -660,7 +669,7 @@ class Horde_PageOutput
                 'URI_SNOOZE' => strval(Horde::url($registry->get('webroot', 'horde') . '/services/snooze.php', true, -1)),
 
                 /* Other constants */
-                'SID' => $session_id ? 'name=' . $session_id : '',
+                'SID' => $SID,
                 'TOKEN' => $session->getToken(),
 
                 /* Other config. */


### PR DESCRIPTION
Restore the original behavior (empty SID if session cookie is set).

Note, this (SID) is only needed for the case when browser does not allow cookies. In future we should consider removing support for session ID passed in URLs altogether due to security risks.

However currently there are multiple places where session ID is used in URLs, `PageOutput.php`  is just one of them.

This fixes #34.