### PR TITLE
refactor/modern routes psr4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,11 +104,14 @@
         }
     },
     "config": {
-        "allow-plugins": {}
+        "allow-plugins": {
+            "horde/horde-installer-plugin": true
+        }
     },
     "extra": {
         "branch-alias": {
             "dev-FRAMEWORK_6_0": "3.x-dev"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/lib/Horde/Core/Controller/RequestMapper.php
+++ b/lib/Horde/Core/Controller/RequestMapper.php
@@ -12,6 +12,8 @@
  * @package  Core
  */
 
+use Horde\Routes\Mapper;
+
 /**
  * The Horde_Core_Controller_RequestMapper class provides
  * logic to identify which app is supposed to handle the request.
@@ -42,11 +44,11 @@
 class Horde_Core_Controller_RequestMapper
 {
     /**
-     * @var Horde_Routes_Mapper $mapper
+     * @var Mapper $mapper
      */
     protected $_mapper;
 
-    public function __construct(Horde_Routes_Mapper $mapper)
+    public function __construct(Mapper $mapper)
     {
         $this->_mapper = $mapper;
     }

--- a/lib/Horde/Core/Factory/Logger.php
+++ b/lib/Horde/Core/Factory/Logger.php
@@ -21,30 +21,40 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
     protected static $_queue;
 
     /**
+     * Logger configuration service
+     *
+     * @var \Horde\Core\Config\LoggerConfig
+     */
+    private $config;
+
+    /**
      */
     public function create(Horde_Injector $injector)
     {
-        global $conf;
+        // Get LoggerConfig service (autowired by injector)
+        if ($this->config === null) {
+            $this->config = $injector->getInstance('Horde\\Core\\Config\\LoggerConfig');
+        }
 
         $this->error = null;
 
-        /* Default handler. */
-        if (empty($conf['log']['enabled'])) {
+        /* Default handler if logging is disabled. */
+        if (!$this->config->isEnabled()) {
             return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
         }
 
-        switch ($conf['log']['type']) {
+        switch ($this->config->getType()) {
             case 'file':
             case 'stream':
-                $append = ($conf['log']['type'] == 'file')
-                    ? ($conf['log']['params']['append'] ? 'a+' : 'w+')
+                $append = ($this->config->getType() === 'file')
+                    ? $this->config->getAppendMode()
                     : null;
-                $format = $conf['log']['params']['format']
-                    ?? 'default';
 
-                switch ($format) {
+                switch ($this->config->getFormat()) {
                     case 'custom':
-                        $formatter = new Horde_Log_Formatter_Simple(['format' => $conf['log']['params']['template']]);
+                        $formatter = ($this->config->getTemplate() !== null)
+                            ? new Horde_Log_Formatter_Simple(['format' => $this->config->getTemplate()])
+                            : null;
                         break;
 
                     case 'default':
@@ -59,14 +69,13 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
                 }
 
                 try {
-                    // TODO: In some cases we arrive at the logger factory and are unable to autoload this Handler class.
-                    $handler = new Horde_Log_Handler_Stream($conf['log']['name'], $append, $formatter);
+                    $handler = new Horde_Log_Handler_Stream($this->config->getName(), $append, $formatter);
                 } catch (Horde_Log_Exception $e) {
                     $this->error = $e;
                     return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
                 }
                 try {
-                    $handler->setOption('ident', $conf['log']['ident']);
+                    $handler->setOption('ident', $this->config->getIdent());
                 } catch (Horde_Log_Exception $e) {
                 }
                 break;
@@ -74,11 +83,13 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
             case 'syslog':
                 try {
                     $handler = new Horde_Log_Handler_Syslog();
-                    if (!empty($conf['log']['name'])) {
-                        $handler->setOption('facility', $conf['log']['name']);
+                    $facility = $this->config->getFacility();
+                    if ($facility !== null) {
+                        $handler->setOption('facility', $facility);
                     }
-                    if (!empty($conf['log']['ident'])) {
-                        $handler->setOption('ident', $conf['log']['ident']);
+                    $ident = $this->config->getIdent();
+                    if (!empty($ident)) {
+                        $handler->setOption('ident', $ident);
                     }
                 } catch (Horde_Log_Exception $e) {
                     $this->error = $e;
@@ -92,19 +103,7 @@ class Horde_Core_Factory_Logger extends Horde_Core_Factory_Injector
                 return new Horde_Core_Log_Logger(new Horde_Log_Handler_Null());
         }
 
-        switch ($conf['log']['priority']) {
-            case 'WARNING':
-                // Bug #12109
-                $priority = 'WARN';
-                break;
-
-            default:
-                $priority = defined('Horde_Log::' . $conf['log']['priority'])
-                    ? $conf['log']['priority']
-                    : 'NOTICE';
-                break;
-        }
-        $handler->addFilter(constant('Horde_Log::' . $priority));
+        $handler->addFilter($this->config->getPriorityValue());
 
         try {
             /* Horde_Core_Log_Logger contains code to format the log

--- a/lib/Horde/Core/Factory/Mapper.php
+++ b/lib/Horde/Core/Factory/Mapper.php
@@ -1,5 +1,7 @@
 <?php
 
+use Horde\Routes\Mapper;
+
 /**
  * @category Horde
  * @package  Core
@@ -8,7 +10,7 @@ class Horde_Core_Factory_Mapper extends Horde_Core_Factory_Injector
 {
     public function create(Horde_Injector $injector)
     {
-        return new Horde_Routes_Mapper();
+        return new Mapper();
     }
 
 }

--- a/lib/Horde/Core/Factory/Matcher.php
+++ b/lib/Horde/Core/Factory/Matcher.php
@@ -1,5 +1,8 @@
 <?php
 
+use Horde\Routes\Mapper;
+use Horde\Routes\Matcher;
+
 /**
  * @category Horde
  * @package  Core
@@ -8,8 +11,8 @@ class Horde_Core_Factory_Matcher extends Horde_Core_Factory_Injector
 {
     public function create(Horde_Injector $injector)
     {
-        return new Horde_Routes_Matcher(
-            $injector->getInstance('Horde_Routes_Mapper'),
+        return new Matcher(
+            $injector->getInstance(Mapper::class),
             $injector->getInstance('Horde_Controller_Request')
         );
     }

--- a/lib/Horde/Core/Smartmobile/Url.php
+++ b/lib/Horde/Core/Smartmobile/Url.php
@@ -35,7 +35,7 @@ class Horde_Core_Smartmobile_Url extends \Horde\Url\Url
     /**
      * Constructor.
      *
-     * @param \Horde\Url\Url|Horde_Url|string|null $url  The basic URL.
+     * @param \Horde\Url\Url|Horde_Url|string|null $url  The basic URL (URL object or string).
      * @param bool|null $raw                              Whether to output the URL in raw format or HTML-encoded.
      */
     public function __construct(\Horde\Url\Url|Horde_Url|string|null $url = null, ?bool $raw = null)
@@ -43,16 +43,17 @@ class Horde_Core_Smartmobile_Url extends \Horde\Url\Url
         if ($url === null) {
             $url = new \Horde\Url\Url();
         } elseif ($url instanceof Horde_Url) {
-            // Extract the modern instance from the legacy wrapper
+            // Convert legacy wrapper to modern Url
             $url = new \Horde\Url\Url((string)$url, $raw);
             // Copy parameters from the wrapper
             foreach ((array)$url->parameters as $key => $value) {
                 $url->add($key, $value);
             }
         } elseif (is_string($url)) {
+            // Accept strings for convenience
             $url = new \Horde\Url\Url($url, $raw);
         } elseif (!($url instanceof \Horde\Url\Url)) {
-            throw new InvalidArgumentException('First argument must be a URL object or string');
+            throw new \InvalidArgumentException('First argument must be a URL object or string');
         }
 
         $query = '';

--- a/lib/Horde/Core/Smartmobile/Url.php
+++ b/lib/Horde/Core/Smartmobile/Url.php
@@ -23,29 +23,36 @@
  * @category Horde
  * @package  Core
  */
-class Horde_Core_Smartmobile_Url extends Horde_Url
+class Horde_Core_Smartmobile_Url extends \Horde\Url\Url
 {
     /**
      * The URL used as the base for the smartmobile anchor.
      *
-     * @var Horde_Url
+     * @var \Horde\Url\Url
      */
     protected $_baseUrl;
 
     /**
      * Constructor.
      *
-     * @param Horde_Url $url   The basic URL.
-     * @param boolean $raw     Whether to output the URL in the raw URL format
-     *                         or HTML-encoded.
+     * @param \Horde\Url\Url|Horde_Url|string|null $url  The basic URL.
+     * @param bool|null $raw                              Whether to output the URL in raw format or HTML-encoded.
      */
-    public function __construct($url = null, $raw = null)
+    public function __construct(\Horde\Url\Url|Horde_Url|string|null $url = null, ?bool $raw = null)
     {
-        if (is_null($url)) {
-            $url = new Horde_Url();
-        }
-        if (!($url instanceof Horde_Url)) {
-            throw new InvalidArgumentException('First argument to Horde_Core_Smartmobile_Url constructor must be a Horde_Url object');
+        if ($url === null) {
+            $url = new \Horde\Url\Url();
+        } elseif ($url instanceof Horde_Url) {
+            // Extract the modern instance from the legacy wrapper
+            $url = new \Horde\Url\Url((string)$url, $raw);
+            // Copy parameters from the wrapper
+            foreach ((array)$url->parameters as $key => $value) {
+                $url->add($key, $value);
+            }
+        } elseif (is_string($url)) {
+            $url = new \Horde\Url\Url($url, $raw);
+        } elseif (!($url instanceof \Horde\Url\Url)) {
+            throw new InvalidArgumentException('First argument must be a URL object or string');
         }
 
         $query = '';
@@ -70,13 +77,12 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
     /**
      * Creates the full URL string.
      *
-     * @param boolean $raw   Whether to output the URL in the raw URL format
-     *                       or HTML-encoded.
-     * @param boolean $full  Output the full URL?
+     * @param bool $raw   Whether to output the URL in the raw URL format or HTML-encoded.
+     * @param bool $full  Output the full URL?
      *
      * @return string  The string representation of this object.
      */
-    public function toString($raw = false, $full = true)
+    public function toString(bool $raw = false, bool $full = true): string
     {
         if ($this->toStringCallback || !strlen($this->anchor)) {
             $baseUrl = clone $this->_baseUrl;
@@ -105,7 +111,14 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
             $url .= '?' . http_build_query($params, '', $raw ? '&' : '&amp;');
         }
 
-        return strval($url);
+        return $url;
     }
 
+    /**
+     * Magic __toString method for PHP 8+ compatibility
+     */
+    public function __toString(): string
+    {
+        return $this->toString($this->raw ?? false);
+    }
 }

--- a/lib/Horde/Core/Smartmobile/Url.php
+++ b/lib/Horde/Core/Smartmobile/Url.php
@@ -79,7 +79,7 @@ class Horde_Core_Smartmobile_Url extends Horde_Url
     public function toString($raw = false, $full = true)
     {
         if ($this->toStringCallback || !strlen($this->anchor)) {
-            $baseUrl = $this->_baseUrl->copy();
+            $baseUrl = clone $this->_baseUrl;
             $baseUrl->parameters = array_merge(
                 $baseUrl->parameters,
                 $this->parameters

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -437,6 +437,7 @@ class Horde_Registry implements Horde_Shutdown_Task
             'Horde_Perms' => 'Horde_Core_Factory_Perms',
             'Horde_Queue_Storage' => 'Horde_Core_Factory_QueueStorage',
             'Horde_Routes_Mapper' => 'Horde_Core_Factory_Mapper',
+            Horde\Routes\Mapper::class => 'Horde_Core_Factory_Mapper',
             'Horde_Routes_Matcher' => 'Horde_Core_Factory_Matcher',
             'Horde_Secret' => 'Horde_Core_Factory_Secret',
             'Horde_Secret_Cbc' => 'Horde_Core_Factory_Secret_Cbc',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         bootstrap="test/bootstrap.php"
-         cacheDirectory=".phpunit.cache/code-coverage"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         beStrictAboutOutputDuringTests="true"
-         failOnRisky="true"
-         failOnWarning="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.0/phpunit.xsd" bootstrap="test/bootstrap.php" cacheDirectory=".phpunit.cache/code-coverage" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true">
   <testsuites>
     <testsuite name="horde/core">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <coverage>
+  <source>
     <include>
       <directory suffix=".php">lib</directory>
       <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
 </phpunit>

--- a/src/Config/LoggerConfig.php
+++ b/src/Config/LoggerConfig.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+declare(strict_types=1);
+
+namespace Horde\Core\Config;
+
+/**
+ * Logger configuration service
+ *
+ * Parses conf.php log settings once and provides structured configuration
+ * to both legacy and modern logger factories. This ensures consistent
+ * configuration interpretation across both implementations.
+ *
+ * @author   Ralf Lang <lang@b1-systems.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+class LoggerConfig
+{
+    private State $conf;
+    private ?array $parsed = null;
+
+    /**
+     * Constructor
+     *
+     * @param State $conf Configuration state object wrapping $GLOBALS['conf']
+     */
+    public function __construct(State $conf)
+    {
+        $this->conf = $conf;
+    }
+
+    /**
+     * Parse configuration once and cache
+     *
+     * @return array Parsed configuration values
+     */
+    private function parse(): array
+    {
+        if ($this->parsed !== null) {
+            return $this->parsed;
+        }
+
+        $conf = $this->conf->toArray();
+        $logConf = $conf['log'] ?? [];
+
+        $this->parsed = [
+            'enabled' => $logConf['enabled'] ?? true,
+            'type' => $logConf['type'] ?? 'null',
+            'name' => $logConf['name'] ?? '',
+            'ident' => $logConf['ident'] ?? '',
+            'priority' => $this->normalizePriority($logConf['priority'] ?? 'NOTICE'),
+            'format' => $logConf['params']['format'] ?? 'default',
+            'template' => $logConf['params']['template'] ?? null,
+            'append' => $logConf['params']['append'] ?? true,
+            'facility' => is_numeric($logConf['name'] ?? null) ? (int) $logConf['name'] : null,
+        ];
+
+        return $this->parsed;
+    }
+
+    /**
+     * Normalize priority level
+     *
+     * Handles special case for Bug #12109 where WARNING should map to WARN.
+     * Also validates that the priority constant exists.
+     *
+     * @param string $priority Raw priority from configuration
+     * @return string Normalized priority constant name
+     */
+    private function normalizePriority(string $priority): string
+    {
+        // Bug #12109: WARNING should be WARN
+        if ($priority === 'WARNING') {
+            return 'WARN';
+        }
+
+        // Validate constant exists, fallback to NOTICE
+        return defined('Horde_Log::' . $priority) ? $priority : 'NOTICE';
+    }
+
+    /**
+     * Is logging enabled?
+     *
+     * @return bool True if logging is enabled in configuration
+     */
+    public function isEnabled(): bool
+    {
+        return $this->parse()['enabled'];
+    }
+
+    /**
+     * Get logger type
+     *
+     * @return string One of: 'file', 'stream', 'syslog', 'null'
+     */
+    public function getType(): string
+    {
+        return $this->parse()['type'];
+    }
+
+    /**
+     * Get log destination name
+     *
+     * For file/stream handlers: file path or stream URL
+     * For syslog handler: facility number (or empty for default)
+     *
+     * @return string Log destination
+     */
+    public function getName(): string
+    {
+        return $this->parse()['name'];
+    }
+
+    /**
+     * Get log identifier
+     *
+     * Identifier prepended to log messages
+     *
+     * @return string Log identifier
+     */
+    public function getIdent(): string
+    {
+        return $this->parse()['ident'];
+    }
+
+    /**
+     * Get normalized priority level
+     *
+     * Returns the constant name (e.g., 'NOTICE', 'WARN', 'DEBUG')
+     *
+     * @return string Priority constant name
+     */
+    public function getPriority(): string
+    {
+        return $this->parse()['priority'];
+    }
+
+    /**
+     * Get priority as integer constant value
+     *
+     * @return int Priority constant value (e.g., Horde_Log::NOTICE)
+     */
+    public function getPriorityValue(): int
+    {
+        return constant('Horde_Log::' . $this->getPriority());
+    }
+
+    /**
+     * Get format type
+     *
+     * @return string One of: 'default', 'custom', 'xml'
+     */
+    public function getFormat(): string
+    {
+        return $this->parse()['format'];
+    }
+
+    /**
+     * Get custom format template
+     *
+     * Only applicable when format type is 'custom'
+     *
+     * @return string|null Custom format template or null
+     */
+    public function getTemplate(): ?string
+    {
+        return $this->parse()['template'];
+    }
+
+    /**
+     * Get append mode for file handlers
+     *
+     * @return bool True to append, false to overwrite
+     */
+    public function getAppend(): bool
+    {
+        return $this->parse()['append'];
+    }
+
+    /**
+     * Get append mode as fopen() mode string
+     *
+     * @return string 'a+' for append, 'w+' for overwrite
+     */
+    public function getAppendMode(): string
+    {
+        return $this->getAppend() ? 'a+' : 'w+';
+    }
+
+    /**
+     * Get syslog facility
+     *
+     * @return int|null Syslog facility number or null if not specified
+     */
+    public function getFacility(): ?int
+    {
+        return $this->parse()['facility'];
+    }
+
+    /**
+     * Get raw parsed configuration array
+     *
+     * Provided for backward compatibility and debugging.
+     * Prefer using specific getter methods.
+     *
+     * @return array Parsed configuration
+     */
+    public function toArray(): array
+    {
+        return $this->parse();
+    }
+}

--- a/src/Config/State.php
+++ b/src/Config/State.php
@@ -39,9 +39,13 @@ class State
      */
     public function __construct(?array $conf = null)
     {
-        $this->conf = $conf ?? $GLOBALS['conf'] ?? null;
-        // If we still have no array, give up.
-        if (empty($this->conf)) {
+        // If explicitly passed (even if empty array), use it
+        // Otherwise fall back to $GLOBALS['conf']
+        if ($conf !== null) {
+            $this->conf = $conf;
+        } elseif (isset($GLOBALS['conf'])) {
+            $this->conf = $GLOBALS['conf'];
+        } else {
             throw new \Horde_Exception(
                 'Config neither passed nor available from global'
             );

--- a/src/Factory/LogHandlerFactory.php
+++ b/src/Factory/LogHandlerFactory.php
@@ -11,7 +11,7 @@ namespace Horde\Core\Factory;
 
 use Horde_Core_Factory_Injector;
 use Horde\Log\Logger;
-use Horde\Core\Config\State;
+use Horde\Core\Config\LoggerConfig;
 use Horde\Injector\Injector;
 use Horde\Log\Filter\MaximumLevelFilter;
 use Horde\Log\Formatter\Psr3Formatter;
@@ -32,29 +32,25 @@ use Horde\Log\LogException;
  */
 class LogHandlerFactory extends Horde_Core_Factory_Injector
 {
-    private State $conf;
+    private LoggerConfig $config;
 
     /**
      * Constructor
      *
-     *
-     * @param State $config The conf.php values for the global log handler
-     *
+     * @param LoggerConfig $config Logger configuration service
      */
-    public function __construct(State $config)
+    public function __construct(LoggerConfig $config)
     {
-        $this->conf = $config;
+        $this->config = $config;
     }
 
     /**
      * Create default LogHandler
      *
-     * This creates a LogHandler with
-     *   configuration from conf.php
+     * This creates a LogHandler with configuration from conf.php via
+     * LoggerConfig service:
      * - the PSR-3 formatter and depending on options, another formatter,
      * - a handler-level filter by loglevel as the config suggests
-     *
-     * TODO: Mechanism to add and expose custom handlers
      *
      * @param Injector $injector
      * @return LogHandler
@@ -62,23 +58,20 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
      */
     public function create(Injector $injector): LogHandler
     {
-        $conf = $this->conf->toArray();
         $formatters = [new Psr3Formatter()];
 
-        switch ($conf['log']['type']) {
+        switch ($this->config->getType()) {
             case 'file':
             case 'stream':
-                // TODO: Default context?
-
-                $append = ($conf['log']['type'] == 'file')
-                    ? ($conf['log']['params']['append'] ? 'a+' : 'w+')
+                $append = ($this->config->getType() === 'file')
+                    ? $this->config->getAppendMode()
                     : null;
-                $format = $conf['log']['params']['format']
-                    ?? 'default';
 
-                switch ($format) {
+                switch ($this->config->getFormat()) {
                     case 'custom':
-                        $formatters[] = new SimpleFormatter(['format' => $conf['log']['params']['template']]);
+                        if ($this->config->getTemplate() !== null) {
+                            $formatters[] = new SimpleFormatter(['format' => $this->config->getTemplate()]);
+                        }
                         break;
 
                     case 'default':
@@ -92,18 +85,19 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
                 }
 
                 $options = new Options();
-                $options->ident = (string) $conf['log']['ident'] ?? '';
-                // Let's not try and catch. Let it fail, the caller should care
-                $handler = new StreamHandler($conf['log']['name'], $append, $options, $formatters);
+                $options->ident = $this->config->getIdent();
+                $handler = new StreamHandler($this->config->getName(), $append, $options, $formatters);
                 break;
 
             case 'syslog':
                 $options = new SyslogOptions();
-                if (!empty($conf['log']['name'] && is_numeric($conf['log']['name']))) {
-                    $options->facility = (int) $conf['log']['name'];
+                $facility = $this->config->getFacility();
+                if ($facility !== null) {
+                    $options->facility = $facility;
                 }
-                if (!empty($conf['log']['ident'])) {
-                    $options->ident = (string) $conf['log']['ident'];
+                $ident = $this->config->getIdent();
+                if (!empty($ident)) {
+                    $options->ident = $ident;
                 }
                 $handler = new SyslogHandler($options, $formatters, []);
                 break;
@@ -114,19 +108,7 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
                 return new NullHandler();
         }
 
-        switch ($conf['log']['priority']) {
-            case 'WARNING':
-                // Bug #12109
-                $priority = 'WARN';
-                break;
-
-            default:
-                $priority = defined('Horde_Log::' . $conf['log']['priority'])
-                    ? $conf['log']['priority']
-                    : 'NOTICE';
-                break;
-        }
-        $handler->addFilter(new MaximumLevelFilter(constant('Horde_Log::' . $priority)));
+        $handler->addFilter(new MaximumLevelFilter($this->config->getPriorityValue()));
         return $handler;
     }
 

--- a/src/Factory/LoggerFactory.php
+++ b/src/Factory/LoggerFactory.php
@@ -12,7 +12,7 @@ namespace Horde\Core\Factory;
 use Horde_Core_Factory_Injector;
 use Horde\Log\Logger;
 use Horde\Log\LogException;
-use Horde\Core\Config\State;
+use Horde\Core\Config\LoggerConfig;
 use Horde\Injector\Injector;
 use Horde\Log\LogHandler;
 use Horde\Log\LogLevels;
@@ -23,7 +23,7 @@ use Horde\Log\LogLevels;
  */
 class LoggerFactory extends Horde_Core_Factory_Injector
 {
-    private State $conf;
+    private LoggerConfig $config;
     private LogLevels $levels;
     private Logger $logger;
 
@@ -38,26 +38,23 @@ class LoggerFactory extends Horde_Core_Factory_Injector
     /**
      * Constructor
      *
-     *
-     * @param State $config The conf.php values for the global log handler
-     *
+     * @param LoggerConfig $config Logger configuration service
+     * @param LogHandlerFactory $handlerFactory Handler factory
      */
-    public function __construct(State $config, LogHandlerFactory $handlerFactory)
+    public function __construct(LoggerConfig $config, LogHandlerFactory $handlerFactory)
     {
-        $this->conf = $config;
+        $this->config = $config;
         $this->handlerFactory = $handlerFactory;
     }
 
     /**
      * Create default logger
      *
-     * This creates a logger with
+     * This creates a logger with:
      * - one handler based on the horde config or no handler,
-     * - canonic log levels,
+     * - canonical log levels,
      * - the PSR-3 formatter and depending on options, another formatter,
      * - a handler-level filter by loglevel
-     *
-     * TODO: Mechanism to add specialised handlers without a configuration mess.
      *
      * @param Injector $injector
      * @return Logger
@@ -65,9 +62,7 @@ class LoggerFactory extends Horde_Core_Factory_Injector
      */
     public function create(Injector $injector): Logger
     {
-        $conf = $this->conf->toArray();
         $this->levels = LogLevels::initWithCanonicalLevels();
-        //
         $handlers = $this->predefinedHandlers();
         $handlers[] = $this->handlerFactory->create($injector);
         return new Logger($handlers, $this->levels);

--- a/src/Middleware/AppRouter.php
+++ b/src/Middleware/AppRouter.php
@@ -16,7 +16,8 @@ use Horde_Registry;
 use Horde_Application;
 use Horde_Controller;
 use Horde_Injector;
-use Horde_Routes_Mapper as Router;
+use Horde\Routes\Mapper;
+use Horde\Routes\Matcher;
 use Horde_String;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Horde\Exception\HordeException;
@@ -40,14 +41,14 @@ use Horde\Exception\HordeException;
  */
 class AppRouter extends RampageRequestHandler implements MiddlewareInterface, RequestHandlerInterface
 {
-    private Router $router;
+    private Mapper $mapper;
     private Horde_Registry $registry;
     private Horde_Injector $injector;
 
-    public function __construct(Horde_Registry $registry, Router $router, Horde_Injector $injector)
+    public function __construct(Horde_Registry $registry, Mapper $mapper, Horde_Injector $injector)
     {
         $this->registry = $registry;
-        $this->router = $router;
+        $this->mapper = $mapper;
         $this->injector = $injector;
     }
 
@@ -92,21 +93,22 @@ class AppRouter extends RampageRequestHandler implements MiddlewareInterface, Re
 
         // Application routes are relative only to the application. Let the
         // mapper know where they start.
-        $this->router->prefix = $prefix;
+        $this->mapper->prefix = $prefix;
 
         // Load application routes.
         // Cannot rename mapper as long as we support the existing routes definitions
-        $mapper = $router = $this->router;
-        $router->environ = ['REQUEST_METHOD' => $request->getMethod()];
+        $mapper = $router = $this->mapper;
         include $routeFile;
         if (file_exists($fileroot . '/config/routes.local.php')) {
             include $fileroot . '/config/routes.local.php';
         }
-        // Match
+
+        // Match using PSR-7 Matcher (auto-populates environ from request)
         // @TODO Cache routes
-        $path = $request->getUri()->getPath();
-        $path = strtok($path, '?');
-        $match = $this->router->match($path);
+        $matcher = new Matcher($this->mapper, $request);
+        $matchDict = $matcher->getMatchDict();
+        // Unwrap Horde_Support_Array to plain array for compatibility
+        $match = iterator_to_array($matchDict);
         $request = $request->withAttribute('route', $match);
 
         // compatibility: if unset stack and HordeAuthType is 'NONE' set empty stack

--- a/src/Middleware/AuthHordeSession.php
+++ b/src/Middleware/AuthHordeSession.php
@@ -12,7 +12,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Horde_Registry;
 use Horde_Application;
 use Horde_Controller;
-use Horde_Routes_Mapper as Router;
 use Horde_String;
 use Horde;
 

--- a/src/Middleware/AuthIsGlobalAdmin.php
+++ b/src/Middleware/AuthIsGlobalAdmin.php
@@ -12,7 +12,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Horde_Registry;
 use Horde_Application;
 use Horde_Controller;
-use Horde_Routes_Mapper as Router;
 use Horde_String;
 use Horde;
 use Horde\Core\UserPassport;

--- a/src/Middleware/HordeCore.php
+++ b/src/Middleware/HordeCore.php
@@ -18,6 +18,7 @@ use Horde\Http\RequestFactory;
 use Horde\Http\UriFactory;
 use Horde\Http\StreamFactory;
 use Horde\Http\ResponseFactory;
+use Horde\Routes\Mapper;
 
 /**
  * HordeCoreMiddleware
@@ -62,7 +63,7 @@ class HordeCore implements MiddlewareInterface
         // Detect correct app
         $handler->addMiddleware(new AppFinder($registry, new ResponseFactory(), new StreamFactory()));
         // Find route inside detected app
-        $handler->addMiddleware(new AppRouter($registry, $injector->get('Horde_Routes_Mapper'), $injector));
+        $handler->addMiddleware(new AppRouter($registry, $injector->get(Mapper::class), $injector));
 
         $request = $request->withAttribute('registry', $registry);
         return $handler->handle($request);

--- a/src/Middleware/RedirectToLogin.php
+++ b/src/Middleware/RedirectToLogin.php
@@ -12,7 +12,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Horde_Registry;
 use Horde_Application;
 use Horde_Controller;
-use Horde_Routes_Mapper as Router;
 use Horde_String;
 use Horde\Core\Config\State;
 use Horde;

--- a/test/Assets/ResponsiveAssetsTest.php
+++ b/test/Assets/ResponsiveAssetsTest.php
@@ -54,8 +54,9 @@ class ResponsiveAssetsTest extends TestCase
 
         // Setup filesystem mock - file exists
         $this->filesystemMock->method('fileExists')
-            ->with('/horde/themes/default/responsive.css')
-            ->willReturn(true);
+            ->willReturnCallback(function($path) {
+                return $path === '/horde/themes/default/responsive.css';
+            });
 
         // Create assets helper
         $assets = new ResponsiveAssets($this->registryMock, $this->filesystemMock);
@@ -170,8 +171,9 @@ class ResponsiveAssetsTest extends TestCase
 
         // File exists
         $this->filesystemMock->method('fileExists')
-            ->with('/horde/js/login-form.js')
-            ->willReturn(true);
+            ->willReturnCallback(function($path) {
+                return $path === '/horde/js/login-form.js';
+            });
 
         $assets = new ResponsiveAssets($this->registryMock, $this->filesystemMock);
         $urls = $assets->getJsUrls(['login-form.js'], 'horde');
@@ -271,8 +273,9 @@ class ResponsiveAssetsTest extends TestCase
         // Mock preferences
         $prefsMock = $this->createMock(\Horde_Prefs::class);
         $prefsMock->method('getValue')
-            ->with('theme')
-            ->willReturn('dark');
+            ->willReturnCallback(function($key) {
+                return $key === 'theme' ? 'dark' : null;
+            });
 
         $GLOBALS['prefs'] = $prefsMock;
 

--- a/test/Config/LoggerConfigTest.php
+++ b/test/Config/LoggerConfigTest.php
@@ -1,0 +1,344 @@
+<?php
+
+/**
+ * Tests for LoggerConfig
+ *
+ * @category   Horde
+ * @license    http://www.horde.org/licenses/lgpl21 LGPL
+ * @package    Core
+ * @subpackage UnitTests
+ */
+declare(strict_types=1);
+
+namespace Horde\Core\Test\Config;
+
+use Horde\Core\Config\LoggerConfig;
+use Horde\Core\Config\State;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(LoggerConfig::class)]
+class LoggerConfigTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+        $this->assertInstanceOf(LoggerConfig::class, $config);
+    }
+
+    public function testDefaultValues(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+        $this->assertSame('', $config->getName());
+        $this->assertSame('', $config->getIdent());
+        $this->assertSame('NOTICE', $config->getPriority());
+        $this->assertSame('default', $config->getFormat());
+        $this->assertNull($config->getTemplate());
+        $this->assertTrue($config->getAppend());
+        $this->assertNull($config->getFacility());
+    }
+
+    public function testEnabledFalse(): void
+    {
+        $state = new State(['log' => ['enabled' => false]]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->isEnabled());
+    }
+
+    public function testFileType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'file',
+                'name' => '/var/log/horde.log',
+                'ident' => 'HORDE',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('file', $config->getType());
+        $this->assertSame('/var/log/horde.log', $config->getName());
+        $this->assertSame('HORDE', $config->getIdent());
+    }
+
+    public function testStreamType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'stream',
+                'name' => 'php://stderr',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('stream', $config->getType());
+        $this->assertSame('php://stderr', $config->getName());
+    }
+
+    public function testSyslogType(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'syslog',
+                'name' => '24', // LOG_DAEMON facility
+                'ident' => 'horde-app',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('syslog', $config->getType());
+        $this->assertSame('24', $config->getName());
+        $this->assertSame('horde-app', $config->getIdent());
+        $this->assertSame(24, $config->getFacility());
+    }
+
+    public function testSyslogTypeWithNonNumericName(): void
+    {
+        $state = new State([
+            'log' => [
+                'type' => 'syslog',
+                'name' => 'daemon',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertNull($config->getFacility());
+    }
+
+    public function testPriorityNormalizationWarning(): void
+    {
+        // Bug #12109: WARNING should map to WARN
+        $state = new State([
+            'log' => ['priority' => 'WARNING'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('WARN', $config->getPriority());
+    }
+
+    public function testPriorityNormalizationValid(): void
+    {
+        $priorities = ['EMERG', 'ALERT', 'CRIT', 'ERR', 'WARN', 'NOTICE', 'INFO', 'DEBUG'];
+
+        foreach ($priorities as $priority) {
+            $state = new State(['log' => ['priority' => $priority]]);
+            $config = new LoggerConfig($state);
+
+            $this->assertSame($priority, $config->getPriority(), "Priority $priority should normalize to itself");
+        }
+    }
+
+    public function testPriorityNormalizationInvalid(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'INVALID_PRIORITY'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        // Invalid priority should fall back to NOTICE
+        $this->assertSame('NOTICE', $config->getPriority());
+    }
+
+    public function testGetPriorityValue(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'WARN'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame(\Horde_Log::WARN, $config->getPriorityValue());
+    }
+
+    public function testFormatDefault(): void
+    {
+        $state = new State(['log' => []]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('default', $config->getFormat());
+        $this->assertNull($config->getTemplate());
+    }
+
+    public function testFormatCustom(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => [
+                    'format' => 'custom',
+                    'template' => '%timestamp% [%levelName%] %message%',
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('custom', $config->getFormat());
+        $this->assertSame('%timestamp% [%levelName%] %message%', $config->getTemplate());
+    }
+
+    public function testFormatXml(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['format' => 'xml'],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertSame('xml', $config->getFormat());
+    }
+
+    public function testAppendTrue(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['append' => true],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->getAppend());
+        $this->assertSame('a+', $config->getAppendMode());
+    }
+
+    public function testAppendFalse(): void
+    {
+        $state = new State([
+            'log' => [
+                'params' => ['append' => false],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->getAppend());
+        $this->assertSame('w+', $config->getAppendMode());
+    }
+
+    public function testToArray(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'file',
+                'name' => '/var/log/test.log',
+                'ident' => 'TEST',
+                'priority' => 'INFO',
+                'params' => [
+                    'format' => 'custom',
+                    'template' => '%message%',
+                    'append' => false,
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $array = $config->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertTrue($array['enabled']);
+        $this->assertSame('file', $array['type']);
+        $this->assertSame('/var/log/test.log', $array['name']);
+        $this->assertSame('TEST', $array['ident']);
+        $this->assertSame('INFO', $array['priority']);
+        $this->assertSame('custom', $array['format']);
+        $this->assertSame('%message%', $array['template']);
+        $this->assertFalse($array['append']);
+    }
+
+    public function testConfigurationCaching(): void
+    {
+        $state = new State([
+            'log' => ['priority' => 'DEBUG'],
+        ]);
+        $config = new LoggerConfig($state);
+
+        // First call parses
+        $priority1 = $config->getPriority();
+
+        // Second call should use cached value
+        $priority2 = $config->getPriority();
+
+        $this->assertSame($priority1, $priority2);
+        $this->assertSame('DEBUG', $priority2);
+    }
+
+    public function testCompleteFileConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'file',
+                'name' => '/var/log/horde/horde.log',
+                'ident' => 'HORDE',
+                'priority' => 'NOTICE',
+                'params' => [
+                    'format' => 'default',
+                    'append' => true,
+                ],
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('file', $config->getType());
+        $this->assertSame('/var/log/horde/horde.log', $config->getName());
+        $this->assertSame('HORDE', $config->getIdent());
+        $this->assertSame('NOTICE', $config->getPriority());
+        $this->assertSame(\Horde_Log::NOTICE, $config->getPriorityValue());
+        $this->assertSame('default', $config->getFormat());
+        $this->assertTrue($config->getAppend());
+        $this->assertSame('a+', $config->getAppendMode());
+    }
+
+    public function testCompleteSyslogConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => true,
+                'type' => 'syslog',
+                'name' => '24',
+                'ident' => 'horde-imp',
+                'priority' => 'WARNING', // Bug #12109 test
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('syslog', $config->getType());
+        $this->assertSame('24', $config->getName());
+        $this->assertSame(24, $config->getFacility());
+        $this->assertSame('horde-imp', $config->getIdent());
+        $this->assertSame('WARN', $config->getPriority()); // Normalized
+        $this->assertSame(\Horde_Log::WARN, $config->getPriorityValue());
+    }
+
+    public function testMissingLogConfiguration(): void
+    {
+        // State with no log key at all
+        $state = new State([]);
+        $config = new LoggerConfig($state);
+
+        // Should use all defaults
+        $this->assertTrue($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+        $this->assertSame('NOTICE', $config->getPriority());
+    }
+
+    public function testNullHandlerConfiguration(): void
+    {
+        $state = new State([
+            'log' => [
+                'enabled' => false,
+                'type' => 'null',
+            ],
+        ]);
+        $config = new LoggerConfig($state);
+
+        $this->assertFalse($config->isEnabled());
+        $this->assertSame('null', $config->getType());
+    }
+}

--- a/test/Middleware/AppRouterTest.php
+++ b/test/Middleware/AppRouterTest.php
@@ -1,0 +1,508 @@
+<?php
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Core\Test\Middleware;
+
+use Horde\Core\Middleware\AppRouter;
+use Horde\Core\Middleware\AuthHordeSession;
+use Horde\Core\Middleware\RedirectToLogin;
+use Horde\Http\RequestFactory;
+use Horde\Http\ResponseFactory;
+use Horde\Http\Server\RampageRequestHandler;
+use Horde\Http\StreamFactory;
+use Horde\Test\TestCase;
+use Horde_Injector;
+use Horde_Registry;
+use Horde_Routes_Mapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Unit tests for AppRouter middleware
+ *
+ * Tests routing functionality including:
+ * - Route matching from URI
+ * - Controller resolution
+ * - Middleware stack configuration
+ * - Default vs custom middleware stacks
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ * @category Horde
+ * @package  Core
+ */
+#[CoversClass(AppRouter::class)]
+class AppRouterTest extends TestCase
+{
+    private RequestFactory $requestFactory;
+    private ResponseFactory $responseFactory;
+    private StreamFactory $streamFactory;
+    private Horde_Registry $registry;
+    private Horde_Routes_Mapper $router;
+    private Horde_Injector $injector;
+    private AppRouter $appRouter;
+    private RampageRequestHandler $handler;
+
+    protected function setUp(): void
+    {
+        $this->requestFactory = new RequestFactory();
+        $this->responseFactory = new ResponseFactory();
+        $this->streamFactory = new StreamFactory();
+
+        // Mock registry
+        $this->registry = $this->createMock(Horde_Registry::class);
+
+        // Real router
+        $this->router = new Horde_Routes_Mapper();
+
+        // Mock injector - configured per test
+        $this->injector = $this->createMock(Horde_Injector::class);
+
+        $this->appRouter = new AppRouter($this->registry, $this->router, $this->injector);
+    }
+
+    /**
+     * Create a test middleware that adds an attribute to track execution
+     */
+    private function createTestMiddleware(string $name): MiddlewareInterface
+    {
+        return new class($name) implements MiddlewareInterface {
+            public function __construct(private string $name)
+            {
+            }
+
+            public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+            {
+                $executed = $request->getAttribute('middlewares_executed', []);
+                $executed[] = $this->name;
+                $request = $request->withAttribute('middlewares_executed', $executed);
+                return $handler->handle($request);
+            }
+        };
+    }
+
+    /**
+     * Test basic route matching with controller
+     */
+    public function testMatchRouteWithController(): void
+    {
+        // Create temporary routes file
+        $tempDir = sys_get_temp_dir() . '/horde-test-' . uniqid();
+        mkdir($tempDir);
+        mkdir($tempDir . '/config');
+        $routesFile = $tempDir . '/config/routes.php';
+
+        file_put_contents($routesFile, <<<'PHP'
+<?php
+$mapper->connect('test-route', '/test', ['controller' => 'TestController']);
+PHP
+        );
+
+        // Setup registry mock
+        $this->registry->expects($this->once())
+            ->method('get')
+            ->with('fileroot', 'testapp')
+            ->willReturn($tempDir);
+
+        $this->registry->expects($this->once())
+            ->method('pushApp')
+            ->with('testapp');
+
+        // Setup injector
+        $this->injector->method('get')
+            ->willReturnCallback(function ($key) {
+                if ($key === ResponseFactoryInterface::class) {
+                    return $this->responseFactory;
+                }
+                if ($key === StreamFactoryInterface::class) {
+                    return $this->streamFactory;
+                }
+                if ($key === AuthHordeSession::class) {
+                    return $this->createTestMiddleware('AuthHordeSession');
+                }
+                if ($key === RedirectToLogin::class) {
+                    return $this->createTestMiddleware('RedirectToLogin');
+                }
+                throw new \Exception("Injector: Unknown key: $key");
+            });
+
+        // Setup injector to return a mock controller
+        $mockController = $this->createMock(RequestHandlerInterface::class);
+        $mockController->method('handle')
+            ->willReturn($this->responseFactory->createResponse(200));
+
+        $this->injector->method('getInstance')
+            ->with('TestController')
+            ->willReturn($mockController);
+
+        // Create request
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/test')
+            ->withAttribute('app', 'testapp')
+            ->withAttribute('routerPrefix', '/testapp');
+
+        // Create handler
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        // Process
+        $response = $this->appRouter->process($request, $handler);
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Cleanup
+        unlink($routesFile);
+        rmdir($tempDir . '/config');
+        rmdir($tempDir);
+    }
+
+    /**
+     * Test route matching with default middleware stack
+     */
+    public function testRouteWithDefaultMiddlewareStack(): void
+    {
+        // Create temporary routes file
+        $tempDir = sys_get_temp_dir() . '/horde-test-' . uniqid();
+        mkdir($tempDir);
+        mkdir($tempDir . '/config');
+        $routesFile = $tempDir . '/config/routes.php';
+
+        // Route without explicit stack = default stack
+        file_put_contents($routesFile, <<<'PHP'
+<?php
+$mapper->connect('default-stack', '/default', ['controller' => 'DefaultController']);
+PHP
+        );
+
+        $this->registry->method('get')
+            ->with('fileroot', 'testapp')
+            ->willReturn($tempDir);
+
+        $this->registry->method('pushApp');
+
+        // Setup injector to provide default middlewares
+        $this->injector->method('get')
+            ->willReturnCallback(function ($key) {
+                if ($key === ResponseFactoryInterface::class) {
+                    return $this->responseFactory;
+                }
+                if ($key === StreamFactoryInterface::class) {
+                    return $this->streamFactory;
+                }
+                if ($key === AuthHordeSession::class) {
+                    return $this->createTestMiddleware('AuthHordeSession');
+                }
+                if ($key === RedirectToLogin::class) {
+                    return $this->createTestMiddleware('RedirectToLogin');
+                }
+                throw new \Exception("Injector: Unknown key: $key");
+            });
+
+        // Mock controller that tracks middleware execution
+        $mockController = $this->createMock(RequestHandlerInterface::class);
+        $mockController->method('handle')
+            ->willReturnCallback(function ($request) {
+                $middlewares = $request->getAttribute('middlewares_executed', []);
+                // Verify default middlewares ran
+                $this->assertContains('AuthHordeSession', $middlewares);
+                $this->assertContains('RedirectToLogin', $middlewares);
+                return $this->responseFactory->createResponse(200);
+            });
+
+        $this->injector->method('getInstance')
+            ->with('DefaultController')
+            ->willReturn($mockController);
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/default')
+            ->withAttribute('app', 'testapp')
+            ->withAttribute('routerPrefix', '/testapp');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $response = $this->appRouter->process($request, $handler);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Cleanup
+        unlink($routesFile);
+        rmdir($tempDir . '/config');
+        rmdir($tempDir);
+    }
+
+    /**
+     * Test route with empty stack (bypasses HordeCore default middleware)
+     */
+    public function testRouteWithEmptyStackBypassesDefaultMiddleware(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/horde-test-' . uniqid();
+        mkdir($tempDir);
+        mkdir($tempDir . '/config');
+        $routesFile = $tempDir . '/config/routes.php';
+
+        // Explicit empty stack = NO middleware
+        file_put_contents($routesFile, <<<'PHP'
+<?php
+$mapper->connect('no-middleware', '/public', [
+    'controller' => 'PublicController',
+    'stack' => []
+]);
+PHP
+        );
+
+        $this->registry->method('get')
+            ->with('fileroot', 'testapp')
+            ->willReturn($tempDir);
+
+        $this->registry->method('pushApp');
+
+        // Setup injector to NOT provide middlewares for empty stack test
+        // The injector should only be called for controllers, not middlewares when stack is empty
+        $this->injector->method('get')
+            ->willReturnCallback(function ($key) {
+                if ($key === ResponseFactoryInterface::class) {
+                    return $this->responseFactory;
+                }
+                if ($key === StreamFactoryInterface::class) {
+                    return $this->streamFactory;
+                }
+                // If middlewares are requested, something is wrong with empty stack
+                if ($key === AuthHordeSession::class || $key === RedirectToLogin::class) {
+                    $this->fail("Middleware {$key} should not be requested with empty stack");
+                }
+                throw new \Exception("Injector: Unknown key: $key");
+            });
+        $mockController = $this->createMock(RequestHandlerInterface::class);
+        $mockController->method('handle')
+            ->willReturnCallback(function ($request) {
+                $middlewares = $request->getAttribute('middlewares_executed', []);
+                // Empty stack = no default middlewares
+                $this->assertEmpty($middlewares, 'No middlewares should execute with empty stack');
+                return $this->responseFactory->createResponse(200);
+            });
+
+        $this->injector->method('getInstance')
+            ->with('PublicController')
+            ->willReturn($mockController);
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/public')
+            ->withAttribute('app', 'testapp')
+            ->withAttribute('routerPrefix', '/testapp');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $response = $this->appRouter->process($request, $handler);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Cleanup
+        unlink($routesFile);
+        rmdir($tempDir . '/config');
+        rmdir($tempDir);
+    }
+
+    /**
+     * Test route with HordeAuthType=NONE (legacy way to bypass middleware)
+     */
+    public function testRouteWithHordeAuthTypeNoneBypassesMiddleware(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/horde-test-' . uniqid();
+        mkdir($tempDir);
+        mkdir($tempDir . '/config');
+        $routesFile = $tempDir . '/config/routes.php';
+
+        // HordeAuthType=NONE implies empty stack
+        file_put_contents($routesFile, <<<'PHP'
+<?php
+$mapper->connect('auth-none', '/login', [
+    'controller' => 'LoginController',
+    'HordeAuthType' => 'NONE'
+]);
+PHP
+        );
+
+        $this->registry->method('get')
+            ->with('fileroot', 'testapp')
+            ->willReturn($tempDir);
+
+        $this->registry->method('pushApp');
+
+        // Setup injector - should NOT provide middlewares for HordeAuthType=NONE
+        $this->injector->method('get')
+            ->willReturnCallback(function ($key) {
+                if ($key === ResponseFactoryInterface::class) {
+                    return $this->responseFactory;
+                }
+                if ($key === StreamFactoryInterface::class) {
+                    return $this->streamFactory;
+                }
+                // Middlewares should not be requested
+                if ($key === AuthHordeSession::class || $key === RedirectToLogin::class) {
+                    $this->fail("Middleware {$key} should not be requested with HordeAuthType=NONE");
+                }
+                throw new \Exception("Injector: Unknown key: $key");
+            });
+
+        $mockController = $this->createMock(RequestHandlerInterface::class);
+        $mockController->method('handle')
+            ->willReturnCallback(function ($request) {
+                $middlewares = $request->getAttribute('middlewares_executed', []);
+                $this->assertEmpty($middlewares, 'HordeAuthType=NONE should bypass middlewares');
+                return $this->responseFactory->createResponse(200);
+            });
+
+        $this->injector->method('getInstance')
+            ->with('LoginController')
+            ->willReturn($mockController);
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/login')
+            ->withAttribute('app', 'testapp')
+            ->withAttribute('routerPrefix', '/testapp');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $response = $this->appRouter->process($request, $handler);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Cleanup
+        unlink($routesFile);
+        rmdir($tempDir . '/config');
+        rmdir($tempDir);
+    }
+
+    /**
+     * Test missing app attribute throws exception
+     */
+    public function testMissingAppAttributeThrowsException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Missing Attribute: 'app'");
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/test')
+            ->withAttribute('routerPrefix', '/test');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $this->appRouter->process($request, $handler);
+    }
+
+    /**
+     * Test missing routerPrefix attribute throws exception
+     */
+    public function testMissingRouterPrefixThrowsException(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Missing Attribute: 'routerPrefix'");
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/test')
+            ->withAttribute('app', 'testapp');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $this->appRouter->process($request, $handler);
+    }
+
+    /**
+     * Test route match is added as request attribute
+     */
+    public function testRouteMatchAddedAsAttribute(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/horde-test-' . uniqid();
+        mkdir($tempDir);
+        mkdir($tempDir . '/config');
+        $routesFile = $tempDir . '/config/routes.php';
+
+        file_put_contents($routesFile, <<<'PHP'
+<?php
+$mapper->connect('test-params', '/item/:id', [
+    'controller' => 'ItemController',
+    'stack' => []
+]);
+PHP
+        );
+
+        $this->registry->method('get')
+            ->with('fileroot', 'testapp')
+            ->willReturn($tempDir);
+
+        $this->registry->method('pushApp');
+
+        // Setup injector for empty stack test
+        $this->injector->method('get')
+            ->willReturnCallback(function ($key) {
+                if ($key === ResponseFactoryInterface::class) {
+                    return $this->responseFactory;
+                }
+                if ($key === StreamFactoryInterface::class) {
+                    return $this->streamFactory;
+                }
+                throw new \Exception("Injector: Unknown key: $key");
+            });
+
+        $mockController = $this->createMock(RequestHandlerInterface::class);
+        $mockController->method('handle')
+            ->willReturnCallback(function ($request) {
+                $route = $request->getAttribute('route');
+                $this->assertIsArray($route);
+                $this->assertEquals('123', $route['id']);
+                $this->assertEquals('ItemController', $route['controller']);
+                return $this->responseFactory->createResponse(200);
+            });
+
+        $this->injector->method('getInstance')
+            ->with('ItemController')
+            ->willReturn($mockController);
+
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/item/123')
+            ->withAttribute('app', 'testapp')
+            ->withAttribute('routerPrefix', '/testapp');
+
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            []
+        );
+
+        $response = $this->appRouter->process($request, $handler);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Cleanup
+        unlink($routesFile);
+        rmdir($tempDir . '/config');
+        rmdir($tempDir);
+    }
+}

--- a/test/Middleware/AppRouterTest.php
+++ b/test/Middleware/AppRouterTest.php
@@ -24,7 +24,7 @@ use Horde\Http\StreamFactory;
 use Horde\Test\TestCase;
 use Horde_Injector;
 use Horde_Registry;
-use Horde_Routes_Mapper;
+use Horde\Routes\Mapper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -53,7 +53,7 @@ class AppRouterTest extends TestCase
     private ResponseFactory $responseFactory;
     private StreamFactory $streamFactory;
     private Horde_Registry $registry;
-    private Horde_Routes_Mapper $router;
+    private Mapper $router;
     private Horde_Injector $injector;
     private AppRouter $appRouter;
     private RampageRequestHandler $handler;
@@ -68,7 +68,7 @@ class AppRouterTest extends TestCase
         $this->registry = $this->createMock(Horde_Registry::class);
 
         // Real router
-        $this->router = new Horde_Routes_Mapper();
+        $this->router = new Mapper();
 
         // Mock injector - configured per test
         $this->injector = $this->createMock(Horde_Injector::class);

--- a/test/NlsconfigTest.php
+++ b/test/NlsconfigTest.php
@@ -69,12 +69,14 @@ class NlsconfigTest extends TestCase
     }
 
     /**
-     * @dataProvider providerForTestGet
+     * @todo Implement test for accessing language/alias/charset data via __get()
      */
-    public function testGet($key, $expected)
+    public function testGet()
     {
-        $nls = new Horde_Registry_Nlsconfig();
-        $this->markTestIncomplete();
+        $this->markTestIncomplete(
+            'Test for Nlsconfig::__get() not yet implemented. ' .
+            'Should test accessing $nls->languages, $nls->aliases, and $nls->charsets.'
+        );
     }
 
     public function testValidLang()

--- a/test/RampageIntegrationTest.php
+++ b/test/RampageIntegrationTest.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+
+declare(strict_types=1);
+
+namespace Horde\Core\Test;
+
+use Horde\Core\Middleware\AppFinder;
+use Horde\Core\Middleware\AppRouter;
+use Horde\Core\Middleware\AuthHordeSession;
+use Horde\Core\Middleware\HordeCore;
+use Horde\Core\Middleware\RedirectToLogin;
+use Horde\Http\RequestFactory;
+use Horde\Http\ResponseFactory;
+use Horde\Http\Server\RampageRequestHandler;
+use Horde\Http\StreamFactory;
+use Horde\Http\UriFactory;
+use Horde\Test\TestCase;
+use Horde_Injector;
+use Horde_Registry;
+use Horde_Routes_Mapper;
+use PHPUnit\Framework\Attributes\Group;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Semi-integration tests for Rampage request handling
+ *
+ * These tests exercise the full request handling pipeline:
+ * URI -> AppFinder -> AppRouter -> Middleware Stack -> Controller
+ *
+ * Tests two scenarios:
+ * a) Using default HordeCore middleware (authentication required)
+ * b) Bypassing HordeCore middleware (public endpoints)
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ * @category Horde
+ * @package  Core
+ */
+#[Group('integration')]
+class RampageIntegrationTest extends TestCase
+{
+    private RequestFactory $requestFactory;
+    private ResponseFactory $responseFactory;
+    private StreamFactory $streamFactory;
+    private UriFactory $uriFactory;
+    private string $tempAppDir;
+
+    protected function setUp(): void
+    {
+        $this->requestFactory = new RequestFactory();
+        $this->responseFactory = new ResponseFactory();
+        $this->streamFactory = new StreamFactory();
+        $this->uriFactory = new UriFactory();
+
+        // Create temporary app directory structure
+        $this->tempAppDir = sys_get_temp_dir() . '/horde-rampage-test-' . uniqid();
+        mkdir($this->tempAppDir);
+        mkdir($this->tempAppDir . '/config');
+    }
+
+    protected function tearDown(): void
+    {
+        // Cleanup temp directory
+        if (is_dir($this->tempAppDir)) {
+            if (file_exists($this->tempAppDir . '/config/routes.php')) {
+                unlink($this->tempAppDir . '/config/routes.php');
+            }
+            if (file_exists($this->tempAppDir . '/config/routes.local.php')) {
+                unlink($this->tempAppDir . '/config/routes.local.php');
+            }
+            rmdir($this->tempAppDir . '/config');
+            rmdir($this->tempAppDir);
+        }
+    }
+
+    /**
+     * Test full request handling WITH default HordeCore middleware
+     *
+     * Scenario: Protected endpoint requiring authentication
+     * URI: /testapp/api/protected
+     * Expected: Default middleware stack (AuthHordeSession, RedirectToLogin) runs
+     */
+    public function testFullRequestWithDefaultMiddleware(): void
+    {
+        // Create routes file with default middleware
+        file_put_contents($this->tempAppDir . '/config/routes.php', <<<'PHP'
+<?php
+// Route without explicit stack = uses default middleware
+$mapper->connect('protected-api', '/api/protected', [
+    'controller' => 'ProtectedApiController'
+]);
+PHP
+        );
+
+        // Mock registry
+        $registry = $this->createMock(Horde_Registry::class);
+        $registry->method('get')
+            ->willReturnCallback(function ($key, $app) {
+                if ($key === 'fileroot' && $app === 'testapp') {
+                    return $this->tempAppDir;
+                }
+                if ($key === 'webroot' && $app === 'testapp') {
+                    return '/testapp';
+                }
+                return null;
+            });
+
+        $registry->method('pushApp')
+            ->with('testapp');
+
+        // Mock injector
+        $injector = $this->createMock(Horde_Injector::class);
+
+        // Track middleware execution
+        $middlewaresExecuted = [];
+
+        // Mock middleware instances
+        $authMiddleware = $this->createTrackingMiddleware('AuthHordeSession', $middlewaresExecuted);
+        $redirectMiddleware = $this->createTrackingMiddleware('RedirectToLogin', $middlewaresExecuted);
+
+        // Mock controller
+        $controller = $this->createMock(RequestHandlerInterface::class);
+        $controller->method('handle')
+            ->willReturnCallback(function ($request) use (&$middlewaresExecuted) {
+                // Verify middlewares ran BEFORE controller
+                $this->assertContains('AuthHordeSession', $middlewaresExecuted);
+                $this->assertContains('RedirectToLogin', $middlewaresExecuted);
+
+                $body = $this->streamFactory->createStream(json_encode([
+                    'status' => 'success',
+                    'data' => 'Protected data',
+                    'middlewares' => $middlewaresExecuted
+                ]));
+
+                return $this->responseFactory->createResponse(200)
+                    ->withBody($body)
+                    ->withHeader('Content-Type', 'application/json');
+            });
+
+        // Setup injector behavior
+        $injector->method('get')
+            ->willReturnCallback(function ($key) use ($authMiddleware, $redirectMiddleware) {
+                return match ($key) {
+                    ResponseFactoryInterface::class => $this->responseFactory,
+                    StreamFactoryInterface::class => $this->streamFactory,
+                    AuthHordeSession::class => $authMiddleware,
+                    RedirectToLogin::class => $redirectMiddleware,
+                    default => throw new \Exception("Injector: Unknown key: $key")
+                };
+            });
+
+        $injector->method('getInstance')
+            ->with('ProtectedApiController')
+            ->willReturn($controller);
+
+        // Create router
+        $router = new Horde_Routes_Mapper();
+
+        // Create AppRouter
+        $appRouter = new AppRouter($registry, $router, $injector);
+
+        // Create AppFinder
+        $appFinder = new AppFinder($registry, $this->responseFactory, $this->streamFactory);
+
+        // Build full middleware stack
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            [$appFinder, $appRouter]
+        );
+
+        // Create request
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/api/protected');
+
+        // Execute
+        $response = $handler->handle($request);
+
+        // Verify
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true);
+
+        $this->assertEquals('success', $data['status']);
+        $this->assertEquals('Protected data', $data['data']);
+        $this->assertContains('AuthHordeSession', $data['middlewares']);
+        $this->assertContains('RedirectToLogin', $data['middlewares']);
+    }
+
+    /**
+     * Test full request handling WITHOUT HordeCore middleware (bypassing)
+     *
+     * Scenario: Public endpoint with empty stack
+     * URI: /testapp/api/public
+     * Expected: NO default middleware runs, direct to controller
+     */
+    public function testFullRequestBypassingDefaultMiddleware(): void
+    {
+        // Create routes file with empty stack
+        file_put_contents($this->tempAppDir . '/config/routes.php', <<<'PHP'
+<?php
+// Route with empty stack = NO default middleware
+$mapper->connect('public-api', '/api/public', [
+    'controller' => 'PublicApiController',
+    'stack' => []  // Explicitly bypass default middleware
+]);
+PHP
+        );
+
+        // Mock registry
+        $registry = $this->createMock(Horde_Registry::class);
+        $registry->method('get')
+            ->willReturnCallback(function ($key, $app) {
+                if ($key === 'fileroot' && $app === 'testapp') {
+                    return $this->tempAppDir;
+                }
+                if ($key === 'webroot' && $app === 'testapp') {
+                    return '/testapp';
+                }
+                return null;
+            });
+
+        $registry->method('pushApp')
+            ->with('testapp');
+
+        // Mock injector
+        $injector = $this->createMock(Horde_Injector::class);
+
+        // Track middleware execution
+        $middlewaresExecuted = [];
+
+        // Mock controller (NO middlewares should execute)
+        $controller = $this->createMock(RequestHandlerInterface::class);
+        $controller->method('handle')
+            ->willReturnCallback(function ($request) use (&$middlewaresExecuted) {
+                // Verify NO middlewares ran
+                $this->assertEmpty($middlewaresExecuted, 'No middlewares should execute with empty stack');
+
+                $body = $this->streamFactory->createStream(json_encode([
+                    'status' => 'success',
+                    'data' => 'Public data - no auth required',
+                    'middlewares' => $middlewaresExecuted
+                ]));
+
+                return $this->responseFactory->createResponse(200)
+                    ->withBody($body)
+                    ->withHeader('Content-Type', 'application/json');
+            });
+
+        // Setup injector behavior
+        $injector->method('get')
+            ->willReturnCallback(function ($key) {
+                return match ($key) {
+                    ResponseFactoryInterface::class => $this->responseFactory,
+                    StreamFactoryInterface::class => $this->streamFactory,
+                    default => throw new \Exception("Injector: Unknown key: $key")
+                };
+            });
+
+        $injector->method('getInstance')
+            ->with('PublicApiController')
+            ->willReturn($controller);
+
+        // Create router
+        $router = new Horde_Routes_Mapper();
+
+        // Create AppRouter
+        $appRouter = new AppRouter($registry, $router, $injector);
+
+        // Create AppFinder
+        $appFinder = new AppFinder($registry, $this->responseFactory, $this->streamFactory);
+
+        // Build full middleware stack
+        $handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            [$appFinder, $appRouter]
+        );
+
+        // Create request
+        $request = $this->requestFactory->createServerRequest('GET', 'http://example.com/testapp/api/public');
+
+        // Execute
+        $response = $handler->handle($request);
+
+        // Verify
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('application/json', $response->getHeaderLine('Content-Type'));
+
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true);
+
+        $this->assertEquals('success', $data['status']);
+        $this->assertEquals('Public data - no auth required', $data['data']);
+        $this->assertEmpty($data['middlewares'], 'Should bypass all default middlewares');
+    }
+
+    /**
+     * Helper: Create middleware that tracks execution
+     */
+    private function createTrackingMiddleware(string $name, array &$tracker): object
+    {
+        return new class($name, $tracker) implements \Psr\Http\Server\MiddlewareInterface {
+            public function __construct(
+                private string $name,
+                private array &$tracker
+            ) {
+            }
+
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ): ResponseInterface {
+                // Track that this middleware executed
+                $this->tracker[] = $this->name;
+
+                // Continue chain
+                return $handler->handle($request);
+            }
+        };
+    }
+}

--- a/test/SmartmobileUrlTest.php
+++ b/test/SmartmobileUrlTest.php
@@ -6,7 +6,6 @@ use Horde\Test\TestCase;
 
 use Horde_Core_Smartmobile_Url as SmartmobileUrl;
 use Horde_Url;
-use InvalidArgumentException;
 
 /**
  * @author     Jan Schneider <jan@horde.org>
@@ -17,10 +16,12 @@ use InvalidArgumentException;
  */
 class SmartmobileUrlTest extends TestCase
 {
-    public function testInvalidParamter()
+    public function testStringParameter()
     {
-        $this->expectException(InvalidArgumentException::class);
-        new SmartmobileUrl('test');
+        // String parameters now work for convenience (no need to wrap in Horde_Url)
+        $url = new SmartmobileUrl('test');
+        $url->add(['foo' => 1, 'bar' => 2]);
+        $this->assertEquals('test?foo=1&amp;bar=2', (string)$url);
     }
 
     public function testWithoutAnchor()


### PR DESCRIPTION
We only want one place to configure the logger and it should work for both the legacy Horde_Log and the PSR-3 logger 


- **feat: Move logger configuration to a single place for both PSR-3 and traditional logger. Allows step by step migration without breaking changes.**
- **fix(smartmobile): use clone instead of copy() to preserve base URL**
- **refactor(smartmobile): extend modern Horde\Url\Url directly**
- **feat(smartmobile): accept string URLs for convenience**
- **fix(config): allow empty config array in State constructor**
- **test(rampage): add routing unit and integration tests**
- **refactor(routes): migrate to modern PSR-4 Horde\Routes\Mapper**
- **fix composer.json plugin settings**
