### PR TITLE
feat: Move logger configuration to a single place for both PSR-3 and traditional logger. Allows step by step migration without breaking changes.

### DIFF
--- a/lib/Horde/Core/Factory/Logger.php
+++ b/lib/Horde/Core/Factory/Logger.php
@@ -21,30 +21,40 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
     protected static $_queue;
 
     /**
+     * Logger configuration service
+     *
+     * @var \Horde\Core\Config\LoggerConfig
+     */
+    private $config;
+
+    /**
      */
     public function create(Horde_Injector $injector)
     {
-        global $conf;
+        // Get LoggerConfig service (autowired by injector)
+        if ($this->config === null) {
+            $this->config = $injector->getInstance('Horde\\Core\\Config\\LoggerConfig');
+        }
 
         $this->error = null;
 
-        /* Default handler. */
-        if (empty($conf['log']['enabled'])) {
+        /* Default handler if logging is disabled. */
+        if (!$this->config->isEnabled()) {
             return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
         }
 
-        switch ($conf['log']['type']) {
+        switch ($this->config->getType()) {
             case 'file':
             case 'stream':
-                $append = ($conf['log']['type'] == 'file')
-                    ? ($conf['log']['params']['append'] ? 'a+' : 'w+')
+                $append = ($this->config->getType() === 'file')
+                    ? $this->config->getAppendMode()
                     : null;
-                $format = $conf['log']['params']['format']
-                    ?? 'default';
 
-                switch ($format) {
+                switch ($this->config->getFormat()) {
                     case 'custom':
-                        $formatter = new Horde_Log_Formatter_Simple(['format' => $conf['log']['params']['template']]);
+                        $formatter = ($this->config->getTemplate() !== null)
+                            ? new Horde_Log_Formatter_Simple(['format' => $this->config->getTemplate()])
+                            : null;
                         break;
 
                     case 'default':
@@ -59,14 +69,13 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
                 }
 
                 try {
-                    // TODO: In some cases we arrive at the logger factory and are unable to autoload this Handler class.
-                    $handler = new Horde_Log_Handler_Stream($conf['log']['name'], $append, $formatter);
+                    $handler = new Horde_Log_Handler_Stream($this->config->getName(), $append, $formatter);
                 } catch (Horde_Log_Exception $e) {
                     $this->error = $e;
                     return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
                 }
                 try {
-                    $handler->setOption('ident', $conf['log']['ident']);
+                    $handler->setOption('ident', $this->config->getIdent());
                 } catch (Horde_Log_Exception $e) {
                 }
                 break;
@@ -74,11 +83,13 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
             case 'syslog':
                 try {
                     $handler = new Horde_Log_Handler_Syslog();
-                    if (!empty($conf['log']['name'])) {
-                        $handler->setOption('facility', $conf['log']['name']);
+                    $facility = $this->config->getFacility();
+                    if ($facility !== null) {
+                        $handler->setOption('facility', $facility);
                     }
-                    if (!empty($conf['log']['ident'])) {
-                        $handler->setOption('ident', $conf['log']['ident']);
+                    $ident = $this->config->getIdent();
+                    if (!empty($ident)) {
+                        $handler->setOption('ident', $ident);
                     }
                 } catch (Horde_Log_Exception $e) {
                     $this->error = $e;
@@ -92,19 +103,7 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
                 return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
         }
 
-        switch ($conf['log']['priority']) {
-            case 'WARNING':
-                // Bug #12109
-                $priority = 'WARN';
-                break;
-
-            default:
-                $priority = defined('Horde_Log::' . $conf['log']['priority'])
-                    ? $conf['log']['priority']
-                    : 'NOTICE';
-                break;
-        }
-        $handler->addFilter(constant('Horde_Log::' . $priority));
+        $handler->addFilter($this->config->getPriorityValue());
 
         try {
             /* Horde_Core_Log_Logger contains code to format the log

--- a/lib/Horde/Core/Smartmobile/Url.php
+++ b/lib/Horde/Core/Smartmobile/Url.php
@@ -79,7 +79,7 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
     public function toString($raw = false, $full = true)
     {
         if ($this->toStringCallback || !strlen($this->anchor)) {
-            $baseUrl = $this->_baseUrl->copy();
+            $baseUrl = clone $this->_baseUrl;
             $baseUrl->parameters = array_merge(
                 $baseUrl->parameters,
                 $this->parameters

--- a/src/Config/LoggerConfig.php
+++ b/src/Config/LoggerConfig.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+declare(strict_types=1);
+
+namespace Horde\Core\Config;
+
+/**
+ * Logger configuration service
+ *
+ * Parses conf.php log settings once and provides structured configuration
+ * to both legacy and modern logger factories. This ensures consistent
+ * configuration interpretation across both implementations.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+class LoggerConfig
+{
+    private State $conf;
+    private ?array $parsed = null;
+
+    /**
+     * Constructor
+     *
+     * @param State $conf Configuration state object wrapping $GLOBALS['conf']
+     */
+    public function __construct(State $conf)
+    {
+        $this->conf = $conf;
+    }
+
+    /**
+     * Parse configuration once and cache
+     *
+     * @return array Parsed configuration values
+     */
+    private function parse(): array
+    {
+        if ($this->parsed !== null) {
+            return $this->parsed;
+        }
+
+        $conf = $this->conf->toArray();
+        $logConf = $conf['log'] ?? [];
+
+        $this->parsed = [
+            'enabled' => $logConf['enabled'] ?? true,
+            'type' => $logConf['type'] ?? 'null',
+            'name' => $logConf['name'] ?? '',
+            'ident' => $logConf['ident'] ?? '',
+            'priority' => $this->normalizePriority($logConf['priority'] ?? 'NOTICE'),
+            'format' => $logConf['params']['format'] ?? 'default',
+            'template' => $logConf['params']['template'] ?? null,
+            'append' => $logConf['params']['append'] ?? true,
+            'facility' => is_numeric($logConf['name'] ?? null) ? (int) $logConf['name'] : null,
+        ];
+
+        return $this->parsed;
+    }
+
+    /**
+     * Normalize priority level
+     *
+     * Handles special case for Bug #12109 where WARNING should map to WARN.
+     * Also validates that the priority constant exists.
+     *
+     * @param string $priority Raw priority from configuration
+     * @return string Normalized priority constant name
+     */
+    private function normalizePriority(string $priority): string
+    {
+        // Bug #12109: WARNING should be WARN
+        if ($priority === 'WARNING') {
+            return 'WARN';
+        }
+
+        // Validate constant exists, fallback to NOTICE
+        return defined('Horde_Log::' . $priority) ? $priority : 'NOTICE';
+    }
+
+    /**
+     * Is logging enabled?
+     *
+     * @return bool True if logging is enabled in configuration
+     */
+    public function isEnabled(): bool
+    {
+        return $this->parse()['enabled'];
+    }
+
+    /**
+     * Get logger type
+     *
+     * @return string One of: 'file', 'stream', 'syslog', 'null'
+     */
+    public function getType(): string
+    {
+        return $this->parse()['type'];
+    }
+
+    /**
+     * Get log destination name
+     *
+     * For file/stream handlers: file path or stream URL
+     * For syslog handler: facility number (or empty for default)
+     *
+     * @return string Log destination
+     */
+    public function getName(): string
+    {
+        return $this->parse()['name'];
+    }
+
+    /**
+     * Get log identifier
+     *
+     * Identifier prepended to log messages
+     *
+     * @return string Log identifier
+     */
+    public function getIdent(): string
+    {
+        return $this->parse()['ident'];
+    }
+
+    /**
+     * Get normalized priority level
+     *
+     * Returns the constant name (e.g., 'NOTICE', 'WARN', 'DEBUG')
+     *
+     * @return string Priority constant name
+     */
+    public function getPriority(): string
+    {
+        return $this->parse()['priority'];
+    }
+
+    /**
+     * Get priority as integer constant value
+     *
+     * @return int Priority constant value (e.g., Horde_Log::NOTICE)
+     */
+    public function getPriorityValue(): int
+    {
+        return constant('Horde_Log::' . $this->getPriority());
+    }
+
+    /**
+     * Get format type
+     *
+     * @return string One of: 'default', 'custom', 'xml'
+     */
+    public function getFormat(): string
+    {
+        return $this->parse()['format'];
+    }
+
+    /**
+     * Get custom format template
+     *
+     * Only applicable when format type is 'custom'
+     *
+     * @return string|null Custom format template or null
+     */
+    public function getTemplate(): ?string
+    {
+        return $this->parse()['template'];
+    }
+
+    /**
+     * Get append mode for file handlers
+     *
+     * @return bool True to append, false to overwrite
+     */
+    public function getAppend(): bool
+    {
+        return $this->parse()['append'];
+    }
+
+    /**
+     * Get append mode as fopen() mode string
+     *
+     * @return string 'a+' for append, 'w+' for overwrite
+     */
+    public function getAppendMode(): string
+    {
+        return $this->getAppend() ? 'a+' : 'w+';
+    }
+
+    /**
+     * Get syslog facility
+     *
+     * @return int|null Syslog facility number or null if not specified
+     */
+    public function getFacility(): ?int
+    {
+        return $this->parse()['facility'];
+    }
+
+    /**
+     * Get raw parsed configuration array
+     *
+     * Provided for backward compatibility and debugging.
+     * Prefer using specific getter methods.
+     *
+     * @return array Parsed configuration
+     */
+    public function toArray(): array
+    {
+        return $this->parse();
+    }
+}

--- a/src/Factory/LogHandlerFactory.php
+++ b/src/Factory/LogHandlerFactory.php
@@ -11,7 +11,7 @@ namespace Horde\Core\Factory;
 
 use Horde_Core_Factory_Injector;
 use Horde\Log\Logger;
-use Horde\Core\Config\State;
+use Horde\Core\Config\LoggerConfig;
 use Horde\Injector\Injector;
 use Horde\Log\Filter\MaximumLevelFilter;
 use Horde\Log\Formatter\Psr3Formatter;
@@ -32,29 +32,25 @@ use Horde\Log\LogException;
  */
 class LogHandlerFactory extends Horde_Core_Factory_Injector
 {
-    private State $conf;
+    private LoggerConfig $config;
 
     /**
      * Constructor
      *
-     *
-     * @param State $config The conf.php values for the global log handler
-     *
+     * @param LoggerConfig $config Logger configuration service
      */
-    public function __construct(State $config)
+    public function __construct(LoggerConfig $config)
     {
-        $this->conf = $config;
+        $this->config = $config;
     }
 
     /**
      * Create default LogHandler
      *
-     * This creates a LogHandler with
-     *   configuration from conf.php
+     * This creates a LogHandler with configuration from conf.php via
+     * LoggerConfig service:
      * - the PSR-3 formatter and depending on options, another formatter,
      * - a handler-level filter by loglevel as the config suggests
-     *
-     * TODO: Mechanism to add and expose custom handlers
      *
      * @param Injector $injector
      * @return LogHandler
@@ -62,23 +58,20 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
      */
     public function create(Injector $injector): LogHandler
     {
-        $conf = $this->conf->toArray();
         $formatters = [new Psr3Formatter()];
 
-        switch ($conf['log']['type']) {
+        switch ($this->config->getType()) {
             case 'file':
             case 'stream':
-                // TODO: Default context?
-
-                $append = ($conf['log']['type'] == 'file')
-                    ? ($conf['log']['params']['append'] ? 'a+' : 'w+')
+                $append = ($this->config->getType() === 'file')
+                    ? $this->config->getAppendMode()
                     : null;
-                $format = $conf['log']['params']['format']
-                    ?? 'default';
 
-                switch ($format) {
+                switch ($this->config->getFormat()) {
                     case 'custom':
-                        $formatters[] = new SimpleFormatter(['format' => $conf['log']['params']['template']]);
+                        if ($this->config->getTemplate() !== null) {
+                            $formatters[] = new SimpleFormatter(['format' => $this->config->getTemplate()]);
+                        }
                         break;
 
                     case 'default':
@@ -92,18 +85,19 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
                 }
 
                 $options = new Options();
-                $options->ident = (string) $conf['log']['ident'] ?? '';
-                // Let's not try and catch. Let it fail, the caller should care
-                $handler = new StreamHandler($conf['log']['name'], $append, $options, $formatters);
+                $options->ident = $this->config->getIdent();
+                $handler = new StreamHandler($this->config->getName(), $append, $options, $formatters);
                 break;
 
             case 'syslog':
                 $options = new SyslogOptions();
-                if (!empty($conf['log']['name'] && is_numeric($conf['log']['name']))) {
-                    $options->facility = (int) $conf['log']['name'];
+                $facility = $this->config->getFacility();
+                if ($facility !== null) {
+                    $options->facility = $facility;
                 }
-                if (!empty($conf['log']['ident'])) {
-                    $options->ident = (string) $conf['log']['ident'];
+                $ident = $this->config->getIdent();
+                if (!empty($ident)) {
+                    $options->ident = $ident;
                 }
                 $handler = new SyslogHandler($options, $formatters, []);
                 break;
@@ -114,19 +108,7 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
                 return new NullHandler();
         }
 
-        switch ($conf['log']['priority']) {
-            case 'WARNING':
-                // Bug #12109
-                $priority = 'WARN';
-                break;
-
-            default:
-                $priority = defined('Horde_Log::' . $conf['log']['priority'])
-                    ? $conf['log']['priority']
-                    : 'NOTICE';
-                break;
-        }
-        $handler->addFilter(new MaximumLevelFilter(constant('Horde_Log::' . $priority)));
+        $handler->addFilter(new MaximumLevelFilter($this->config->getPriorityValue()));
         return $handler;
     }
 

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -12,7 +12,7 @@ namespace Horde\Core\Factory;
 use Horde_Core_Factory_Injector;
 use Horde\Log\Logger;
 use Horde\Log\LogException;
-use Horde\Core\Config\State;
+use Horde\Core\Config\LoggerConfig;
 use Horde\Injector\Injector;
 use Horde\Log\LogHandler;
 use Horde\Log\LogLevels;
@@ -23,7 +23,7 @@ use Horde\Log\LogLevels;
  */
 class LoggerFactory extends Horde_Core_Factory_Injector
 {
-    private State $conf;
+    private LoggerConfig $config;
     private LogLevels $levels;
     private Logger $logger;
 
@@ -38,26 +38,23 @@ class LoggerFactory extends Horde_Core_Factory_Injector
     /**
      * Constructor
      *
-     *
-     * @param State $config The conf.php values for the global log handler
-     *
+     * @param LoggerConfig $config Logger configuration service
+     * @param LogHandlerFactory $handlerFactory Handler factory
      */
-    public function __construct(State $config, LogHandlerFactory $handlerFactory)
+    public function __construct(LoggerConfig $config, LogHandlerFactory $handlerFactory)
     {
-        $this->conf = $config;
+        $this->config = $config;
         $this->handlerFactory = $handlerFactory;
     }
 
     /**
      * Create default logger
      *
-     * This creates a logger with
+     * This creates a logger with:
      * - one handler based on the horde config or no handler,
-     * - canonic log levels,
+     * - canonical log levels,
      * - the PSR-3 formatter and depending on options, another formatter,
      * - a handler-level filter by loglevel
-     *
-     * TODO: Mechanism to add specialised handlers without a configuration mess.
      *
      * @param Injector $injector
      * @return Logger
@@ -65,9 +62,7 @@ class LoggerFactory extends Horde_Core_Factory_Injector
      */
     public function create(Injector $injector): Logger
     {
-        $conf = $this->conf->toArray();
         $this->levels = LogLevels::initWithCanonicalLevels();
-        //
         $handlers = $this->predefinedHandlers();
         $handlers[] = $this->handlerFactory->create($injector);
         return new Logger($handlers, $this->levels);

--- a/test/Config/LoggerConfigTest.php
+++ b/test/Config/LoggerConfigTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * Tests for LoggerConfig
+ *
+ * @category   Horde
+ * @license    http://www.horde.org/licenses/lgpl21 LGPL
+ * @package    Core
+ * @subpackage UnitTests
+ */
+declare(strict_types=1);
+
+namespace Horde\Core\Test\Config;
+
+use Horde\Core\Config\LoggerConfig;
+use Horde\Core\Config\State;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LoggerConfig::class)]
+class LoggerConfigTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+        $this->assertInstanceOf(LoggerConfig::class, $config);
+    }
+
+    public function testDefaultValues(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+        $this->assertSame('', $config->getName());
+        $this->assertSame('', $config->getIdent());
+        $this->assertSame('NOTICE', $config->getPriority());
+        $this->assertSame('default', $config->getFormat());
+        $this->assertNull($config->getTemplate());
+        $this->assertTrue($config->getAppend());
+        $this->assertNull($config->getFacility());
+    }
+
+    public function testEnabledFalse(): void
+    {
+        $state = new State(['log' => ['enabled' => false]]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->isEnabled());
+    }
+
+    public function testFileType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'file',
+                'name' => '/var/log/horde.log',
+                'ident' => 'HORDE',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('file', $config->getType());
+        $this->assertSame('/var/log/horde.log', $config->getName());
+        $this->assertSame('HORDE', $config->getIdent());
+    }
+
+    public function testStreamType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'stream',
+                'name' => 'php://stderr',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('stream', $config->getType());
+        $this->assertSame('php://stderr', $config->getName());
+    }
+
+    public function testSyslogType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'syslog',
+                'name' => '24', // LOG_DAEMON facility
+                'ident' => 'horde-app',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('syslog', $config->getType());
+        $this->assertSame('24', $config->getName());
+        $this->assertSame('horde-app', $config->getIdent());
+        $this->assertSame(24, $config->getFacility());
+    }
+
+    public function testSyslogTypeWithNonNumericName(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'syslog',
+                'name' => 'daemon',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertNull($config->getFacility());
+    }
+
+    public function testPriorityNormalizationWarning(): void
+    {
+        // Bug #12109: WARNING should map to WARN
+        $state = new State([
+            'log' => ['priority' => 'WARNING'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('WARN', $config->getPriority());
+    }
+
+    public function testPriorityNormalizationValid(): void
+    {
+        $priorities = ['EMERG', 'ALERT', 'CRIT', 'ERR', 'WARN', 'NOTICE', 'INFO', 'DEBUG'];
+
+        foreach ($priorities as $priority) {
+            $state = new State(['log' => ['priority' => $priority]]);
+            $config = new LoggerConfig($state);
+
+            $this->assertSame($priority, $config->getPriority(), "Priority $priority should normalize to itself");
+        }
+    }
+
+    public function testPriorityNormalizationInvalid(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'INVALID_PRIORITY'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        // Invalid priority should fall back to NOTICE
+        $this->assertSame('NOTICE', $config->getPriority());
+    }
+
+    public function testGetPriorityValue(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'WARN'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame(\Horde_Log::WARN, $config->getPriorityValue());
+    }
+
+    public function testFormatDefault(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('default', $config->getFormat());
+        $this->assertNull($config->getTemplate());
+    }
+
+    public function testFormatCustom(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => [
+                    'format' => 'custom',
+                    'template' => '%timestamp% [%levelName%] %message%',
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('custom', $config->getFormat());
+        $this->assertSame('%timestamp% [%levelName%] %message%', $config->getTemplate());
+    }
+
+    public function testFormatXml(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['format' => 'xml'],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('xml', $config->getFormat());
+    }
+
+    public function testAppendTrue(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['append' => true],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->getAppend());
+        $this->assertSame('a+', $config->getAppendMode());
+    }
+
+    public function testAppendFalse(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['append' => false],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->getAppend());
+        $this->assertSame('w+', $config->getAppendMode());
+    }
+
+    public function testToArray(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'file',
+                'name' => '/var/log/test.log',
+                'ident' => 'TEST',
+                'priority' => 'INFO',
+                'params' => [
+                    'format' => 'custom',
+                    'template' => '%message%',
+                    'append' => false,
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $array = $config->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertTrue($array['enabled']);
+        $this->assertSame('file', $array['type']);
+        $this->assertSame('/var/log/test.log', $array['name']);
+        $this->assertSame('TEST', $array['ident']);
+        $this->assertSame('INFO', $array['priority']);
+        $this->assertSame('custom', $array['format']);
+        $this->assertSame('%message%', $array['template']);
+        $this->assertFalse($array['append']);
+    }
+
+    public function testConfigurationCaching(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'DEBUG'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        // First call parses
+        $priority1 = $config->getPriority();
+
+        // Second call should use cached value
+        $priority2 = $config->getPriority();
+
+        $this->assertSame($priority1, $priority2);
+        $this->assertSame('DEBUG', $priority2);
+    }
+
+    public function testCompleteFileConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'file',
+                'name' => '/var/log/horde/horde.log',
+                'ident' => 'HORDE',
+                'priority' => 'NOTICE',
+                'params' => [
+                    'format' => 'default',
+                    'append' => true,
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('file', $config->getType());
+        $this->assertSame('/var/log/horde/horde.log', $config->getName());
+        $this->assertSame('HORDE', $config->getIdent());
+        $this->assertSame('NOTICE', $config->getPriority());
+        $this->assertSame(\Horde_Log::NOTICE, $config->getPriorityValue());
+        $this->assertSame('default', $config->getFormat());
+        $this->assertTrue($config->getAppend());
+        $this->assertSame('a+', $config->getAppendMode());
+    }
+
+    public function testCompleteSyslogConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'syslog',
+                'name' => '24',
+                'ident' => 'horde-imp',
+                'priority' => 'WARNING', // Bug #12109 test
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('syslog', $config->getType());
+        $this->assertSame('24', $config->getName());
+        $this->assertSame(24, $config->getFacility());
+        $this->assertSame('horde-imp', $config->getIdent());
+        $this->assertSame('WARN', $config->getPriority()); // Normalized
+        $this->assertSame(\Horde_Log::WARN, $config->getPriorityValue());
+    }
+
+    public function testMissingLogConfiguration(): void
+    {
+        // State with no log key at all
+        $state = new State([]);
+        $config = new LoggerConfig($state);
+
+        // Should use all defaults
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+        $this->assertSame('NOTICE', $config->getPriority());
+    }
+
+    public function testNullHandlerConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => false,
+                'type' => 'null',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+    }
+}


### PR DESCRIPTION
Unify logger loading - one config drives both the old logger interface and the PSR-3 equivalent.