### PR TITLE
Continuous integration fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,59 +1,67 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run. 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches:
-      - master
-      - maintaina-composerfixed
-      - FRAMEWORK_6_0
+    branches: [ FRAMEWORK_6_0 ]
   pull_request:
-    branches:
-      - master
-      - maintaina-composerfixed
-      - FRAMEWORK_6_0
-
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: [ FRAMEWORK_6_0 ]
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  run:
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        operating-system: ['ubuntu-20.04']
-        php-versions: ['7.4', '8.0', 'latest']
-        phpunit-versions: ['latest', '9.5']
-        exclude:
-          - php-versions: '7.4'
-            phpunit-versions: 'latest'
-          - php-versions: '8.0'
-            phpunit-versions: 'latest'
-    steps:
-    - name: Setup github ssh key
-      run:  mkdir -p ~/.ssh/ && ssh-keyscan -t rsa github.com > ~/.ssh/known_hosts
-    - name: Checkout
-      uses: actions/checkout@v2
+  test:
+    name: ${{ matrix.os }} / PHP ${{ matrix.php }}
+    runs-on: ${{ matrix.os }}
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php-versions }}
-        extensions: bcmath, ctype, curl, dom, gd, gettext, iconv, imagick, json, ldap, mbstring, mysql, opcache, openssl, pcntl, pdo, posix, redis, soap, sockets, sqlite, tokenizer, xmlwriter
-        ini-values: post_max_size=512M, max_execution_time=360
-        coverage: xdebug
-        tools: php-cs-fixer, phpunit:${{ matrix.phpunit-versions }}, composer:v2
-    - name: Setup Github Token as composer credential
-      run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
-    - name: Install horde/test dependency and other dependencies
-      run: |
-        ## For unclear reasons, github action fails randomly if we do not install before we require.
-        COMPOSER_ROOT_VERSION=dev-FRAMEWORK_6_0 composer config minimum-stability dev
-        COMPOSER_ROOT_VERSION=dev-FRAMEWORK_6_0 composer install
-    - name: run phpunit
-      run: phpunit --bootstrap test/bootstrap.php
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
+
+    env:
+      COMPOSER_ROOT_VERSION: dev-FRAMEWORK_6_0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set PHPUnit version
+        run: |
+          case "${{ matrix.php }}" in
+            8.1) echo "PHPUNIT_VERSION=10" >> $GITHUB_ENV ;;
+            *) echo "PHPUNIT_VERSION=11" >> $GITHUB_ENV ;;
+          esac
+          echo "Using PHPUnit version $PHPUNIT_VERSION for PHP ${{ matrix.php }}"
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: bcmath, ctype, curl, dom, gd, gettext, iconv, imagick, json, ldap, mbstring, mysql, opcache, openssl, pcntl, pdo, posix, redis, soap, sockets, sqlite, tokenizer, xmlwriter
+          ini-values: post_max_size=512M, max_execution_time=360
+          coverage: xdebug
+          tools: phpunit:${{ env.PHPUNIT_VERSION }}, composer:v2
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php }}-
+
+      - name: Configure Composer auth
+        run: composer config -g github-oauth.github.com ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          # Allow Horde installer plugin
+          composer config --no-plugins allow-plugins.horde/horde-installer-plugin true
+
+          # Enable dev stability
+          composer config minimum-stability dev
+
+          # Install project dependencies
+          composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: phpunit --bootstrap test/bootstrap.php

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "horde/view": "^3 || dev-FRAMEWORK_6_0",
         "pear/pear": "*",
         "php81_bc/strftime": "^0.7",
-        "ext-session": "*"
+        "ext-session": "*",
+        "psr/http-factory": "^1"
     },
     "require-dev": {
         "horde/test": "^3 || dev-FRAMEWORK_6_0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="test/bootstrap.php"
          cacheDirectory=".phpunit.cache/code-coverage"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"


### PR DESCRIPTION
Redesign `ci.yml` to work again:
 * Replace unsupported `ubuntu-20.04` with `ubuntu-22.04`
 * Drop support for PHP 7.4 and 8.0
 * Add support for PHP 8.1, 8.2, 8.3, 8.4
 * Remove unused ssh keys
 * Allow horde/horde-installer-plugin
 * Other improvements

The redesigned `ci.yml` should probably be used in other `Horde` apps.

Add `psr/http-factory` to `composer.json`

Note, to work properly under PHP 8.2+ it also requires horde/test#8 to be merged.