### PR TITLE
Fix setlocale to match requested type

### DIFF
--- a/lib/Horde/Registry/Nlsconfig.php
+++ b/lib/Horde/Registry/Nlsconfig.php
@@ -128,7 +128,7 @@ class Horde_Registry_Nlsconfig
         if (!$GLOBALS['session']->exists('horde', 'nls/valid_' . $lang)) {
             $valid = false;
             if (isset($this->languages[$lang])) {
-                $locale = setlocale(LC_ALL, 0);
+                $locale = setlocale(LC_ALL, '0');
                 if (setlocale(LC_ALL, $lang . '.UTF-8')) {
                     $valid = true;
                 }


### PR DESCRIPTION
This will fix setlocale to accept the proper type.

Changed: $locale = setlocale(LC_ALL, 0);
to: $locale = setlocale(LC_ALL, '0');

will change it to null if preferred.

Going to do this for horde/date, horde/util, horde/autoloader as well.

@ralflang , @TDannhauer 