### PR TITLE
Fix/logout in smartmobile view

### DIFF
--- a/lib/Horde/Core/Smartmobile/View/Helper.php
+++ b/lib/Horde/Core/Smartmobile/View/Helper.php
@@ -60,10 +60,11 @@ class Horde_Core_Smartmobile_View_Helper extends Horde_View_Helper_Base
         }
 
         if (!empty($params['logout']) && $registry->showService('logout')) {
-            // Use modern logout endpoint (no token required)
-            $logout = $registry->get('webroot', 'horde') . '/auth/logout';
+            $logout = $registry->getLogoutUrl([
+                'reason' => Horde_Auth::REASON_LOGOUT,
+            ])->setRaw(false);
             $out .= '<a class="smartmobile-logout ui-btn-right" href="'
-                . htmlspecialchars($logout)
+                . htmlspecialchars((string) $logout)
                 . '" data-ajax="false" data-theme="e" data-icon="delete">'
                 . Horde_Core_Translation::t('Log out') . '</a>';
         }

--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -620,7 +620,7 @@ class Horde_PageOutput
                 $this->addInlineJsVars([
                     'HordeMobile.conf' => [
                         'ajax_url' => $registry->getServiceLink('ajax', $registry->getApp())->url,
-                        'logout_url' => $registry->get('webroot', 'horde') . '/auth/logout',
+                        'logout_url' => strval($registry->getServiceLink('logout')),
                         'sid' => SID,
                         'token' => $session->getToken(),
                     ],

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -2330,7 +2330,7 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function currentProcessAuth()
     {
-        return ($this->_args['authentication'] !== 'none');
+        return (($this->_args['authentication'] ?? null) !== 'none');
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix smartmobile logout errors by using the same logout URL as dynamic view, and harden `Registry::currentProcessAuth()` during session teardown.

## Problem

Logging out from **smartmobile** produced errors that did not appear (or were much rarer) from **dynamic view**:

- IMP identity / IMAP errors during `clearAuth()`
- Ingo calling `mail/imapOb` when IMP was unavailable
- `PHP ERROR: Undefined array key "authentication"` in `Horde_Registry::currentProcessAuth()`

**Root cause (smartmobile-specific):** Dynamic view uses `Registry::getLogoutUrl()` → `login.php` with `logout_reason` and CSRF token. Smartmobile used a hardcoded `/auth/logout` endpoint (header link and `HordeMobile.conf.logout_url`). That path runs through PSR middleware with `authentication => 'none'` and triggers application `logout()` handlers in a context where IMP and related APIs are not reliably available.

## Solution

1. **Unify smartmobile logout URLs** with the established `getLogoutUrl()` / `getServiceLink('logout')` flow (same as dynamic topbar and `hordecore.js`).
2. **Harden `currentProcessAuth()`** so missing `_args['authentication']` does not emit PHP notices during teardown or concurrent requests.

## Changes

### `lib/Horde/Core/Smartmobile/View/Helper.php`

- Replace hardcoded `{webroot}/auth/logout` in the smartmobile header logout link with `getLogoutUrl(['reason' => Horde_Auth::REASON_LOGOUT])`.
- Ensures the visible “Log out” button uses `login.php` + CSRF token.

### `lib/Horde/PageOutput.php`

- Set `HordeMobile.conf.logout_url` to `getServiceLink('logout')` instead of `/auth/logout`.
- Ensures `HordeMobile.logout()` in JavaScript uses the same URL as the header.

### `lib/Horde/Registry.php`

- In `currentProcessAuth()`, use `($this->_args['authentication'] ?? null) !== 'none'` instead of direct array access.
- Prevents undefined index notices when `authentication` is not set on the registry instance.

## Test plan

- [ ] Log in and open an app in **smartmobile** view (e.g. IMP Folders, Ingo Rules).
- [ ] Click **Log out** in the header; confirm redirect to login without UI errors.
- [ ] Verify logout URL in page source / network tab points to `login.php` with `logout_reason` and `horde_logout_token`, not `/auth/logout`.
- [ ] Log out from **dynamic view**; confirm behavior unchanged.
- [ ] Check Horde logs after smartmobile logout; confirm reduction/absence of `Undefined array key "authentication"` for imp/gollem.
- [ ] Optional: trigger auth failure paths that call `HordeMobile.logout()` and confirm redirect uses `login.php` logout URL.

## Notes

- `/auth/logout` (`ResponsiveLogoutController`) remains for responsive/API routes; this PR only fixes smartmobile to use the proven `login.php` logout path.
- IMP-specific teardown hardening (`IMP_Application::logout()` try/catch) is a separate change in the **imp** repository.
- Site-local Ingo `transport_auth` hooks are deployment config, not part of this **core** PR.