### PR TITLE
fix: Deprecated strlen(null) in Redis Hashtable on PHP 8.1+

### DIFF
--- a/lib/Horde/Core/Factory/HashTable.php
+++ b/lib/Horde/Core/Factory/HashTable.php
@@ -66,7 +66,7 @@ class Horde_Core_Factory_HashTable extends Horde_Core_Factory_Injector
                 $redis_params = [];
 
                 $common = array_filter([
-                    'password' => !empty($params['password']) ? $params['password'] : null,
+                    'password' => $params['password'] ?? null,
                     'persistent' => !empty($params['persistent']),
                     'database' => !empty($params['database']) ? $params['database'] : null,
                 ]);

--- a/lib/Horde/Core/Factory/HashTable.php
+++ b/lib/Horde/Core/Factory/HashTable.php
@@ -66,7 +66,7 @@ class Horde_Core_Factory_HashTable extends Horde_Core_Factory_Injector
                 $redis_params = [];
 
                 $common = array_filter([
-                    'password' => strlen($params['password']) ? $params['password'] : null,
+                    'password' => !empty($params['password']) ? $params['password'] : null,
                     'persistent' => !empty($params['persistent']),
                     'database' => !empty($params['database']) ? $params['database'] : null,
                 ]);


### PR DESCRIPTION
### Problem
On PHP 8.1+, calling `strlen(null)` raises a deprecation warning in Redis Hashtable configuration when no password is set.

### Solution
Replaced `strlen()` check with `!empty()` to ensure proper handling of null/empty passwords while preserving previous behavior.

### Compatibility
- No change in functionality.
- Tested on PHP 8.4