### PR TITLE
Fix authentication username check in versionCallback

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3229,7 +3229,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     public function versionCallback(Horde_ActiveSync $server)
     {
         $credentials = new Horde_ActiveSync_Credentials($server);
-        $authUsername = !empty($credentials->username)
+        $authUsername = ($credentials->username !== false && $credentials->username !== '')
             ? (string) $credentials->username
             : null;
         if ($authUsername === null) {


### PR DESCRIPTION
Fix per-user ActiveSync EAS version permissions in versionCallback()
Summary
Per-user horde:activesync:version permissions did not raise the server’s advertised EAS ceiling when the global conf['activesync']['version'] was lower. Clients kept negotiating the global maximum (for example 14.1) even when a user or group was allowed a higher version (for example 16.0).

Problem
Horde_Core_ActiveSync_Driver::versionCallback() runs before authentication on each ActiveSync request. It should read the client username from Horde_ActiveSync_Credentials, resolve horde:activesync:version for that principal, and call Horde_ActiveSync::setSupportedVersion() when a valid permission is present.

In practice the override was skipped on authenticated requests. The server stayed on the global default, so MS-ASProtocolVersions and related negotiation did not reflect per-user permissions.

Root cause
versionCallback() used !empty($credentials->username) to detect a Basic-auth username. Horde_ActiveSync_Credentials exposes username via __get() and does not implement __isset(). For magic properties, PHP’s empty() does not invoke __get() in this situation, so a valid username was treated as missing.

The method then fell back to getUser(), which is still empty before authenticate() completes. The callback returned early and never applied the permission-based ceiling.

Solution
Read the credential username explicitly instead of using empty() on the magic property:

Treat false as “no username provided” (existing __get() sentinel).
Treat an empty string the same way.
Otherwise cast the username to string and continue with the existing permission resolution and setSupportedVersion() path.
No change to permission storage, global defaults, or client-side version selection.