### PR TITLE
fix/null safety builtins

### DIFF
--- a/lib/Horde.php
+++ b/lib/Horde.php
@@ -16,6 +16,9 @@
 /**
  * Provides the base functionality shared by all Horde applications.
  *
+ * Methods in this class delegate to the namespaced {@see Horde\Core\Horde}
+ * wherever possible.  Callers should migrate to the namespaced class directly.
+ *
  * @author   Chuck Hagenbuch <chuck@horde.org>
  * @author   Jon Parise <jon@horde.org>
  * @category Horde
@@ -28,40 +31,8 @@ class Horde
     public const SSL_ALWAYS       = 1;
     public const SSL_AUTO         = 2;
     public const SSL_ONLY_LOGIN   = 3;
-    /**
-     * The current buffer level.
-     *
-     * @var integer
-     */
-    protected static $_bufferLevel = 0;
-
-    /**
-     * Has content been sent at the base buffer level?
-     *
-     * @var boolean
-     */
-    protected static $_contentSent = false;
-
-    /**
-     * The labels already used in this page.
-     *
-     * @var array
-     */
-    protected static $_labels = [];
-
-    /**
-     * Are accesskeys supported on this system.
-     *
-     * @var boolean
-     */
-    protected static $_noAccessKey;
-
-    /**
-     * The access keys already used in this page.
-     *
-     * @var array
-     */
-    protected static $_used = [];
+    // Static state ($_bufferLevel, $_contentSent, $_labels,
+    // $_noAccessKey, $_used) lives in \Horde\Core\Horde.
 
     /**
      * Shortcut to logging method.
@@ -209,6 +180,8 @@ class Horde
     /**
      * Verifies a signature and timestamp on a URL.
      *
+     * @deprecated Use {@see Horde\Core\Horde::verifySignedUrl()} instead.
+     *
      * @since Horde_Core 2.30.0
      *
      * @param string $data  The signed URL.
@@ -219,49 +192,17 @@ class Horde
      */
     public static function verifySignedUrl($data, $now = null)
     {
-        global $conf;
-
-        if (is_null($now)) {
-            $now = time();
-        }
-
         if (!is_string($data)) {
             return false;
         }
-
-        $pos = strrpos($data, '&_h=');
-        if ($pos === false) {
-            return false;
-        }
-        $pos += 4;
-
-        $url = substr($data, 0, $pos);
-        $hmac = substr($data, $pos);
-
-        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $url, $conf['secret_key'], true))) {
-            return false;
-        }
-
-        // String was not tampered with; now validate timestamp
-        parse_str(parse_url($url, PHP_URL_QUERY), $values);
-        if ($values['_t'] + $conf['urls']['hmac_lifetime'] * 60 < $now) {
-            return false;
-        }
-
-        $pos = strrpos($data, '&_t=');
-        if ($pos === false) {
-            $pos = strrpos($data, '?_t=');
-        }
-        if ($pos === false) {
-            return false;
-        }
-
-        return substr($data, 0, $pos);
+        return Horde\Core\Horde::verifySignedUrl($data, $now);
     }
 
     /**
      * Adds a signature + timestamp to a query string and returns the signed
      * query string.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::signQueryString()} instead.
      *
      * @param mixed $queryString  The query string (or Horde_Url object)
      *                            to sign.
@@ -273,28 +214,13 @@ class Horde
      */
     public static function signQueryString($queryString, $now = null)
     {
-        if (!isset($GLOBALS['conf']['secret_key'])) {
-            return $queryString;
-        }
-
-        if (is_null($now)) {
-            $now = time();
-        }
-
-        if ($queryString instanceof Horde_Url) {
-            $queryString->setRaw(true)->add(['_t' => $now, '_h' => '']);
-            $query = parse_url($queryString, PHP_URL_QUERY);
-            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query . '=', $GLOBALS['conf']['secret_key'], true)));
-            return $queryString;
-        }
-
-        $queryString .= '&_t=' . $now . '&_h=';
-
-        return $queryString . Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true));
+        return Horde\Core\Horde::signQueryString($queryString, $now);
     }
 
     /**
      * Verifies a signature and timestamp on a query string.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::verifySignedQueryString()} instead.
      *
      * @param string $data  The signed query string.
      * @param integer $now  The current time (can override for testing).
@@ -303,31 +229,13 @@ class Horde
      */
     public static function verifySignedQueryString($data, $now = null)
     {
-        if (is_null($now)) {
-            $now = time();
-        }
-
-        $pos = strrpos($data, '&_h=');
-        if ($pos === false) {
-            return false;
-        }
-        $pos += 4;
-
-        $queryString = substr($data, 0, $pos);
-        $hmac = substr($data, $pos);
-
-        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true))) {
-            return false;
-        }
-
-        // String was not tampered with; now validate timestamp
-        parse_str($queryString, $values);
-
-        return !($values['_t'] + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 < $now);
+        return Horde\Core\Horde::verifySignedQueryString($data, $now);
     }
 
     /**
      * Do necessary escaping to output JSON.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::escapeJson()} instead.
      *
      * @param mixed $data     The data to JSON-ify.
      * @param array $options  Additional options:
@@ -340,68 +248,38 @@ class Horde
      */
     public static function escapeJson($data, array $options = [])
     {
-        $json = Horde_Serialize::serialize($data, Horde_Serialize::JSON);
-        if (empty($options['nodelimit'])) {
-            $json = '/*-secure-' . $json . '*/';
-        }
-
-        return empty($options['urlencode'])
-            ? $json
-            : '\'' . rawurlencode($json) . '\'';
+        return Horde\Core\Horde::escapeJson($data, $options);
     }
 
     /**
      * Is the current HTTP connection considered secure?
      * @TODO Move this to the request classes!
      *
+     * @deprecated Use {@see Horde\Core\Horde::isConnectionSecure()} instead.
+     *
      * @return boolean
      */
     public static function isConnectionSecure()
     {
-        global $browser, $conf, $registry;
-
-        if ($browser->usingSSLConnection()) {
-            return true;
-        }
-
-        if (!empty($conf['safe_ips'])) {
-            if (reset($conf['safe_ips']) == '*') {
-                return true;
-            }
-
-            /* $_SERVER['HTTP_X_FORWARDED_FOR'] is user data and not
-             * reliable. We don't consult it for safe IPs. We also have to
-             * assume that if it is present, the user is coming through a proxy
-             * server. If so, we don't count any non-SSL connection as safe, no
-             * matter the source IP. */
-            $remote = $registry->remoteHost();
-            if (!$remote->proxy) {
-                foreach ($conf['safe_ips'] as $safe_ip) {
-                    $safe_ip = preg_replace('/(\.0)*$/', '', $safe_ip);
-                    if (strpos($remote->addr, $safe_ip) === 0) {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
+        return Horde\Core\Horde::isConnectionSecure();
     }
 
     /**
      * Throws an exception if not using a secure connection.
      *
+     * @deprecated Use {@see Horde\Core\Horde::requireSecureConnection()} instead.
+     *
      * @throws Horde_Exception
      */
     public static function requireSecureConnection()
     {
-        if (!self::isConnectionSecure()) {
-            throw new Horde_Exception(Horde_Core_Translation::t('The encryption features require a secure web connection.'));
-        }
+        Horde\Core\Horde::requireSecureConnection();
     }
 
     /**
      * Returns the driver parameters for the specified backend.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::getDriverConfig()} instead.
      *
      * @param mixed $backend  The backend system (e.g. 'prefs', 'categories',
      *                        'contacts') being used.
@@ -415,53 +293,15 @@ class Horde
      */
     public static function getDriverConfig($backend, $type = 'sql')
     {
-        global $conf;
-
-        if (!is_null($type)) {
-            $type = Horde_String::lower($type);
-        }
-
-        if (is_array($backend)) {
-            $c = Horde_Array::getElement($conf, $backend);
-        } elseif (isset($conf[$backend])) {
-            $c = $conf[$backend];
-        } else {
-            $c = null;
-        }
-
-        if (!is_null($c) && isset($c['params'])) {
-            $c['params']['umask'] = $conf['umask'];
-
-            $result = (!is_null($type) && isset($conf[$type]))
-                ? array_merge($conf[$type], $c['params'])
-                : $c['params'];
-
-            // HOTFIX for Bug #14547. If using different protocols for the
-            // base SQL config and the explicit driver we are creating, we
-            // need to remove the not-used connection config since they use
-            // different keys.
-            if ((!isset($c['params']['driverconfig'])
-                 || $c['params']['driverconfig'] != 'horde')
-                && !is_null($type) && $type == 'sql') {
-                if (($c['params']['protocol'] ?? null) == 'unix') {
-                    unset($result['hostspec'], $result['port']);
-                } else {
-                    unset($result['socket']);
-                }
-            }
-
-            return $result;
-        }
-
-        return (!is_null($type) && isset($conf[$type]))
-            ? $conf[$type]
-            : [];
+        return Horde\Core\Horde::getDriverConfig($backend, $type);
     }
 
     /**
      * Checks if all necessary parameters for a driver configuration
      * are set and throws a fatal error with a detailed explanation
      * how to fix this, if something is missing.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::assertDriverConfig()} instead.
      *
      * @param array $params     The configuration array with all parameters.
      * @param string $driver    The key name (in the configuration array) of
@@ -484,38 +324,14 @@ class Horde
         $file = 'conf.php',
         $variable = '$conf'
     ) {
-        global $registry;
-
-        // Don't generate a fatal error if we fail during or before
-        // Registry instantiation.
-        if (is_null($name)) {
-            $name = isset($registry) ? $registry->getApp() : '[unknown]';
-        }
-        $fileroot = isset($registry) ? $registry->get('fileroot') : '';
-
-        if (!is_array($params) || !count($params)) {
-            throw new Horde_Exception(
-                sprintf(Horde_Core_Translation::t('No configuration information specified for %s.'), $name) . "\n\n"
-                . sprintf(
-                    Horde_Core_Translation::t('The file %s should contain some %s settings.'),
-                    $fileroot . '/config/' . $file,
-                    sprintf("%s['%s']['params']", $variable, $driver)
-                )
-            );
-        }
-
-        foreach ($fields as $field) {
-            if (!isset($params[$field])) {
-                throw new Horde_Exception(
-                    sprintf(Horde_Core_Translation::t('Required "%s" not specified in %s configuration.'), $field, $name) . "\n\n"
-                    . sprintf(
-                        Horde_Core_Translation::t('The file %s should contain a %s setting.'),
-                        $fileroot . '/config/' . $file,
-                        sprintf("%s['%s']['params']['%s']", $variable, $driver, $field)
-                    )
-                );
-            }
-        }
+        Horde\Core\Horde::assertDriverConfig(
+            is_array($params) ? $params : [],
+            $driver,
+            $fields,
+            $name,
+            $file,
+            $variable,
+        );
     }
 
     /**
@@ -663,6 +479,8 @@ class Horde
      * Returns an external link passed through the dereferrer to strip session
      * IDs from the referrer.
      *
+     * @deprecated Use {@see Horde\Core\Horde::externalUrl()} instead.
+     *
      * @param string $url   The external URL to link to.
      * @param boolean $tag  If true, a complete <a> tag is returned, only the
      *                      url otherwise.
@@ -671,23 +489,13 @@ class Horde
      */
     public static function externalUrl($url, $tag = false)
     {
-        if (!isset($_GET[session_name()])
-            || Horde_String::substr($url, 0, 1) == '#'
-            || Horde_String::substr($url, 0, 7) == 'mailto:') {
-            $ext = $url;
-        } else {
-            $ext = self::signQueryString($GLOBALS['registry']->getServiceLink('go', 'horde')->add('url', $url));
-        }
-
-        if ($tag) {
-            $ext = self::link($ext, $url, '', '_blank');
-        }
-
-        return $ext;
+        return Horde\Core\Horde::externalUrl($url, $tag);
     }
 
     /**
      * Returns an anchor tag with the relevant parameters
+     *
+     * @deprecated Use {@see Horde\Core\Horde::link()} instead.
      *
      * @param Horde_Url|string $url  The full URL to be linked to.
      * @param string $title          The link title/description.
@@ -715,43 +523,25 @@ class Horde
         $attributes = [],
         $escape = true
     ) {
-        if (!($url instanceof Horde_Url)) {
-            $url = new Horde_Url($url);
-        }
-
         if (!empty($title2)) {
             $title = $title2;
         }
-        if (!empty($onclick)) {
-            $attributes['onclick'] = $onclick;
-        }
-        if (!empty($class)) {
-            $attributes['class'] = $class;
-        }
-        if (!empty($target)) {
-            $attributes['target'] = $target;
-        }
-        if (!empty($accesskey)) {
-            $attributes['accesskey'] = $accesskey;
-        }
-        if (!empty($title)) {
-            if ($escape) {
-                $title = str_replace(
-                    ["\r", "\n"],
-                    '',
-                    htmlspecialchars(nl2br(htmlspecialchars($title)))
-                );
-                /* Remove double encoded entities. */
-                $title = preg_replace('/&amp;([a-z]+|(#\d+));/i', '&\\1;', $title);
-            }
-            $attributes['title.raw'] = $title;
-        }
-
-        return $url->link($attributes);
+        return Horde\Core\Horde::link(
+            $url,
+            $title,
+            $class,
+            $target,
+            $onclick,
+            $accesskey,
+            $attributes,
+            $escape,
+        );
     }
 
     /**
      * Uses DOM Tooltips to display the 'title' attribute for link() calls.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::linkTooltip()} instead.
      *
      * @param string $url        The full URL to be linked to
      * @param string $status     The JavaScript mouse-over string
@@ -777,35 +567,23 @@ class Horde
         $accesskey = '',
         $attributes = []
     ) {
-        if (strlen($title)) {
-            $attributes['nicetitle'] = Horde_Serialize::serialize(
-                preg_split(
-                    '/\r?\n/',
-                    preg_replace('/<br\s*\/?\s*>/', "\n", $title)
-                ),
-                Horde_Serialize::JSON
-            );
-            $title = null;
-            $GLOBALS['injector']->getInstance('Horde_PageOutput')
-                ->addScriptFile('tooltips.js', 'horde');
-        }
-
-        return self::link(
+        return Horde\Core\Horde::linkTooltip(
             $url,
-            $title,
+            $status,
             $class,
             $target,
             $onclick,
-            null,
+            $title,
             $accesskey,
             $attributes,
-            false
         );
     }
 
     /**
      * Returns an anchor sequence with the relevant parameters for a widget
      * with accesskey and text.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::widget()} instead.
      *
      * @param array $params  A hash with widget options (other options will be
      *                       passed as attributes to the link tag):
@@ -819,26 +597,7 @@ class Horde
      */
     public static function widget($params)
     {
-        $params = array_merge(
-            [
-                'class' => '',
-                'target' => '',
-                'onclick' => '',
-                'nocheck' => false],
-            $params
-        );
-
-        $url = ($params['url'] instanceof Horde_Url)
-            ? $params['url']
-            : new Horde_Url($params['url']);
-        $title = $params['title'];
-        $params['accesskey'] = self::getAccessKey($title, $params['nocheck']);
-
-        unset($params['url'], $params['title'], $params['nocheck']);
-
-        return $url->link($params)
-            . self::highlightAccessKey($title, $params['accesskey'])
-            . '</a>';
+        return Horde\Core\Horde::widget($params);
     }
 
     /**
@@ -939,33 +698,21 @@ class Horde
      * Determines the location of the system temporary directory. If a specific
      * configuration cannot be found, it defaults to /tmp.
      *
+     * @deprecated Use {@see Horde\Core\Horde::getTempDir()} instead.
+     *
      * @return string  A directory name that can be used for temp files.
      *                 Returns false if one could not be found.
      */
     public static function getTempDir()
     {
-        global $conf;
-
-        /* If one has been specifically set, then use that */
-        if (!empty($conf['tmpdir'])) {
-            $tmp = $conf['tmpdir'];
-        }
-
-        /* Next, try sys_get_temp_dir(). */
-        if (empty($tmp)) {
-            $tmp = sys_get_temp_dir();
-        }
-
-        /* If it is still empty, we have failed, so return false;
-         * otherwise return the directory determined. */
-        return empty($tmp)
-            ? false
-            : $tmp;
+        return Horde\Core\Horde::getTempDir();
     }
 
     /**
      * Creates a temporary filename for the lifetime of the script, and
      * (optionally) registers it to be deleted at request shutdown.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::getTempFile()} instead.
      *
      * @param string $prefix           Prefix to make the temporary name more
      *                                 recognizable.
@@ -988,43 +735,33 @@ class Horde
         $secure = false,
         $session_remove = false
     ) {
-        if (empty($dir) || !is_dir($dir)) {
-            $dir = self::getTempDir();
-        }
-        $tmpfile = Horde_Util::getTempFile($prefix, $delete, $dir, $secure);
-        if ($session_remove) {
-            $gcfiles = $GLOBALS['session']->get('horde', 'gc_tempfiles', Horde_Session::TYPE_ARRAY);
-            $gcfiles[] = $tmpfile;
-            $GLOBALS['session']->set('horde', 'gc_tempfiles', $gcfiles);
-        }
-
-        return $tmpfile;
+        return Horde\Core\Horde::getTempFile(
+            $prefix,
+            $delete,
+            $dir,
+            $secure,
+            $session_remove,
+        );
     }
 
     /**
      * Returns the Web server being used.
      * PHP string list built from the PHP 'configure' script.
      *
+     * @deprecated Use {@see Horde\Core\Horde::webServerID()} instead.
+     *
      * @return string  A web server identification string.
      * @see php_sapi_name()
      */
     public static function webServerID()
     {
-        switch (PHP_SAPI) {
-            case 'apache':
-                return 'apache1';
-
-            case 'apache2filter':
-            case 'apache2handler':
-                return 'apache2';
-
-            default:
-                return PHP_SAPI;
-        }
+        return Horde\Core\Horde::webServerID();
     }
 
     /**
      * Returns an un-used access key from the label given.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::getAccessKey()} instead.
      *
      * @param string $label      The label to choose an access key from.
      * @param boolean $nocheck   Don't check if the access key already has been
@@ -1039,46 +776,7 @@ class Horde
         $nocheck = false,
         $shutdown = false
     ) {
-        /* Shutdown call for translators? */
-        if ($shutdown) {
-            if (!count(self::$_labels)) {
-                return;
-            }
-            $script = basename($_SERVER['PHP_SELF']);
-            $labels = array_keys(self::$_labels);
-            sort($labels);
-            $used = array_keys(self::$_used);
-            sort($used);
-            $remaining = str_replace($used, [], 'abcdefghijklmnopqrstuvwxyz');
-            self::log('Access key information for ' . $script);
-            self::log('Used labels: ' . implode(',', $labels));
-            self::log('Used keys: ' . implode('', $used));
-            self::log('Free keys: ' . $remaining);
-            return;
-        }
-
-        /* Use access keys at all? */
-        if (!isset(self::$_noAccessKey)) {
-            self::$_noAccessKey = !$GLOBALS['browser']->hasFeature('accesskey') || !$GLOBALS['prefs']->getValue('widget_accesskey');
-        }
-
-        if (self::$_noAccessKey
-            || !preg_match('/_(\w)/u', $label, $match)) {
-            return '';
-        }
-        $key = Horde_String_Transliterate::toAscii($match[1]);
-
-        /* Has this key already been used? */
-        if (isset(self::$_used[strtolower($key)])
-            && !($nocheck && isset(self::$_labels[$label]))) {
-            return '';
-        }
-
-        /* Save key and label. */
-        self::$_used[strtolower($key)] = true;
-        self::$_labels[$label] = true;
-
-        return $key;
+        return Horde\Core\Horde::getAccessKey($label, $nocheck, $shutdown);
     }
 
     /**
@@ -1087,21 +785,21 @@ class Horde
      * For multibyte charset strings the access key gets removed completely,
      * otherwise only the underscore gets removed.
      *
+     * @deprecated Use {@see Horde\Core\Horde::stripAccessKey()} instead.
+     *
      * @param string $label  The label containing an access key.
      *
      * @return string  The label with the access key being stripped.
      */
     public static function stripAccessKey($label)
     {
-        $replace = $GLOBALS['registry']->nlsconfig->curr_multibyte
-            && preg_match('/[\x80-\xff]/', $label)
-            ? ''
-            : '$1';
-        return preg_replace('/_(\w)/u', $replace, $label);
+        return Horde\Core\Horde::stripAccessKey($label);
     }
 
     /**
      * Highlights an access key in a label.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::highlightAccessKey()} instead.
      *
      * @param string $label      The label to highlight the access key in.
      * @param string $accessKey  The access key to highlight.
@@ -1111,30 +809,14 @@ class Horde
      */
     public static function highlightAccessKey($label, $accessKey)
     {
-        $stripped_label = self::stripAccessKey($label);
-
-        if (empty($accessKey)) {
-            return $stripped_label;
-        }
-
-        if ($GLOBALS['registry']->nlsconfig->curr_multibyte) {
-            /* Prefix parenthesis with the UTF-8 representation of the LRO
-             * (Left-to-Right-Override) Unicode codepoint U+202D. */
-            return $stripped_label . "\xe2\x80\xad"
-                . '(<span class="accessKey">' . strtoupper($accessKey)
-                . '</span>' . ')';
-        }
-
-        return preg_replace(
-            '/_(\w)/u',
-            '<span class="accessKey">$1</span>',
-            $label
-        );
+        return Horde\Core\Horde::highlightAccessKey($label, $accessKey);
     }
 
     /**
      * Returns the appropriate "accesskey" and "title" attributes for an HTML
      * tag and the given label.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::getAccessKeyAndTitle()} instead.
      *
      * @param string $label          The title of an HTML element
      * @param boolean $nocheck       Don't check if the access key already has
@@ -1149,27 +831,18 @@ class Horde
         $nocheck = false,
         $return_array = false
     ) {
-        $ak = self::getAccessKey($label, $nocheck);
-        $attributes = ['title' => self::stripAccessKey($label)];
-        if (!empty($ak)) {
-            $attributes['title'] .= sprintf(Horde_Core_Translation::t(' (Accesskey %s)'), strtoupper($ak));
-            $attributes['accesskey'] = $ak;
-        }
-
-        if ($return_array) {
-            return $attributes;
-        }
-
-        $html = '';
-        foreach ($attributes as $attribute => $value) {
-            $html .= sprintf(' %s="%s"', $attribute, $value);
-        }
-        return $html;
+        return Horde\Core\Horde::getAccessKeyAndTitle(
+            $label,
+            $nocheck,
+            $return_array,
+        );
     }
 
     /**
      * Returns a label element including an access key for usage in conjuction
      * with a form field. User preferences regarding access keys are respected.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::label()} instead.
      *
      * @param string $for    The form field's id attribute.
      * @param string $label  The label text.
@@ -1180,22 +853,14 @@ class Horde
      */
     public static function label($for, $label, $ak = null)
     {
-        if (is_null($ak)) {
-            $ak = self::getAccessKey($label, 1);
-        }
-        $label = self::highlightAccessKey($label, $ak);
-
-        return sprintf(
-            '<label for="%s"%s>%s</label>',
-            $for,
-            !empty($ak) ? ' accesskey="' . $ak . '"' : '',
-            $label
-        );
+        return Horde\Core\Horde::label($for, $label, $ak);
     }
 
     /**
      * Print inline javascript to output buffer after wrapping with necessary
      * javascript tags.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::wrapInlineScript()} instead.
      *
      * @param array $script  The script to output.
      *
@@ -1204,7 +869,7 @@ class Horde
      */
     public static function wrapInlineScript($script)
     {
-        return '<script type="text/javascript">//<![CDATA[' . "\n" . implode('', $script) . "\n//]]></script>\n";
+        return Horde\Core\Horde::wrapInlineScript($script);
     }
 
     /**
@@ -1240,6 +905,8 @@ class Horde
     /**
      * Output the javascript needed to call the popup JS function.
      *
+     * @deprecated Use {@see Horde\Core\Horde::popupJs()} instead.
+     *
      * @param string|Horde_Url $url  The page to load.
      * @param array $options         Additional options:
      *   - height: (integer) The height of the popup window.
@@ -1260,77 +927,47 @@ class Horde
      */
     public static function popupJs($url, $options = [])
     {
-        $GLOBALS['page_output']->addScriptPackage('Horde_Core_Script_Package_Popup');
-
-        $params = new stdClass();
-
-        if (!$url instanceof Horde_Url) {
-            $url = new Horde_Url($url);
-        }
-        $params->url = $url->url;
-
-        if (!empty($url->parameters)) {
-            if (!isset($options['params'])) {
-                $options['params'] = [];
-            }
-            foreach (array_merge($url->parameters, $options['params']) as $key => $val) {
-                $options['params'][$key] = addcslashes($val, '"');
-            }
-        }
-
-        if (!empty($options['menu'])) {
-            $params->menu = 1;
-        }
-        foreach (['height', 'onload', 'params', 'width'] as $key) {
-            if (!empty($options[$key])) {
-                $params->$key = $options[$key];
-            }
-        }
-
-        return 'void(HordePopup.popup(' . self::escapeJson($params, ['nodelimit' => true, 'urlencode' => !empty($options['urlencode'])]) . '));';
+        return Horde\Core\Horde::popupJs($url, $options);
     }
 
     /**
      * Start buffering output.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::startBuffer()} instead.
      */
     public static function startBuffer()
     {
-        if (!self::$_bufferLevel) {
-            self::$_contentSent = self::contentSent();
-        }
-
-        ++self::$_bufferLevel;
-        ob_start();
+        Horde\Core\Horde::startBuffer();
     }
 
     /**
      * End buffering output.
      *
+     * @deprecated Use {@see Horde\Core\Horde::endBuffer()} instead.
+     *
      * @return string  The buffered output.
      */
     public static function endBuffer()
     {
-        if (self::$_bufferLevel) {
-            --self::$_bufferLevel;
-            return ob_get_clean();
-        }
-
-        return '';
+        return Horde\Core\Horde::endBuffer();
     }
 
     /**
      * Has any content been sent to the browser?
      *
+     * @deprecated Use {@see Horde\Core\Horde::contentSent()} instead.
+     *
      * @return boolean  True if content has been sent.
      */
     public static function contentSent()
     {
-        return ((self::$_bufferLevel && self::$_contentSent)
-                || (!self::$_bufferLevel && (ob_get_length() || headers_sent())));
+        return Horde\Core\Horde::contentSent();
     }
 
     /**
      * Returns the sidebar for the current application.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::sidebar()} instead.
      *
      * @param string $app  The application to generate the menu for. Defaults
      *                     to the current app.
@@ -1339,27 +976,14 @@ class Horde
      */
     public static function sidebar($app = null)
     {
-        global $registry;
-
-        if (empty($app)) {
-            $app = $registry->getApp();
-        }
-
-        $menu = new Horde_Menu();
-        $registry->callAppMethod($app, 'menu', [
-            'args' => [$menu],
-        ]);
-        $sidebar = $menu->render();
-        $registry->callAppMethod($app, 'sidebar', [
-            'args' => [$sidebar],
-        ]);
-
-        return $sidebar;
+        return Horde\Core\Horde::sidebar($app);
     }
 
     /**
      * Process a permission denied error, running a user-defined hook if
      * necessary.
+     *
+     * @deprecated Use {@see Horde\Core\Horde::permissionDeniedError()} instead.
      *
      * @param string $app    Application name.
      * @param string $perm   Permission name.
@@ -1368,15 +992,7 @@ class Horde
      */
     public static function permissionDeniedError($app, $perm, $error = null)
     {
-        try {
-            $GLOBALS['injector']->getInstance('Horde_Core_Hooks')
-                ->callHook('perms_denied', 'horde', [$app, $perm]);
-        } catch (Horde_Exception_HookNotSet $e) {
-        }
-
-        if (!is_null($error)) {
-            $GLOBALS['notification']->push($error, 'horde.warning');
-        }
+        Horde\Core\Horde::permissionDeniedError($app, $perm, $error);
     }
 
     /**

--- a/lib/Horde.php
+++ b/lib/Horde.php
@@ -651,8 +651,8 @@ class Horde
         $ob = new Horde_Url($url, $full);
 
         if (empty($GLOBALS['conf']['session']['use_only_cookies'])
-            && ($append_session == 1
-             || $append_session == 0 && !isset($_COOKIE[session_name()]))) {
+            && ($append_session === 1
+             || $append_session === 0 && !isset($_COOKIE[session_name()]))) {
             $ob->add(session_name(), session_id());
         }
 

--- a/lib/Horde/Config.php
+++ b/lib/Horde/Config.php
@@ -214,7 +214,11 @@ class Horde_Config
 
         /* Load the DOM object. */
         $dom = new DOMDocument();
