### PR TITLE
Correct Data Provider signature for Nlsconfigtest

### DIFF
--- a/test/NlsconfigTest.php
+++ b/test/NlsconfigTest.php
@@ -51,7 +51,7 @@ class NlsconfigTest extends TestCase
         );
     }
 
-    public function providerForTestGet()
+    public static function providerForTestGet()
     {
         return [
             'languages' => [


### PR DESCRIPTION
This fixes the error when running phpunit:

The data provider specified for Horde\Core\Test\NlsconfigTest::testGet is invalid
Data Provider method Horde\Core\Test\NlsconfigTest::providerForTestGet() is not static