### PR TITLE
Add '=' after '_h' for Horde_Url objects in signUrl()/signQueryString()

### DIFF
--- a/lib/Horde.php
+++ b/lib/Horde.php
@@ -183,7 +183,7 @@ class Horde
             $url->add(
                 '_h',
                 Horde_Url::uriB64Encode(
-                    hash_hmac('sha1', $url, $conf['secret_key'], true)
+                    hash_hmac('sha1', $url . '=', $conf['secret_key'], true)
                 )
             );
             return $url;
@@ -284,7 +284,7 @@ class Horde
         if ($queryString instanceof Horde_Url) {
             $queryString->setRaw(true)->add(['_t' => $now, '_h' => '']);
             $query = parse_url($queryString, PHP_URL_QUERY);
-            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query, $GLOBALS['conf']['secret_key'], true)));
+            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query . '=', $GLOBALS['conf']['secret_key'], true)));
             return $queryString;
         }
 


### PR DESCRIPTION
The horde/Url@bf2b51b restored the original behavior or `Horde_Url` ('=' is not added for parameters with empty values).

See https://github.com/horde/Core/pull/28#issuecomment-3192234335.