-        $dom->loadXML(file_get_contents($path . '/conf.xml'));
+        $xml = file_get_contents($path . '/conf.xml');
+        if ($xml === false) {
+            throw new Horde_Exception(sprintf('Could not read configuration file %s/conf.xml', $path));
+        }
+        $dom->loadXML($xml);
 
         /* Create config file hash. */
         $this->_configHash = hash_file('sha1', $path . '/conf.xml');

--- a/lib/Horde/Core/ActiveSync/Mail.php
+++ b/lib/Horde/Core/ActiveSync/Mail.php
@@ -407,6 +407,9 @@ class Horde_Core_ActiveSync_Mail
     {
         $mail = new Horde_Mime_Mail($this->_headers->toArray(['charset' => 'UTF-8']));
         $base_part = $this->imapMessage->getStructure();
+        if ($base_part === null) {
+            throw new Horde_ActiveSync_Exception('Unable to retrieve message structure.');
+        }
         $plain_id = $base_part->findBody('plain');
         $html_id = $base_part->findBody('html');
 
@@ -427,7 +430,7 @@ class Horde_Core_ActiveSync_Mail
             $mail->setBody($this->_getPlainPart($plain_id, $mime_message, $body_data, $base_part));
         }
 
-        foreach ($mime_message->contentTypeMap() as $mid => $type) {
+        foreach ($mime_message->contentTypeMap() ?? [] as $mid => $type) {
             if ($mid != 0 && $mid != $mime_message->findBody('plain') && $mid != $mime_message->findBody('html')) {
                 $mail->addMimePart($mime_message->getPart($mid));
             }
@@ -469,7 +472,7 @@ class Horde_Core_ActiveSync_Mail
         $mail->setBody($this->_getSmartPlainText($mime_message));
         $mail->setHtmlBody($this->_getSmartHtmlText($mime_message));
 
-        foreach ($mime_message->contentTypeMap() as $mid => $type) {
+        foreach ($mime_message->contentTypeMap() ?? [] as $mid => $type) {
             if ($mid != 0 && $mid != $mime_message->findBody('plain') && $mid != $mime_message->findBody('html')) {
                 $mail->addMimePart($mime_message->getPart($mid));
             }

--- a/lib/Horde/Core/ActiveSync/Mail/Draft.php
+++ b/lib/Horde/Core/ActiveSync/Mail/Draft.php
@@ -84,7 +84,7 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
 
         // Check to see if we have any existing parts to add.
         if (!empty($this->_imapMessage)) {
-            foreach ($this->_imapMessage->getStructure() as $part) {
+            foreach ($this->_imapMessage->getStructure() ?? [] as $part) {
                 if ($part->isAttachment()
                     && !in_array($part->getMimeId(), $this->_atcDelete)) {
                     $base->addPart(

--- a/lib/Horde/Core/Ajax/Application.php
+++ b/lib/Horde/Core/Ajax/Application.php
@@ -166,7 +166,7 @@ abstract class Horde_Core_Ajax_Application
     {
         global $injector;
 
-        if (!strlen($this->_action)) {
+        if (!strlen((string) $this->_action)) {
             return;
         }
 

--- a/lib/Horde/Core/Auth/Application.php
+++ b/lib/Horde/Core/Auth/Application.php
@@ -125,7 +125,7 @@ class Horde_Core_Auth_Application extends Horde_Auth_Base
      */
     public function authenticate($userId, $credentials, $login = true)
     {
-        if (!strlen($credentials['password'])) {
+        if (!strlen((string) ($credentials['password'] ?? ''))) {
             return false;
         }
 

--- a/lib/Horde/Core/Auth/X509.php
+++ b/lib/Horde/Core/Auth/X509.php
@@ -24,7 +24,7 @@ class Horde_Core_Auth_X509 extends Horde_Auth_X509
              * @deprecated Use $GLOBALS['injector']->getInstance('Horde_Core_Hooks')->callHook() instead
              * @see Horde_Deprecated::callHook()
              */
-return Horde::callHook('x509_validate', [$certificate]);
+            return Horde::callHook('x509_validate', [$certificate]);
         } catch (Horde_Exception_HookNotSet $e) {
         }
 

--- a/lib/Horde/Core/Factory/Mail.php
+++ b/lib/Horde/Core/Factory/Mail.php
@@ -102,7 +102,7 @@ class Horde_Core_Factory_Mail extends Horde_Core_Factory_Base
          * the authentication name but not the credentials. */
         if (strcasecmp($transport, 'smtp') === 0) {
             if ($registry->isAuthenticated()
-                && strlen($auth = $registry->getAuth())) {
+                && strlen((string) ($auth = $registry->getAuth()))) {
                 if (!empty($params['username_auth'])) {
                     $params['username'] = $auth;
                 }

--- a/lib/Horde/Core/Imsp/Utils.php
+++ b/lib/Horde/Core/Imsp/Utils.php
@@ -213,7 +213,7 @@ class Horde_Core_Imsp_Utils
     {
         if (strpos($bookName, $username) === 0) {
             return true;
-        } elseif (strpos($acl, 'a')) {
+        } elseif (strpos((string) $acl, 'a') !== false) {
             return true;
         }
         return false;

--- a/lib/Horde/Core/Mime/Viewer/Vcard.php
+++ b/lib/Horde/Core/Mime/Viewer/Vcard.php
@@ -109,7 +109,7 @@ class Horde_Core_Mime_Viewer_Vcard extends Horde_Mime_Viewer_Base
             && $registry->hasMethod('contacts/import')) {
             $source = Horde_Util::getFormData('source');
             $count = 0;
-            foreach ($iCal->getComponents() as $c) {
+            foreach ($iCal->getComponents() ?? [] as $c) {
                 if ($c->getType() == 'vcard') {
                     try {
                         $registry->call('contacts/import', [$c, null, $source]);
@@ -134,7 +134,7 @@ class Horde_Core_Mime_Viewer_Vcard extends Horde_Mime_Viewer_Base
 
         $html .= '<table class="horde-table" style="width:100%">';
 
-        foreach ($iCal->getComponents() as $i => $vc) {
+        foreach ($iCal->getComponents() ?? [] as $i => $vc) {
             if ($i > 0) {
                 $html .= '<tr><td colspan="2">&nbsp;</td></tr>';
             }

--- a/lib/Horde/Core/Prefs/Identity.php
+++ b/lib/Horde/Core/Prefs/Identity.php
@@ -184,7 +184,7 @@ class Horde_Core_Prefs_Identity extends Horde_Prefs_Identity
         global $registry;
 
         if (!isset($this->_names[$ident])
-            && !strlen($this->getValue($this->_prefnames['fullname'], $ident))) {
+            && !strlen((string) $this->getValue($this->_prefnames['fullname'], $ident))) {
             $this->_names[$ident] = $registry->convertUsername($this->_user, false);
         }
 

--- a/lib/Horde/Core/Prefs/Ui.php
+++ b/lib/Horde/Core/Prefs/Ui.php
@@ -586,7 +586,7 @@ class Horde_Core_Prefs_Ui
                     case 'password':
                     case 'text':
                     case 'textarea':
-                        $t->set('val', htmlspecialchars($prefs->getValue($pref)));
+                        $t->set('val', htmlspecialchars((string) $prefs->getValue($pref)));
                         break;
 
                     case 'rawhtml':

--- a/lib/Horde/Core/TagBrowser.php
+++ b/lib/Horde/Core/TagBrowser.php
@@ -219,10 +219,10 @@ abstract class Horde_Core_TagBrowser
             // Multiple types.
             $counts = [];
             foreach ($result_data as $data) {
-                $counts = array_merge($counts, $this->_tagger->getTagCountsByObjects($data));
+                $counts = array_merge($counts, $this->_tagger->getTagCountsByObjects($data) ?? []);
             }
         } else {
-            $counts = $this->_tagger->getTagCountsByObjects($result_data);
+            $counts = $this->_tagger->getTagCountsByObjects($result_data) ?? [];
         }
         $tag_ids = array_keys($tags);
         foreach ($counts as $result) {

--- a/lib/Horde/Core/Topbar.php
+++ b/lib/Horde/Core/Topbar.php
@@ -239,7 +239,7 @@ class Horde_Core_Topbar
                      * user's locale may not have been loaded when registry.php was
                      * parsed, and the translations of the application names are
                      * not in the Core package. */
-                    $name = strlen($params['name']) ? _($params['name']) : '';
+                    $name = strlen((string) ($params['name'] ?? '')) ? _($params['name']) : '';
 
                     /* Headings have no webroot; they're just containers for other
                      * menu items. */

--- a/lib/Horde/Core/Ui/VarRenderer/Html.php
+++ b/lib/Horde/Core/Ui/VarRenderer/Html.php
@@ -348,7 +348,7 @@ class Horde_Core_Ui_VarRenderer_Html extends Horde_Core_Ui_VarRenderer
                 $filter = $GLOBALS['injector']->getInstance('Horde_Core_Factory_TextFilter')->create('emoticons');
                 $icon_list = [];
 
-                foreach (array_flip($filter->getIcons()) as $icon => $string) {
+                foreach (array_flip($filter->getIcons() ?? []) as $icon => $string) {
                     $icon_list[] = [
                         $filter->getIcon($icon),
                         $string,

--- a/lib/Horde/ErrorHandler.php
+++ b/lib/Horde/ErrorHandler.php
@@ -119,7 +119,7 @@ class Horde_ErrorHandler
         $er = error_reporting();
 
         // Calls prefixed with '@'.
-        if ($er == 0) {
+        if ($er === 0) {
             // Must return false to populate $php_errormsg (as of PHP 5.2).
             return false;
         }

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -1947,7 +1947,7 @@ class Horde_Registry implements Horde_Shutdown_Task
         }
 
         return ($parameter == 'name')
-            ? (strlen($pval) ? _($pval) : '')
+            ? (strlen((string) $pval) ? _($pval) : '')
             : $pval;
     }
 

--- a/src/Horde.php
+++ b/src/Horde.php
@@ -1,0 +1,1162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 1999-2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core;
+
+use Horde_Array;
+use Horde_Auth;
+use Horde_Browser;
+use Horde_Cache;
+use Horde_Core_Factory_Logger;
+use Horde_Core_Hooks;
+use Horde_Core_HordeMap;
+use Horde_Core_Log_Object;
+use Horde_Core_Script_Package_Popup;
+use Horde_Core_Translation;
+use Horde_Exception;
+use Horde_Exception_HookNotSet;
+use Horde_Log;
+use Horde_Log_Handler_Stream;
+use Horde_Log_Logger;
+use Horde_Menu;
+use Horde_Registry;
+use Horde_Serialize;
+use Horde_Session;
+use Horde_String;
+use Horde_String_Transliterate;
+use Horde_Support_Backtrace;
+use Horde_Url;
+use Horde_Util;
+use Horde_Variables;
+use Horde_View_Sidebar;
+use Stringable;
+use stdClass;
+
+/**
+ * Provides the base functionality shared by all Horde applications.
+ *
+ * This is the modern namespaced version of the legacy global Horde class,
+ * without deprecated method delegation.
+ *
+ * @author   Chuck Hagenbuch <chuck@horde.org>
+ * @author   Jon Parise <jon@horde.org>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+class Horde
+{
+    public const SSL_NEVER      = 0;
+    public const SSL_ALWAYS     = 1;
+    public const SSL_AUTO       = 2;
+    public const SSL_ONLY_LOGIN = 3;
+
+    /**
+     * The current buffer level.
+     */
+    protected static int $_bufferLevel = 0;
+
+    /**
+     * Has content been sent at the base buffer level?
+     */
+    protected static bool $_contentSent = false;
+
+    /**
+     * The labels already used in this page.
+     */
+    protected static array $_labels = [];
+
+    /**
+     * Are accesskeys supported on this system.
+     */
+    protected static ?bool $_noAccessKey = null;
+
+    /**
+     * The access keys already used in this page.
+     */
+    protected static array $_used = [];
+
+    /**
+     * Shortcut to logging method.
+     *
+     * @see Horde_Core_Log_Logger
+     */
+    public static function log(
+        mixed $event,
+        ?int $priority = null,
+        array $options = [],
+    ): void {
+        $options['trace'] = isset($options['trace'])
+            ? ($options['trace'] + 1)
+            : 1;
+        $log_ob = new Horde_Core_Log_Object($event, $priority, $options);
+
+        /* Chicken/egg: we must wait until we have basic framework setup
+         * before we can start logging. Otherwise, queue entries. */
+        if (isset($GLOBALS['injector'])
+            && Horde_Core_Factory_Logger::available()) {
+            $GLOBALS['injector']->getInstance('Horde_Log_Logger')->logObject($log_ob);
+        } else {
+            Horde_Core_Factory_Logger::queue($log_ob);
+        }
+    }
+
+    /**
+     * Debug method.  Allows quick shortcut to produce debug output into a
+     * temporary file.
+     */
+    public static function debug(
+        mixed $event = null,
+        ?string $fname = null,
+        bool $backtrace = true,
+    ): void {
+        if ($fname === null) {
+            $fname = self::getTempDir() . '/horde_debug.txt';
+        }
+
+        try {
+            $logger = new Horde_Log_Logger(new Horde_Log_Handler_Stream($fname));
+        } catch (\Exception $e) {
+            return;
+        }
+
+        $html_ini = ini_set('html_errors', 'Off');
+        self::startBuffer();
+        if ($event !== null) {
+            echo "Variable information:\n";
+            var_dump($event);
+            echo "\n";
+        }
+
+        if (is_resource($event)) {
+            echo "Stream contents:\n";
+            rewind($event);
+            fpassthru($event);
+            echo "\n";
+        }
+
+        if ($backtrace) {
+            echo "Backtrace:\n";
+            echo strval(new Horde_Support_Backtrace());
+        }
+
+        $logger->log(self::endBuffer(), Horde_Log::DEBUG);
+        ini_set('html_errors', $html_ini);
+    }
+
+    /**
+     * Adds a signature + timestamp to a URL and returns the signed URL.
+     *
+     * @param string|Horde_Url $url  The URL to sign.
+     * @param int|null $now          The timestamp at which to sign.
+     *
+     * @return string|Horde_Url  The signed URL.
+     */
+    public static function signUrl(string|Horde_Url $url, ?int $now = null): string|Horde_Url
+    {
+        global $conf;
+
+        if (!isset($conf['secret_key'])) {
+            return $url;
+        }
+
+        if ($now === null) {
+            $now = time();
+        }
+
+        if ($url instanceof Horde_Url) {
+            $url->setRaw(true)->add(['_t' => $now, '_h' => '']);
+            $url->add(
+                '_h',
+                Horde_Url::uriB64Encode(
+                    hash_hmac('sha1', $url . '=', $conf['secret_key'], true)
+                )
+            );
+            return $url;
+        }
+
+        if (!$url) {
+            return $url;
+        }
+
+        if (strpos($url, '?')) {
+            $url .= '&';
+        } else {
+            $url .= '?';
+        }
+        $url .= '_t=' . $now . '&_h=';
+        $url .= Horde_Url::uriB64Encode(
+            hash_hmac('sha1', $url, $conf['secret_key'], true)
+        );
+
+        return $url;
+    }
+
+    /**
+     * Verifies a signature and timestamp on a URL.
+     *
+     * @return string|false  The URL stripped of the signature, or false if
+     *                       not verified.
+     */
+    public static function verifySignedUrl(string $data, ?int $now = null): string|false
+    {
+        global $conf;
+
+        if ($now === null) {
+            $now = time();
+        }
+
+        $pos = strrpos($data, '&_h=');
+        if ($pos === false) {
+            return false;
+        }
+        $pos += 4;
+
+        $url = substr($data, 0, $pos);
+        $hmac = substr($data, $pos);
+
+        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $url, $conf['secret_key'], true))) {
+            return false;
+        }
+
+        // String was not tampered with; now validate timestamp
+        parse_str((string) parse_url($url, PHP_URL_QUERY), $values);
+        if ($values['_t'] + $conf['urls']['hmac_lifetime'] * 60 < $now) {
+            return false;
+        }
+
+        $pos = strrpos($data, '&_t=');
+        if ($pos === false) {
+            $pos = strrpos($data, '?_t=');
+        }
+        if ($pos === false) {
+            return false;
+        }
+
+        return substr($data, 0, $pos);
+    }
+
+    /**
+     * Adds a signature + timestamp to a query string and returns the signed
+     * query string.
+     *
+     * @return string|Horde_Url  The signed query string (or Horde_Url object).
+     */
+    public static function signQueryString(
+        string|Horde_Url $queryString,
+        ?int $now = null,
+    ): string|Horde_Url {
+        if (!isset($GLOBALS['conf']['secret_key'])) {
+            return $queryString;
+        }
+
+        if ($now === null) {
+            $now = time();
+        }
+
+        if ($queryString instanceof Horde_Url) {
+            $queryString->setRaw(true)->add(['_t' => $now, '_h' => '']);
+            $query = parse_url((string) $queryString, PHP_URL_QUERY);
+            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query . '=', $GLOBALS['conf']['secret_key'], true)));
+            return $queryString;
+        }
+
+        $queryString .= '&_t=' . $now . '&_h=';
+
+        return $queryString . Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true));
+    }
+
+    /**
+     * Verifies a signature and timestamp on a query string.
+     */
+    public static function verifySignedQueryString(string $data, ?int $now = null): bool
+    {
+        if ($now === null) {
+            $now = time();
+        }
+
+        $pos = strrpos($data, '&_h=');
+        if ($pos === false) {
+            return false;
+        }
+        $pos += 4;
+
+        $queryString = substr($data, 0, $pos);
+        $hmac = substr($data, $pos);
+
+        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true))) {
+            return false;
+        }
+
+        // String was not tampered with; now validate timestamp
+        parse_str($queryString, $values);
+
+        return !($values['_t'] + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 < $now);
+    }
+
+    /**
+     * Do necessary escaping to output JSON.
+     *
+     * @param mixed $data     The data to JSON-ify.
+     * @param array $options  Additional options:
+     *   - nodelimit: (bool) Don't add security delimiters?
+     *   - urlencode: (bool) URL encode the json string
+     */
+    public static function escapeJson(mixed $data, array $options = []): string
+    {
+        $json = Horde_Serialize::serialize($data, Horde_Serialize::JSON);
+        if (empty($options['nodelimit'])) {
+            $json = '/*-secure-' . $json . '*/';
+        }
+
+        return empty($options['urlencode'])
+            ? $json
+            : '\'' . rawurlencode($json) . '\'';
+    }
+
+    /**
+     * Is the current HTTP connection considered secure?
+     */
+    public static function isConnectionSecure(): bool
+    {
+        global $browser, $conf, $registry;
+
+        if ($browser->usingSSLConnection()) {
+            return true;
+        }
+
+        if (!empty($conf['safe_ips'])) {
+            if (reset($conf['safe_ips']) == '*') {
+                return true;
+            }
+
+            $remote = $registry->remoteHost();
+            if (!$remote->proxy) {
+                foreach ($conf['safe_ips'] as $safe_ip) {
+                    $safe_ip = preg_replace('/(\.0)*$/', '', $safe_ip);
+                    if (strpos($remote->addr, (string) $safe_ip) === 0) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Throws an exception if not using a secure connection.
+     *
+     * @throws Horde_Exception
+     */
+    public static function requireSecureConnection(): void
+    {
+        if (!self::isConnectionSecure()) {
+            throw new Horde_Exception(Horde_Core_Translation::t('The encryption features require a secure web connection.'));
+        }
+    }
+
+    /**
+     * Returns the driver parameters for the specified backend.
+     *
+     * @param string|array $backend  The backend system (e.g. 'prefs',
+     *                               'categories', 'contacts').
+     * @param string|null $type      The type of driver. If null, will not
+     *                               merge with base config.
+     *
+     * @return array  The connection parameters.
+     */
+    public static function getDriverConfig(string|array $backend, ?string $type = 'sql'): array
+    {
+        global $conf;
+
+        if ($type !== null) {
+            $type = Horde_String::lower($type);
+        }
+
+        if (is_array($backend)) {
+            $c = Horde_Array::getElement($conf, $backend);
+        } elseif (isset($conf[$backend])) {
+            $c = $conf[$backend];
+        } else {
+            $c = null;
+        }
+
+        if ($c !== null && isset($c['params'])) {
+            $c['params']['umask'] = $conf['umask'];
+
+            $result = ($type !== null && isset($conf[$type]))
+                ? array_merge($conf[$type], $c['params'])
+                : $c['params'];
+
+            if ((!isset($c['params']['driverconfig'])
+                 || $c['params']['driverconfig'] != 'horde')
+                && $type !== null && $type === 'sql') {
+                if (($c['params']['protocol'] ?? null) === 'unix') {
+                    unset($result['hostspec'], $result['port']);
+                } else {
+                    unset($result['socket']);
+                }
+            }
+
+            return $result;
+        }
+
+        return ($type !== null && isset($conf[$type]))
+            ? $conf[$type]
+            : [];
+    }
+
+    /**
+     * Checks if all necessary parameters for a driver configuration
+     * are set and throws a fatal error with a detailed explanation
+     * how to fix this, if something is missing.
+     *
+     * @throws Horde_Exception
+     */
+    public static function assertDriverConfig(
+        array $params,
+        string $driver,
+        array $fields,
+        ?string $name = null,
+        string $file = 'conf.php',
+        string $variable = '$conf',
+    ): void {
+        global $registry;
+
+        if ($name === null) {
+            $name = isset($registry) ? $registry->getApp() : '[unknown]';
+        }
+        $fileroot = isset($registry) ? $registry->get('fileroot') : '';
+
+        if (!count($params)) {
+            throw new Horde_Exception(
+                sprintf(Horde_Core_Translation::t('No configuration information specified for %s.'), $name) . "\n\n"
+                . sprintf(
+                    Horde_Core_Translation::t('The file %s should contain some %s settings.'),
+                    $fileroot . '/config/' . $file,
+                    sprintf("%s['%s']['params']", $variable, $driver)
+                )
+            );
+        }
+
+        foreach ($fields as $field) {
+            if (!isset($params[$field])) {
+                throw new Horde_Exception(
+                    sprintf(Horde_Core_Translation::t('Required "%s" not specified in %s configuration.'), $field, $name) . "\n\n"
+                    . sprintf(
+                        Horde_Core_Translation::t('The file %s should contain a %s setting.'),
+                        $fileroot . '/config/' . $file,
+                        sprintf("%s['%s']['params']['%s']", $variable, $driver, $field)
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns a session-id-ified version of $uri.
+     *
+     * @param string|Stringable $uri  The URI to be modified.
+     * @param bool $full              Generate a full URL.
+     * @param array|int $opts         Additional options or append_session value.
+     */
+    public static function url(
+        string|Stringable $uri,
+        bool $full = false,
+        array|int $opts = [],
+    ): Horde_Url {
+        if (is_array($opts)) {
+            $append_session = $opts['append_session'] ?? 0;
+            if (!empty($opts['force_ssl'])) {
+                $full = true;
+            }
+        } else {
+            $append_session = $opts;
+            $opts = [];
+        }
+
+        $puri = parse_url((string) $uri) ?: [];
+
+        /* Normalize missing components */
+        foreach (['host', 'path'] as $key) {
+            if (!isset($puri[$key])) {
+                $puri[$key] = '';
+            }
+        }
+
+        $url = '';
+        $schemeRegexp = '|^([a-zA-Z][a-zA-Z0-9+.-]{0,19})://|';
+        $webroot = ltrim(
+            (string) $GLOBALS['registry']->get(
+                'webroot',
+                empty($opts['app']) ? null : $opts['app']
+            ),
+            '/'
+        );
+
+        if ($full
+            && !isset($puri['scheme'])
+            && !preg_match($schemeRegexp, $webroot)) {
+
+            /* Store connection parameters in local variables. */
+            $server_name = $GLOBALS['conf']['server']['name'];
+            $server_port = $GLOBALS['conf']['server']['port'] ?? '';
+
+            $protocol = 'http';
+            switch ($GLOBALS['conf']['use_ssl']) {
+                case self::SSL_ALWAYS:
+                    $protocol = 'https';
+                    break;
+
+                case self::SSL_AUTO:
+                    if ($GLOBALS['browser']->usingSSLConnection()) {
+                        $protocol = 'https';
+                    }
+                    break;
+
+                case self::SSL_ONLY_LOGIN:
+                    if (!empty($opts['force_ssl'])) {
+                        $protocol = 'https';
+                        $server_port = '';
+                    }
+                    break;
+            }
+
+            /* If using a non-standard port, add to the URL. */
+            if (!empty($server_port)
+                && ($protocol === 'http' && $server_port != 80
+                 || $protocol === 'https' && $server_port != 443)) {
+                $server_name .= ':' . $server_port;
+            }
+
+            $url = $protocol . '://' . $server_name;
+
+        } elseif (isset($puri['scheme'])) {
+
+            $url = $puri['scheme'] . ':';
+            if ($puri['host'] !== '') {
+                $url .= '//' . $puri['host'];
+
+                /* If using a non-standard port, add to the URL. */
+                if (isset($puri['port'])
+                    && ($puri['scheme'] === 'http' && $puri['port'] != 80
+                     || $puri['scheme'] === 'https' && $puri['port'] != 443)) {
+                    $url .= ':' . $puri['port'];
+                }
+            }
+        }
+
+        if (substr($puri['path'], 0, 1) === '/'
+            && (!preg_match($schemeRegexp, $webroot) || isset($puri['scheme']))) {
+
+            $url .= $puri['path'];
+
+        } elseif ($puri['path'] !== '' && preg_match($schemeRegexp, $webroot)) {
+
+            if (substr($puri['path'], 0, 1) === '/') {
+                $pwebroot = parse_url($webroot);
+                $url = $pwebroot['scheme'] . '://' . $pwebroot['host']
+                    . $puri['path'];
+            } else {
+                $url = $webroot . '/' . $puri['path'];
+            }
+
+        } else {
+            $url .= '/' . ($webroot ? $webroot . '/' : '') . $puri['path'];
+        }
+
+        if (isset($puri['query'])) {
+            $url .= '?' . $puri['query'];
+        }
+        if (isset($puri['fragment'])) {
+            $url .= '#' . $puri['fragment'];
+        }
+
+        $ob = new Horde_Url($url, $full);
+
+        if (empty($GLOBALS['conf']['session']['use_only_cookies'])
+            && ($append_session === 1
+             || $append_session === 0 && !isset($_COOKIE[session_name()]))) {
+            $ob->add(session_name(), session_id());
+        }
+
+        return $ob;
+    }
+
+    /**
+     * Returns an external link passed through the dereferrer to strip session
+     * IDs from the referrer.
+     */
+    public static function externalUrl(string $url, bool $tag = false): string
+    {
+        if (!isset($_GET[session_name()])
+            || Horde_String::substr($url, 0, 1) == '#'
+            || Horde_String::substr($url, 0, 7) == 'mailto:') {
+            $ext = $url;
+        } else {
+            $ext = (string) self::signQueryString($GLOBALS['registry']->getServiceLink('go', 'horde')->add('url', $url));
+        }
+
+        if ($tag) {
+            $ext = self::link($ext, $url, '', '_blank');
+        }
+
+        return $ext;
+    }
+
+    /**
+     * Returns an anchor tag with the relevant parameters.
+     *
+     * @param Horde_Url|string $url  The full URL to be linked to.
+     * @param string $title          The link title/description.
+     * @param string $class          The CSS class of the link.
+     * @param string $target         The window target to point to.
+     * @param string $onclick        JavaScript action for the 'onclick' event.
+     * @param string $accesskey      The access key to use.
+     * @param array $attributes      Any other name/value pairs to add to the
+     *                               <a> tag.
+     * @param bool $escape           Whether to escape special characters in the
+     *                               title attribute.
+     *
+     * @return string  The full <a href> tag.
+     */
+    public static function link(
+        Horde_Url|string $url = '',
+        string $title = '',
+        string $class = '',
+        string $target = '',
+        string $onclick = '',
+        string $accesskey = '',
+        array $attributes = [],
+        bool $escape = true,
+    ): string {
+        if (!($url instanceof Horde_Url)) {
+            $url = new Horde_Url($url);
+        }
+
+        if (!empty($onclick)) {
+            $attributes['onclick'] = $onclick;
+        }
+        if (!empty($class)) {
+            $attributes['class'] = $class;
+        }
+        if (!empty($target)) {
+            $attributes['target'] = $target;
+        }
+        if (!empty($accesskey)) {
+            $attributes['accesskey'] = $accesskey;
+        }
+        if (!empty($title)) {
+            if ($escape) {
+                $title = str_replace(
+                    ["\r", "\n"],
+                    '',
+                    htmlspecialchars(nl2br(htmlspecialchars($title)))
+                );
+                /* Remove double encoded entities. */
+                $title = preg_replace('/&amp;([a-z]+|(#\d+));/i', '&\\1;', $title);
+            }
+            $attributes['title.raw'] = $title;
+        }
+
+        return $url->link($attributes);
+    }
+
+    /**
+     * Uses DOM Tooltips to display the 'title' attribute for link() calls.
+     *
+     * @return string  The full <a href> tag.
+     */
+    public static function linkTooltip(
+        Horde_Url|string $url,
+        string $status = '',
+        string $class = '',
+        string $target = '',
+        string $onclick = '',
+        string $title = '',
+        string $accesskey = '',
+        array $attributes = [],
+    ): string {
+        if (strlen($title)) {
+            $attributes['nicetitle'] = Horde_Serialize::serialize(
+                preg_split(
+                    '/\r?\n/',
+                    preg_replace('/<br\s*\/?\s*>/', "\n", $title)
+                ),
+                Horde_Serialize::JSON
+            );
+            $title = '';
+            $GLOBALS['injector']->getInstance('Horde_PageOutput')
+                ->addScriptFile('tooltips.js', 'horde');
+        }
+
+        return self::link(
+            $url,
+            $title,
+            $class,
+            $target,
+            $onclick,
+            $accesskey,
+            $attributes,
+            false
+        );
+    }
+
+    /**
+     * Returns an anchor sequence with the relevant parameters for a widget
+     * with accesskey and text.
+     *
+     * @return string  The full <a href>Title</a> sequence.
+     */
+    public static function widget(array $params): string
+    {
+        $params = array_merge(
+            [
+                'class' => '',
+                'target' => '',
+                'onclick' => '',
+                'nocheck' => false,
+            ],
+            $params
+        );
+
+        $url = ($params['url'] instanceof Horde_Url)
+            ? $params['url']
+            : new Horde_Url($params['url']);
+        $title = $params['title'];
+        $params['accesskey'] = self::getAccessKey($title, $params['nocheck']);
+
+        unset($params['url'], $params['title'], $params['nocheck']);
+
+        return $url->link($params)
+            . self::highlightAccessKey($title, $params['accesskey'])
+            . '</a>';
+    }
+
+    /**
+     * Returns a session-id-ified version of $SCRIPT_NAME resp. $PHP_SELF.
+     */
+    public static function selfUrl(
+        bool $script_params = false,
+        bool $nocache = true,
+        bool $full = false,
+        bool $force_ssl = false,
+    ): Horde_Url {
+        if (!strncmp(PHP_SAPI, 'cgi', 3)) {
+            $url = $_SERVER['PHP_SELF'];
+        } else {
+            $url = $_SERVER['SCRIPT_NAME']
+                ?? $_SERVER['PHP_SELF'];
+        }
+        if (isset($_SERVER['REQUEST_URI'])) {
+            $url = Horde_String::common($_SERVER['REQUEST_URI'], $url);
+        }
+        if (substr($url, -9) == 'index.php') {
+            $url = substr($url, 0, -9);
+        }
+
+        if ($script_params) {
+            $url = new Horde_Url($url);
+            if ($pathInfo = Horde_Util::getPathInfo()) {
+                $url->pathInfo = ltrim((string) $pathInfo, '/');
+            }
+            if (!empty($_SERVER['QUERY_STRING'])) {
+                parse_str($_SERVER['QUERY_STRING'], $args);
+                $url->add($args);
+            }
+        }
+
+        $url = self::url($url, $full, ['force_ssl' => $force_ssl]);
+
+        return ($nocache && $GLOBALS['browser']->hasQuirk('cache_same_url'))
+            ? $url->unique()
+            : $url;
+    }
+
+    /**
+     * Create a self URL of the current page, building the parameter list from
+     * the current Horde_Variables object.
+     */
+    public static function selfUrlParams(array $opts = []): Horde_Url
+    {
+        $vars = $opts['vars']
+            ?? $GLOBALS['injector']->createInstance('Horde_Variables');
+
+        $url = self::selfUrl(
+            false,
+            (!array_key_exists('nocache', $opts) || empty($opts['nocache'])),
+            !empty($opts['full']),
+            !empty($opts['force_ssl'])
+        )->add(iterator_to_array($vars));
+
+        if (!isset($opts['vars'])) {
+            $url->remove(array_keys($_COOKIE));
+        }
+
+        return $url;
+    }
+
+    /**
+     * Determines the location of the system temporary directory.
+     *
+     * @return string|false  A directory name, or false if one could not
+     *                       be found.
+     */
+    public static function getTempDir(): string|false
+    {
+        global $conf;
+
+        $tmp = '';
+
+        /* If one has been specifically set, then use that */
+        if (!empty($conf['tmpdir'])) {
+            $tmp = $conf['tmpdir'];
+        }
+
+        /* Next, try sys_get_temp_dir(). */
+        if (empty($tmp)) {
+            $tmp = sys_get_temp_dir();
+        }
+
+        return empty($tmp) ? false : $tmp;
+    }
+
+    /**
+     * Creates a temporary filename for the lifetime of the script, and
+     * (optionally) registers it to be deleted at request shutdown.
+     *
+     * @return string|false  Returns the full path-name to the temporary file
+     *                       or false if a temporary file could not be created.
+     */
+    public static function getTempFile(
+        string $prefix = 'Horde',
+        bool $delete = true,
+        string $dir = '',
+        bool $secure = false,
+        bool $session_remove = false,
+    ): string|false {
+        if (empty($dir) || !is_dir($dir)) {
+            $dir = self::getTempDir();
+        }
+        $tmpfile = Horde_Util::getTempFile($prefix, $delete, $dir, $secure);
+        if ($session_remove) {
+            $gcfiles = $GLOBALS['session']->get('horde', 'gc_tempfiles', Horde_Session::TYPE_ARRAY);
+            $gcfiles[] = $tmpfile;
+            $GLOBALS['session']->set('horde', 'gc_tempfiles', $gcfiles);
+        }
+
+        return $tmpfile;
+    }
+
+    /**
+     * Returns the Web server being used.
+     *
+     * @see php_sapi_name()
+     */
+    public static function webServerID(): string
+    {
+        switch (PHP_SAPI) {
+            case 'apache':
+                return 'apache1';
+
+            case 'apache2filter':
+            case 'apache2handler':
+                return 'apache2';
+
+            default:
+                return PHP_SAPI;
+        }
+    }
+
+    /**
+     * Returns an un-used access key from the label given.
+     *
+     * @return string  A single lower case character access key, or an empty
+     *                 string if no key can be found.
+     */
+    public static function getAccessKey(
+        string $label,
+        bool $nocheck = false,
+        bool $shutdown = false,
+    ): string {
+        /* Shutdown call for translators? */
+        if ($shutdown) {
+            if (!count(self::$_labels)) {
+                return '';
+            }
+            $script = basename($_SERVER['PHP_SELF']);
+            $labels = array_keys(self::$_labels);
+            sort($labels);
+            $used = array_keys(self::$_used);
+            sort($used);
+            $remaining = str_replace($used, [], 'abcdefghijklmnopqrstuvwxyz');
+            self::log('Access key information for ' . $script);
+            self::log('Used labels: ' . implode(',', $labels));
+            self::log('Used keys: ' . implode('', $used));
+            self::log('Free keys: ' . $remaining);
+            return '';
+        }
+
+        /* Use access keys at all? */
+        if (self::$_noAccessKey === null) {
+            self::$_noAccessKey = !$GLOBALS['browser']->hasFeature('accesskey') || !$GLOBALS['prefs']->getValue('widget_accesskey');
+        }
+
+        if (self::$_noAccessKey
+            || !preg_match('/_(\w)/u', $label, $match)) {
+            return '';
+        }
+        $key = Horde_String_Transliterate::toAscii($match[1]);
+
+        /* Has this key already been used? */
+        if (isset(self::$_used[strtolower($key)])
+            && !($nocheck && isset(self::$_labels[$label]))) {
+            return '';
+        }
+
+        /* Save key and label. */
+        self::$_used[strtolower($key)] = true;
+        self::$_labels[$label] = true;
+
+        return $key;
+    }
+
+    /**
+     * Strips an access key from a label.
+     */
+    public static function stripAccessKey(string $label): string
+    {
+        $replace = $GLOBALS['registry']->nlsconfig->curr_multibyte
+            && preg_match('/[\x80-\xff]/', $label)
+            ? ''
+            : '$1';
+        return preg_replace('/_(\w)/u', $replace, $label);
+    }
+
+    /**
+     * Highlights an access key in a label.
+     */
+    public static function highlightAccessKey(string $label, string $accessKey): string
+    {
+        $stripped_label = self::stripAccessKey($label);
+
+        if (empty($accessKey)) {
+            return $stripped_label;
+        }
+
+        if ($GLOBALS['registry']->nlsconfig->curr_multibyte) {
+            return $stripped_label . "\xe2\x80\xad"
+                . '(<span class="accessKey">' . strtoupper($accessKey)
+                . '</span>' . ')';
+        }
+
+        return preg_replace(
+            '/_(\w)/u',
+            '<span class="accessKey">$1</span>',
+            $label
+        );
+    }
+
+    /**
+     * Returns the appropriate "accesskey" and "title" attributes for an HTML
+     * tag and the given label.
+     *
+     * @return string|array  The title and accesskey attributes as a string,
+     *                       or as an array if $return_array is true.
+     */
+    public static function getAccessKeyAndTitle(
+        string $label,
+        bool $nocheck = false,
+        bool $return_array = false,
+    ): string|array {
+        $ak = self::getAccessKey($label, $nocheck);
+        $attributes = ['title' => self::stripAccessKey($label)];
+        if (!empty($ak)) {
+            $attributes['title'] .= sprintf(Horde_Core_Translation::t(' (Accesskey %s)'), strtoupper($ak));
+            $attributes['accesskey'] = $ak;
+        }
+
+        if ($return_array) {
+            return $attributes;
+        }
+
+        $html = '';
+        foreach ($attributes as $attribute => $value) {
+            $html .= sprintf(' %s="%s"', $attribute, $value);
+        }
+        return $html;
+    }
+
+    /**
+     * Returns a label element including an access key for usage in
+     * conjunction with a form field.
+     */
+    public static function label(string $for, string $label, ?string $ak = null): string
+    {
+        if ($ak === null) {
+            $ak = self::getAccessKey($label, true);
+        }
+        $label = self::highlightAccessKey($label, $ak);
+
+        return sprintf(
+            '<label for="%s"%s>%s</label>',
+            $for,
+            !empty($ak) ? ' accesskey="' . $ak . '"' : '',
+            $label
+        );
+    }
+
+    /**
+     * Print inline javascript to output buffer after wrapping with necessary
+     * javascript tags.
+     */
+    public static function wrapInlineScript(array $script): string
+    {
+        return '<script type="text/javascript">//<![CDATA[' . "\n" . implode('', $script) . "\n//]]></script>\n";
+    }
+
+    /**
+     * Creates a URL for cached data.
+     *
+     * @param string $type   The cache type ('app', 'css', 'js').
+     * @param array $params  Optional parameters.
+     */
+    public static function getCacheUrl(string $type, array $params = []): Horde_Url
+    {
+        $url = $GLOBALS['registry']
+            ->getserviceLink('cache', 'horde')
+            ->add('cache', $type);
+        foreach ($params as $key => $val) {
+            $url .= '/' . $key . '=' . rawurlencode(strval($val));
+        }
+
+        return self::url($url, true, ['append_session' => -1]);
+    }
+
+    /**
+     * Output the javascript needed to call the popup JS function.
+     *
+     * @param string|Horde_Url $url  The page to load.
+     * @param array $options         Additional options.
+     *
+     * @return string  The javascript needed to call the popup code.
+     */
+    public static function popupJs(string|Horde_Url $url, array $options = []): string
+    {
+        $GLOBALS['page_output']->addScriptPackage('Horde_Core_Script_Package_Popup');
+
+        $params = new stdClass();
+
+        if (!$url instanceof Horde_Url) {
+            $url = new Horde_Url($url);
+        }
+        $params->url = $url->url;
+
+        if (!empty($url->parameters)) {
+            if (!isset($options['params'])) {
+                $options['params'] = [];
+            }
+            foreach (array_merge($url->parameters, $options['params']) as $key => $val) {
+                $options['params'][$key] = addcslashes($val, '"');
+            }
+        }
+
+        if (!empty($options['menu'])) {
+            $params->menu = 1;
+        }
+        foreach (['height', 'onload', 'params', 'width'] as $key) {
+            if (!empty($options[$key])) {
+                $params->$key = $options[$key];
+            }
+        }
+
+        return 'void(HordePopup.popup(' . self::escapeJson($params, ['nodelimit' => true, 'urlencode' => !empty($options['urlencode'])]) . '));';
+    }
+
+    /**
+     * Start buffering output.
+     */
+    public static function startBuffer(): void
+    {
+        if (!self::$_bufferLevel) {
+            self::$_contentSent = self::contentSent();
+        }
+
+        ++self::$_bufferLevel;
+        ob_start();
+    }
+
+    /**
+     * End buffering output.
+     */
+    public static function endBuffer(): string
+    {
+        if (self::$_bufferLevel) {
+            --self::$_bufferLevel;
+            return ob_get_clean();
+        }
+
+        return '';
+    }
+
+    /**
+     * Has any content been sent to the browser?
+     */
+    public static function contentSent(): bool
+    {
+        return (self::$_bufferLevel && self::$_contentSent)
+            || (!self::$_bufferLevel && (ob_get_length() || headers_sent()));
+    }
+
+    /**
+     * Returns the sidebar for the current application.
+     */
+    public static function sidebar(?string $app = null): Horde_View_Sidebar
+    {
+        global $registry;
+
+        if (empty($app)) {
+            $app = $registry->getApp();
+        }
+
+        $menu = new Horde_Menu();
+        $registry->callAppMethod($app, 'menu', [
+            'args' => [$menu],
+        ]);
+        $sidebar = $menu->render();
+        $registry->callAppMethod($app, 'sidebar', [
+            'args' => [$sidebar],
+        ]);
+
+        return $sidebar;
+    }
+
+    /**
+     * Process a permission denied error, running a user-defined hook if
+     * necessary.
+     */
+    public static function permissionDeniedError(
+        string $app,
+        string $perm,
+        ?string $error = null,
+    ): void {
+        try {
+            $GLOBALS['injector']->getInstance('Horde_Core_Hooks')
+                ->callHook('perms_denied', 'horde', [$app, $perm]);
+        } catch (Horde_Exception_HookNotSet $e) {
+        }
+
+        if ($error !== null) {
+            $GLOBALS['notification']->push($error, 'horde.warning');
+        }
+    }
+}

--- a/src/Horde.php
+++ b/src/Horde.php
@@ -11,34 +11,35 @@ declare(strict_types=1);
 
 namespace Horde\Core;
 
-use Horde_Array;
-use Horde_Auth;
-use Horde_Browser;
-use Horde_Cache;
+use Horde\Exception\HordeException;
+use Horde\Log\Handler\BufferHandler;
+use Horde\Log\Handler\StreamHandler;
+use Horde\Log\Handler\SystemdJournalHandler;
+use Horde\Log\Handler\SystemdJournalOptions;
+use Horde\Log\Logger;
+use Horde\Log\LogLevel;
+use Horde\Log\LogMessage;
+use Horde\Support\Backtrace;
+use Horde\Url\Url;
+use Horde\Util\ArrayUtils;
+use Horde\Util\HordeString;
+use Horde\Util\StringTransliterate;
+use Horde\Util\Util;
 use Horde_Core_Factory_Logger;
 use Horde_Core_Hooks;
-use Horde_Core_HordeMap;
 use Horde_Core_Log_Object;
 use Horde_Core_Script_Package_Popup;
 use Horde_Core_Translation;
-use Horde_Exception;
 use Horde_Exception_HookNotSet;
-use Horde_Log;
-use Horde_Log_Handler_Stream;
-use Horde_Log_Logger;
 use Horde_Menu;
-use Horde_Registry;
 use Horde_Serialize;
 use Horde_Session;
-use Horde_String;
-use Horde_String_Transliterate;
-use Horde_Support_Backtrace;
-use Horde_Url;
-use Horde_Util;
-use Horde_Variables;
 use Horde_View_Sidebar;
 use Stringable;
 use stdClass;
+use Exception;
+use PEAR_Error;
+use Throwable;
 
 /**
  * Provides the base functionality shared by all Horde applications.
@@ -85,9 +86,17 @@ class Horde
     protected static array $_used = [];
 
     /**
+     * Pre-init log buffer for messages received before the logger is ready.
+     */
+    private static ?BufferHandler $_logBuffer = null;
+
+    /**
      * Shortcut to logging method.
      *
-     * @see Horde_Core_Log_Logger
+     * Uses the PSR-3 Horde\Log\Logger as primary target. Falls back to the
+     * legacy Horde_Core_Log_Logger if the PSR-4 logger is unavailable.
+     * Messages received before the framework is initialized are buffered
+     * in a BufferHandler and drained on the first post-init call.
      */
     public static function log(
         mixed $event,
@@ -97,21 +106,208 @@ class Horde
         $options['trace'] = isset($options['trace'])
             ? ($options['trace'] + 1)
             : 1;
-        $log_ob = new Horde_Core_Log_Object($event, $priority, $options);
 
-        /* Chicken/egg: we must wait until we have basic framework setup
-         * before we can start logging. Otherwise, queue entries. */
+        [$message, $resolvedPriority, $context] = self::buildLogPayload(
+            $event,
+            $priority,
+            $options,
+        );
+
+        // Skip already-logged HordeException events.
+        if ($message === null) {
+            return;
+        }
+
         if (isset($GLOBALS['injector'])
             && Horde_Core_Factory_Logger::available()) {
+            try {
+                $logger = $GLOBALS['injector']->getInstance(Logger::class);
+                self::drainBuffer($logger);
+                $logger->log($resolvedPriority, $message, $context);
+                return;
+            } catch (Throwable $e) {
+                // PSR-4 logger unavailable — fall through to legacy.
+            }
+            // Legacy fallback.
+            $log_ob = new Horde_Core_Log_Object($event, $priority, $options);
             $GLOBALS['injector']->getInstance('Horde_Log_Logger')->logObject($log_ob);
         } else {
-            Horde_Core_Factory_Logger::queue($log_ob);
+            // Framework not yet initialized — buffer for later.
+            self::bufferLog($resolvedPriority, $message, $context);
         }
     }
 
     /**
+     * Build a log payload from the event, replicating the message formatting
+     * logic of Horde_Core_Log_Object.
+     *
+     * @return array{0: ?string, 1: int, 2: array}  [message, priority, context]
+     *         Message is null if the event was already logged (dedup).
+     */
+    private static function buildLogPayload(
+        mixed $event,
+        ?int $priority,
+        array $options,
+    ): array {
+        $context = [];
+        $text = null;
+        $trace = null;
+
+        if (is_array($event)) {
+            if (isset($event['level'])) {
+                $priority = $event['level'];
+            }
+            $text = $event['message'] ?? '';
+            if (isset($event['timestamp'])) {
+                $context['timestamp'] = $event['timestamp'];
+            }
+        } elseif ($event instanceof Exception) {
+            if ($priority === null) {
+                $priority = 3; // ERR
+            }
+
+            if ($event instanceof HordeException) {
+                if ($event->logged) {
+                    return [null, $priority, []];
+                }
+                if ($loglevel = $event->getLogLevel()) {
+                    $priority = $loglevel;
+                }
+            }
+
+            $text = $event->getMessage();
+            if (!empty($event->details)) {
+                $text .= ' ' . $event->details;
+            }
+            $trace = [
+                'file' => $event->getFile(),
+                'line' => $event->getLine(),
+            ];
+
+            if (empty($options['notracelog'])
+                && class_exists(Backtrace::class)) {
+                $context['backtrace'] = strval(new Backtrace($event));
+            }
+        } elseif ($event instanceof PEAR_Error) {
+            if ($priority === null) {
+                $priority = 3; // ERR
+            }
+            $userinfo = $event->getUserInfo();
+            $text = $event->getMessage();
+            if (!empty($userinfo)) {
+                if (is_array($userinfo)) {
+                    $userinfo = @implode(', ', $userinfo);
+                }
+                $text .= ': ' . $userinfo;
+            }
+        } elseif (is_object($event)) {
+            $text = strval($event);
+            if (!is_string($text)) {
+                $text = is_callable([$event, 'getMessage'])
+                    ? $event->getMessage()
+                    : '';
+            }
+        } else {
+            $text = (string) $event;
+        }
+
+        // Resolve caller location from backtrace if not from an exception.
+        if ($trace === null && !is_array($event)) {
+            $bt = debug_backtrace();
+            $bt_count = count($bt);
+            $frame = isset($options['trace'])
+                ? min($bt_count, $options['trace'])
+                : 0;
+            while ($frame < $bt_count) {
+                if (isset($bt[$frame]['class'])) {
+                    if (!in_array($bt[$frame]['class'], [
+                        self::class,
+                        'Horde',
+                        'Horde_Log_Logger',
+                        'Horde_Core_Log_Logger',
+                    ])) {
+                        break;
+                    }
+                } elseif (isset($bt[$frame]['function'])
+                          && !in_array($bt[$frame]['function'], [
+                              'call_user_func',
+                              'call_user_func_array',
+                          ])) {
+                    break;
+                }
+                ++$frame;
+            }
+            if (isset($bt[$frame])) {
+                $trace = $bt[$frame];
+            }
+        }
+
+        // Default priority: INFO (6).
+        $priority ??= 6;
+
+        // Build the formatted message with app prefix and location suffix.
+        $app = isset($GLOBALS['registry'])
+            ? $GLOBALS['registry']->getApp()
+            : 'horde';
+
+        $message = ($app ? '[' . $app . '] ' : '') . $text . ' [pid ' . getmypid();
+
+        if (isset($options['file']) || isset($trace['file'])) {
+            $file = $options['file'] ?? $trace['file'];
+            $line = $options['line'] ?? ($trace['line'] ?? '');
+            $message .= ' on line ' . $line . ' of "' . $file . '"]';
+        } else {
+            $message .= ']';
+        }
+
+        return [$message, $priority, $context];
+    }
+
+    /**
+     * Buffer a log message for replay once the logger is available.
+     */
+    private static function bufferLog(int $priority, string $message, array $context): void
+    {
+        if (self::$_logBuffer === null) {
+            self::$_logBuffer = new BufferHandler();
+        }
+        $level = new LogLevel($priority, self::priorityName($priority));
+        $logMessage = new LogMessage($level, $message, $context);
+        self::$_logBuffer->log($logMessage);
+    }
+
+    /**
+     * Drain buffered pre-init messages into the given logger.
+     */
+    private static function drainBuffer(Logger $logger): void
+    {
+        if (self::$_logBuffer !== null && self::$_logBuffer->count() > 0) {
+            self::$_logBuffer->drain($logger);
+            self::$_logBuffer = null;
+        }
+    }
+
+    /**
+     * Map numeric priority to PSR-3 level name.
+     */
+    private static function priorityName(int $priority): string
+    {
+        return match ($priority) {
+            0 => 'emergency',
+            1 => 'alert',
+            2 => 'critical',
+            3 => 'error',
+            4 => 'warning',
+            5 => 'notice',
+            6 => 'info',
+            7 => 'debug',
+            default => 'info',
+        };
+    }
+
+    /**
      * Debug method.  Allows quick shortcut to produce debug output into a
-     * temporary file.
+     * temporary file and optionally the systemd journal.
      */
     public static function debug(
         mixed $event = null,
@@ -122,11 +318,30 @@ class Horde
             $fname = self::getTempDir() . '/horde_debug.txt';
         }
 
+        $handlers = [];
+
         try {
-            $logger = new Horde_Log_Logger(new Horde_Log_Handler_Stream($fname));
-        } catch (\Exception $e) {
+            $handlers[] = new StreamHandler($fname);
+        } catch (Exception $e) {
+            // Stream not writable — continue, journal may still work.
+        }
+
+        try {
+            $journalOpts = new SystemdJournalOptions();
+            $journalOpts->ident = 'horde-debug';
+            $journalHandler = new SystemdJournalHandler($journalOpts);
+            if ($journalHandler->isAvailable()) {
+                $handlers[] = $journalHandler;
+            }
+        } catch (Throwable $e) {
+            // Journal not available — ignore.
+        }
+
+        if (empty($handlers)) {
             return;
         }
+
+        $logger = new Logger($handlers);
 
         $html_ini = ini_set('html_errors', 'Off');
         self::startBuffer();
@@ -145,22 +360,22 @@ class Horde
 
         if ($backtrace) {
             echo "Backtrace:\n";
-            echo strval(new Horde_Support_Backtrace());
+            echo strval(new Backtrace());
         }
 
-        $logger->log(self::endBuffer(), Horde_Log::DEBUG);
+        $logger->debug(self::endBuffer());
         ini_set('html_errors', $html_ini);
     }
 
     /**
      * Adds a signature + timestamp to a URL and returns the signed URL.
      *
-     * @param string|Horde_Url $url  The URL to sign.
+     * @param string|Url $url  The URL to sign.
      * @param int|null $now          The timestamp at which to sign.
      *
-     * @return string|Horde_Url  The signed URL.
+     * @return string|Url  The signed URL.
      */
-    public static function signUrl(string|Horde_Url $url, ?int $now = null): string|Horde_Url
+    public static function signUrl(string|Url $url, ?int $now = null): string|Url
     {
         global $conf;
 
@@ -172,11 +387,11 @@ class Horde
             $now = time();
         }
 
-        if ($url instanceof Horde_Url) {
+        if ($url instanceof Url) {
             $url->setRaw(true)->add(['_t' => $now, '_h' => '']);
             $url->add(
                 '_h',
-                Horde_Url::uriB64Encode(
+                Url::uriB64Encode(
                     hash_hmac('sha1', $url . '=', $conf['secret_key'], true)
                 )
             );
@@ -193,7 +408,7 @@ class Horde
             $url .= '?';
         }
         $url .= '_t=' . $now . '&_h=';
-        $url .= Horde_Url::uriB64Encode(
+        $url .= Url::uriB64Encode(
             hash_hmac('sha1', $url, $conf['secret_key'], true)
         );
 
@@ -223,7 +438,7 @@ class Horde
         $url = substr($data, 0, $pos);
         $hmac = substr($data, $pos);
 
-        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $url, $conf['secret_key'], true))) {
+        if ($hmac != Url::uriB64Encode(hash_hmac('sha1', $url, $conf['secret_key'], true))) {
             return false;
         }
 
@@ -248,12 +463,12 @@ class Horde
      * Adds a signature + timestamp to a query string and returns the signed
      * query string.
      *
-     * @return string|Horde_Url  The signed query string (or Horde_Url object).
+     * @return string|Url  The signed query string (or Url object).
      */
     public static function signQueryString(
-        string|Horde_Url $queryString,
+        string|Url $queryString,
         ?int $now = null,
-    ): string|Horde_Url {
+    ): string|Url {
         if (!isset($GLOBALS['conf']['secret_key'])) {
             return $queryString;
         }
@@ -262,16 +477,16 @@ class Horde
             $now = time();
         }
 
-        if ($queryString instanceof Horde_Url) {
+        if ($queryString instanceof Url) {
             $queryString->setRaw(true)->add(['_t' => $now, '_h' => '']);
             $query = parse_url((string) $queryString, PHP_URL_QUERY);
-            $queryString->add('_h', Horde_Url::uriB64Encode(hash_hmac('sha1', $query . '=', $GLOBALS['conf']['secret_key'], true)));
+            $queryString->add('_h', Url::uriB64Encode(hash_hmac('sha1', $query . '=', $GLOBALS['conf']['secret_key'], true)));
             return $queryString;
         }
 
         $queryString .= '&_t=' . $now . '&_h=';
 
-        return $queryString . Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true));
+        return $queryString . Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true));
     }
 
     /**
@@ -292,7 +507,7 @@ class Horde
         $queryString = substr($data, 0, $pos);
         $hmac = substr($data, $pos);
 
-        if ($hmac != Horde_Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true))) {
+        if ($hmac != Url::uriB64Encode(hash_hmac('sha1', $queryString, $GLOBALS['conf']['secret_key'], true))) {
             return false;
         }
 
@@ -355,12 +570,12 @@ class Horde
     /**
      * Throws an exception if not using a secure connection.
      *
-     * @throws Horde_Exception
+     * @throws HordeException
      */
     public static function requireSecureConnection(): void
     {
         if (!self::isConnectionSecure()) {
-            throw new Horde_Exception(Horde_Core_Translation::t('The encryption features require a secure web connection.'));
+            throw new HordeException(Horde_Core_Translation::t('The encryption features require a secure web connection.'));
         }
     }
 
@@ -379,11 +594,11 @@ class Horde
         global $conf;
 
         if ($type !== null) {
-            $type = Horde_String::lower($type);
+            $type = HordeString::lower($type);
         }
 
         if (is_array($backend)) {
-            $c = Horde_Array::getElement($conf, $backend);
+            $c = ArrayUtils::getElement($conf, $backend);
         } elseif (isset($conf[$backend])) {
             $c = $conf[$backend];
         } else {
@@ -420,7 +635,7 @@ class Horde
      * are set and throws a fatal error with a detailed explanation
      * how to fix this, if something is missing.
      *
-     * @throws Horde_Exception
+     * @throws HordeException
      */
     public static function assertDriverConfig(
         array $params,
@@ -438,7 +653,7 @@ class Horde
         $fileroot = isset($registry) ? $registry->get('fileroot') : '';
 
         if (!count($params)) {
-            throw new Horde_Exception(
+            throw new HordeException(
                 sprintf(Horde_Core_Translation::t('No configuration information specified for %s.'), $name) . "\n\n"
                 . sprintf(
                     Horde_Core_Translation::t('The file %s should contain some %s settings.'),
@@ -450,7 +665,7 @@ class Horde
 
         foreach ($fields as $field) {
             if (!isset($params[$field])) {
-                throw new Horde_Exception(
+                throw new HordeException(
                     sprintf(Horde_Core_Translation::t('Required "%s" not specified in %s configuration.'), $field, $name) . "\n\n"
                     . sprintf(
                         Horde_Core_Translation::t('The file %s should contain a %s setting.'),
@@ -473,7 +688,7 @@ class Horde
         string|Stringable $uri,
         bool $full = false,
         array|int $opts = [],
-    ): Horde_Url {
+    ): Url {
         if (is_array($opts)) {
             $append_session = $opts['append_session'] ?? 0;
             if (!empty($opts['force_ssl'])) {
@@ -581,7 +796,7 @@ class Horde
             $url .= '#' . $puri['fragment'];
         }
 
-        $ob = new Horde_Url($url, $full);
+        $ob = new Url($url, $full);
 
         if (empty($GLOBALS['conf']['session']['use_only_cookies'])
             && ($append_session === 1
@@ -599,8 +814,8 @@ class Horde
     public static function externalUrl(string $url, bool $tag = false): string
     {
         if (!isset($_GET[session_name()])
-            || Horde_String::substr($url, 0, 1) == '#'
-            || Horde_String::substr($url, 0, 7) == 'mailto:') {
+            || HordeString::substr($url, 0, 1) == '#'
+            || HordeString::substr($url, 0, 7) == 'mailto:') {
             $ext = $url;
         } else {
             $ext = (string) self::signQueryString($GLOBALS['registry']->getServiceLink('go', 'horde')->add('url', $url));
@@ -616,7 +831,7 @@ class Horde
     /**
      * Returns an anchor tag with the relevant parameters.
      *
-     * @param Horde_Url|string $url  The full URL to be linked to.
+     * @param Url|string $url  The full URL to be linked to.
      * @param string $title          The link title/description.
      * @param string $class          The CSS class of the link.
      * @param string $target         The window target to point to.
@@ -630,7 +845,7 @@ class Horde
      * @return string  The full <a href> tag.
      */
     public static function link(
-        Horde_Url|string $url = '',
+        Url|string $url = '',
         string $title = '',
         string $class = '',
         string $target = '',
@@ -639,8 +854,8 @@ class Horde
         array $attributes = [],
         bool $escape = true,
     ): string {
-        if (!($url instanceof Horde_Url)) {
-            $url = new Horde_Url($url);
+        if (!($url instanceof Url)) {
+            $url = new Url($url);
         }
 
         if (!empty($onclick)) {
@@ -677,7 +892,7 @@ class Horde
      * @return string  The full <a href> tag.
      */
     public static function linkTooltip(
-        Horde_Url|string $url,
+        Url|string $url,
         string $status = '',
         string $class = '',
         string $target = '',
@@ -729,9 +944,9 @@ class Horde
             $params
         );
 
-        $url = ($params['url'] instanceof Horde_Url)
+        $url = ($params['url'] instanceof Url)
             ? $params['url']
-            : new Horde_Url($params['url']);
+            : new Url($params['url']);
         $title = $params['title'];
         $params['accesskey'] = self::getAccessKey($title, $params['nocheck']);
 
@@ -750,7 +965,7 @@ class Horde
         bool $nocache = true,
         bool $full = false,
         bool $force_ssl = false,
-    ): Horde_Url {
+    ): Url {
         if (!strncmp(PHP_SAPI, 'cgi', 3)) {
             $url = $_SERVER['PHP_SELF'];
         } else {
@@ -758,15 +973,15 @@ class Horde
                 ?? $_SERVER['PHP_SELF'];
         }
         if (isset($_SERVER['REQUEST_URI'])) {
-            $url = Horde_String::common($_SERVER['REQUEST_URI'], $url);
+            $url = HordeString::common($_SERVER['REQUEST_URI'], $url);
         }
         if (substr($url, -9) == 'index.php') {
             $url = substr($url, 0, -9);
         }
 
         if ($script_params) {
-            $url = new Horde_Url($url);
-            if ($pathInfo = Horde_Util::getPathInfo()) {
+            $url = new Url($url);
+            if ($pathInfo = Util::getPathInfo()) {
                 $url->pathInfo = ltrim((string) $pathInfo, '/');
             }
             if (!empty($_SERVER['QUERY_STRING'])) {
@@ -786,7 +1001,7 @@ class Horde
      * Create a self URL of the current page, building the parameter list from
      * the current Horde_Variables object.
      */
-    public static function selfUrlParams(array $opts = []): Horde_Url
+    public static function selfUrlParams(array $opts = []): Url
     {
         $vars = $opts['vars']
             ?? $GLOBALS['injector']->createInstance('Horde_Variables');
@@ -847,7 +1062,7 @@ class Horde
         if (empty($dir) || !is_dir($dir)) {
             $dir = self::getTempDir();
         }
-        $tmpfile = Horde_Util::getTempFile($prefix, $delete, $dir, $secure);
+        $tmpfile = Util::getTempFile($prefix, $delete, $dir, $secure);
         if ($session_remove) {
             $gcfiles = $GLOBALS['session']->get('horde', 'gc_tempfiles', Horde_Session::TYPE_ARRAY);
             $gcfiles[] = $tmpfile;
@@ -915,7 +1130,7 @@ class Horde
             || !preg_match('/_(\w)/u', $label, $match)) {
             return '';
         }
-        $key = Horde_String_Transliterate::toAscii($match[1]);
+        $key = StringTransliterate::toAscii($match[1]);
 
         /* Has this key already been used? */
         if (isset(self::$_used[strtolower($key)])
@@ -1030,7 +1245,7 @@ class Horde
      * @param string $type   The cache type ('app', 'css', 'js').
      * @param array $params  Optional parameters.
      */
-    public static function getCacheUrl(string $type, array $params = []): Horde_Url
+    public static function getCacheUrl(string $type, array $params = []): Url
     {
         $url = $GLOBALS['registry']
             ->getserviceLink('cache', 'horde')
@@ -1045,19 +1260,19 @@ class Horde
     /**
      * Output the javascript needed to call the popup JS function.
      *
-     * @param string|Horde_Url $url  The page to load.
+     * @param string|Url $url  The page to load.
      * @param array $options         Additional options.
      *
      * @return string  The javascript needed to call the popup code.
      */
-    public static function popupJs(string|Horde_Url $url, array $options = []): string
+    public static function popupJs(string|Url $url, array $options = []): string
     {
         $GLOBALS['page_output']->addScriptPackage('Horde_Core_Script_Package_Popup');
 
         $params = new stdClass();
 
-        if (!$url instanceof Horde_Url) {
-            $url = new Horde_Url($url);
+        if (!$url instanceof Url) {
+            $url = new Url($url);
         }
         $params->url = $url->url;
 

--- a/test/Unit/HordeTest.php
+++ b/test/Unit/HordeTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL
+ * @package   Core
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Core\Test\Unit;
+
+use Horde\Core\Horde;
+use Horde\Log\Handler\BufferHandler;
+use Horde\Log\Logger;
+use Horde\Test\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Horde_Core_Factory_Logger;
+use Horde_Injector;
+use Horde_Registry;
+use ReflectionClass;
+use Horde_Core_Log_Logger;
+use Horde_Exception;
+use RuntimeException;
+use Stringable;
+
+/**
+ * Unit tests for Horde\Core\Horde::log() and related methods.
+ *
+ * @category  Horde
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL
+ * @package   Core
+ * @subpackage UnitTests
+ */
+#[CoversClass(Horde::class)]
+class HordeTest extends TestCase
+{
+    /**
+     * BufferHandler wired into the PSR-3 logger to capture output.
+     */
+    private BufferHandler $buffer;
+
+    /**
+     * PSR-3 logger with a BufferHandler for assertions.
+     */
+    private Logger $logger;
+
+    protected function setUp(): void
+    {
+        $this->buffer = new BufferHandler();
+        $this->logger = new Logger([$this->buffer]);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $GLOBALS['injector'],
+            $GLOBALS['registry'],
+            $GLOBALS['conf'],
+        );
+
+        // Reset the private static $_logBuffer between tests.
+        $ref = new ReflectionClass(Horde::class);
+        $prop = $ref->getProperty('_logBuffer');
+        $prop->setValue(null, null);
+    }
+
+    /**
+     * Wire up $GLOBALS so that Horde_Core_Factory_Logger::available()
+     * returns true and the injector provides our BufferHandler-backed
+     * Logger for the PSR-4 path.
+     */
+    private function setUpInjectorWithLogger(): void
+    {
+        $registry = $this->createStub(Horde_Registry::class);
+        $registry->hordeInit = true;
+        $registry->method('getApp')->willReturn('test');
+
+        $injector = $this->createStub(Horde_Injector::class);
+        $injector->method('getInstance')
+            ->willReturnCallback(function (string $class) {
+                if ($class === Logger::class) {
+                    return $this->logger;
+                }
+                throw new Horde_Exception('Not configured: ' . $class);
+            });
+
+        $GLOBALS['registry'] = $registry;
+        $GLOBALS['injector'] = $injector;
+    }
+
+    /**
+     * Set up globals that make available() true but the PSR-4 logger
+     * throws, forcing the legacy fallback path.
+     */
+    private function setUpInjectorLegacyFallback(object $legacyLogger): void
+    {
+        $registry = $this->createStub(Horde_Registry::class);
+        $registry->hordeInit = true;
+        $registry->method('getApp')->willReturn('test');
+
+        $injector = $this->createStub(Horde_Injector::class);
+        $injector->method('getInstance')
+            ->willReturnCallback(function (string $class) use ($legacyLogger) {
+                if ($class === Logger::class) {
+                    throw new Horde_Exception('PSR-4 logger not available');
+                }
+                if ($class === 'Horde_Log_Logger') {
+                    return $legacyLogger;
+                }
+                throw new Horde_Exception('Not configured: ' . $class);
+            });
+
+        $GLOBALS['registry'] = $registry;
+        $GLOBALS['injector'] = $injector;
+    }
+
+    // ---------------------------------------------------------------
+    // PSR-3 primary path
+    // ---------------------------------------------------------------
+
+    public function testLogStringMessageToPsr3Logger(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        Horde::log('Hello world');
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+
+    public function testLogMessageContainsAppPrefix(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        Horde::log('Something happened');
+
+        // Drain buffer to inspect the message via a second buffer.
+        $inspection = new BufferHandler();
+        $inspectionLogger = new Logger([$inspection]);
+        $this->buffer->drain($inspectionLogger);
+
+        // The drain replays through the logger, which re-creates
+        // LogMessage objects.  We can't directly read messages from
+        // BufferHandler, but we know the count went up.
+        $this->assertSame(1, $inspection->count());
+    }
+
+    public function testLogWithExplicitPriority(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        // Priority 4 = WARNING
+        Horde::log('Disk space low', 4);
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+
+    public function testLogExceptionEvent(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        Horde::log(new RuntimeException('Something broke'));
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+
+    public function testLogHordeExceptionDedup(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        $exception = new \Horde\Exception\HordeException('Already logged');
+        $exception->logged = true;
+
+        Horde::log($exception);
+
+        // Should be skipped due to dedup.
+        $this->assertSame(0, $this->buffer->count());
+    }
+
+    public function testLogArrayEvent(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        Horde::log([
+            'level' => 5,
+            'message' => 'Array message',
+            'timestamp' => time(),
+        ]);
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+
+    public function testLogStringableObject(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        $obj = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'Stringable event';
+            }
+        };
+
+        Horde::log($obj);
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+
+    // ---------------------------------------------------------------
+    // Legacy fallback path
+    // ---------------------------------------------------------------
+
+    public function testLegacyFallbackWhenPsr4Throws(): void
+    {
+        $legacyLogger = $this->getMockSkipConstructor(Horde_Core_Log_Logger::class);
+        $legacyLogger->expects($this->once())
+            ->method('logObject');
+
+        $this->setUpInjectorLegacyFallback($legacyLogger);
+
+        Horde::log('Fallback message');
+
+        // PSR-4 buffer should be empty — message went to legacy.
+        $this->assertSame(0, $this->buffer->count());
+    }
+
+    // ---------------------------------------------------------------
+    // Pre-init buffering
+    // ---------------------------------------------------------------
+
+    public function testPreInitMessagesAreBuffered(): void
+    {
+        // No injector/registry set — simulates early bootstrap.
+        unset($GLOBALS['injector'], $GLOBALS['registry']);
+
+        Horde::log('Early boot message');
+        Horde::log('Another early message');
+
+        // Messages are in the internal buffer — nothing exploded.
+        // Now wire up the logger and send another message to trigger drain.
+        $this->setUpInjectorWithLogger();
+        Horde::log('Post-init message');
+
+        // All 3 messages should have reached the PSR-3 logger:
+        // 2 buffered + 1 direct.
+        $this->assertSame(3, $this->buffer->count());
+    }
+
+    public function testBufferDrainsOnFirstPostInitLog(): void
+    {
+        unset($GLOBALS['injector'], $GLOBALS['registry']);
+
+        Horde::log('Buffered');
+
+        $this->setUpInjectorWithLogger();
+        Horde::log('First post-init');
+
+        $this->assertSame(2, $this->buffer->count());
+
+        // Second call should not re-drain.
+        Horde::log('Second post-init');
+        $this->assertSame(3, $this->buffer->count());
+    }
+
+    // ---------------------------------------------------------------
+    // priorityName() via buildLogPayload (indirect)
+    // ---------------------------------------------------------------
+
+    public function testDefaultPriorityIsInfo(): void
+    {
+        $this->setUpInjectorWithLogger();
+
+        // No priority specified — should default to INFO (6).
+        Horde::log('Default priority');
+
+        $this->assertSame(1, $this->buffer->count());
+    }
+}


### PR DESCRIPTION
Solve multiple Null Safety issues.
Provide a type-safe equivalent of the Horde:: static class.
For most methods this is a straight conversion with types.
The Horde::log and Horde::debug methods now use the PSR-3 loggers instead of the classic loggers.
Make old Horde:: delegate to modern equivalent for most straight-forward cases.

- **fix: Various null safety and type compatibility issues**
- **feat: Add a PSR-4 equivalent of the Horde:: class but without support for Horde_Deprecated**
- **refactor: Delegate most methods of Horde:: to Horde\Core\Horde typed alternative**
- **test: Cover Horde\Core\Horde class with tests**
