### PR TITLE
Update Activesync driver

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -53,6 +53,13 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     protected $_modCache;
 
     /**
+     * Local cache of mail folders polled from IMAP.
+     *
+     * @var array|null
+     */
+    protected $_mailFolders = null;
+
+    /**
      * Horde connector instance
      *
      * @var Horde_Core_ActiveSync_Connector
@@ -93,6 +100,13 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      * @var array
      */
     protected $_verbs = [];
+
+    /**
+     * Cache object for storing search results etc.
+     *
+     * @var Horde_Cache
+     */
+    protected $_cache;
 
     /**
      * Class => Id map

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -143,34 +143,45 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      */
     public function __construct(array $params = [])
     {
-        parent::__construct($params);
-        if (empty($this->_params['connector']) ||
-            !($this->_params['connector'] instanceof Horde_Core_ActiveSync_Connector)) {
+        $connector = self::extractArrayValue($params, 'connector');
+        if ($connector instanceof Horde_Core_ActiveSync_Connector) {
+            $this->_connector = $connector;
+        } else {
             throw new InvalidArgumentException('Missing required connector object.');
         }
 
-        if (empty($this->_params['auth']) ||
-            !($this->_params['auth'] instanceof Horde_Auth_Base)) {
+        $auth = self::extractArrayValue($params, 'auth');
+        if ($auth instanceof Horde_Auth_Base) {
+            $this->_auth = $auth;
+        } else {
             throw new InvalidArgumentException('Missing required Auth object');
         }
 
-        $this->_connector = $params['connector'];
-        $this->_auth = $params['auth'];
-        unset($this->_params['connector']);
-        unset($this->_params['auth']);
-        if (!empty($this->_params['imap'])) {
-            $this->_imap = $this->_params['imap'];
-            unset($this->_params['imap']);
-        }
-        $this->_cache = $this->_params['cache'] ?? null;
+        $this->_imap = self::extractArrayValue($params, 'imap');
 
-        // Build the displaymap
+        $this->_cache = self::extractArrayValue($params, 'cache');
+
+        // Build the displaymap (@todo: make it static)
         $this->_displayMap = [
             self::APPOINTMENTS_FOLDER_UID => Horde_ActiveSync_Translation::t('Calendar'),
             self::CONTACTS_FOLDER_UID     => Horde_ActiveSync_Translation::t('Contacts'),
             self::TASKS_FOLDER_UID        => Horde_ActiveSync_Translation::t('Tasks'),
             self::NOTES_FOLDER_UID        => Horde_ActiveSync_Translation::t('Notes'),
         ];
+
+        parent::__construct($params);
+    }
+
+    private static function extractArrayValue(array &$array, string $key)
+    {
+        if (isset($array[$key])) {
+            $value = $array[$key];
+            unset($array[$key]);
+        } else {
+            $value = null;
+        }
+
+        return $value;
     }
 
     /**

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3433,13 +3433,13 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
       */
     protected function _getMailFolders()
     {
-        if (empty($this->_mailFolders)) {
+        if ($this->_mailFolders === null) {
             if (empty($this->_imap)) {
-                $this->_mailFolders = [$this->_buildDummyFolder(self::SPECIAL_INBOX)];
-                $this->_mailFolders[] = $this->_buildDummyFolder(self::SPECIAL_TRASH);
-                $this->_mailFolders[] = $this->_buildDummyFolder(self::SPECIAL_SENT);
-                $this->_mailFolders[] = $this->_buildDummyFolder(self::SPECIAL_DRAFTS);
-                $this->_mailFolders[] = $this->_buildDummyFolder(self::SPECIAL_OUTBOX);
+                $folders = [];
+                $folders[] = $this->_buildDummyFolder(self::SPECIAL_INBOX);
+                $folders[] = $this->_buildDummyFolder(self::SPECIAL_TRASH);
+                $folders[] = $this->_buildDummyFolder(self::SPECIAL_SENT);
+                $folders[] = $this->_buildDummyFolder(self::SPECIAL_DRAFTS);
             } else {
                 $this->_logger->meta('Polling Horde_Core_ActiveSync_Driver::_getMailFolders()');
                 $folders = [];
@@ -3466,23 +3466,18 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                                 $folders[] = $this->_getMailFolder((string)$id, $imap_folders, $folder);
                                 ++$cnt;
                             } catch (Horde_ActiveSync_Exception $e) {
-                                $this->_logger->err(
-                                    sprintf(
-                                        'Problem retrieving %s mail folder',
-                                        $id
-                                    )
-                                );
+                                $this->_logger->err(sprintf('Problem retrieving %s mail folder', $id));
                             }
                         }
                     }
                     ++$level;
                 }
-
-                // Fake Outbox for broken clients.
-                $folders[] = $this->_buildDummyFolder(self::SPECIAL_OUTBOX);
-
-                $this->_mailFolders = $folders;
             }
+
+            // Fake Outbox for broken clients.
+            $folders[] = $this->_buildDummyFolder(self::SPECIAL_OUTBOX);
+
+            $this->_mailFolders = $folders;
         }
 
         return $this->_mailFolders;

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -2338,7 +2338,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
         if ($forward || $reply) {
             $source = $message->source;
             if ($source->longid) {
-                [$folderid, $itemid] = explode(':', $source, 2);
+                [$folderid, $itemid] = explode(':', $source->longid, 2);
             } elseif ($forward === true || $reply === true) {
                 $folderid = $source->folderid;
                 $itemid = $source->itemid;


### PR DESCRIPTION
 Minor fixes and refactoring

- add deprecated dynamic properties $_cache and $_mailFolders (PHP 8.2)
- explode() called on object instead of string in sendMail()
- extract connector, auth, imap and cache from $params before calling parent::__construct(), consolidating the repeated extract-and-unset pattern into a private helper method.
-  Use strict null comparison for $_mailFolders cache check, build folders into a local variable before assigning, simplify the code.
