### PR TITLE
Refactor route prefixing logic in RuntimeRoutesMapper

### DIFF
--- a/src/RuntimeRoutesMapper.php
+++ b/src/RuntimeRoutesMapper.php
@@ -131,30 +131,29 @@ class RuntimeRoutesMapper extends Mapper
     /**
      * Prefix secondary route paths with the current app webroot.
      *
-     * buildRoute() already prefixes the primary URI; secondary paths added via
-     * withSecondaryRoute() are app-relative and need the same prefix for
-     * routematch(). We build the RouteBuilder here, prefix secondary Route
-     * objects, and pass the final array to the parent.
+     * buildRoute() already prefixes the primary URI; withSecondaryRoute() paths
+     * are app-relative. Prefix them on the builder before build() so Route's
+     * match regex (built in the constructor) uses the full path.
      */
     public function addRoute(RouteBuilder|Route|array $routeOrBuilder): void
     {
-        if ($this->currentAppPrefix === '') {
-            parent::addRoute($routeOrBuilder);
-            return;
+        if ($routeOrBuilder instanceof RouteBuilder && $this->currentAppPrefix !== '') {
+            $routeOrBuilder->prefixSecondaryPaths($this->currentAppPrefix);
         }
 
-        if ($routeOrBuilder instanceof RouteBuilder) {
-            $routeOrBuilder = $routeOrBuilder->build();
+        parent::addRoute($routeOrBuilder);
+    }
+
+    /**
+     * Prefix legacy addSecondary() paths with the current app webroot.
+     */
+    public function addSecondary(string $path, string $namedRoute): void
+    {
+        if ($this->currentAppPrefix !== '') {
+            $path = $this->currentAppPrefix . '/' . ltrim($path, '/');
         }
 
-        $routes = is_array($routeOrBuilder) ? $routeOrBuilder : [$routeOrBuilder];
-        foreach ($routes as $route) {
-            if ($route->secondary && !str_starts_with($route->routePath, $this->currentAppPrefix)) {
-                $route->routePath = $this->currentAppPrefix . '/' . ltrim($route->routePath, '/');
-            }
-        }
-
-        parent::addRoute($routes);
+        parent::addSecondary($path, $namedRoute);
     }
 
     /**


### PR DESCRIPTION
Last Change was not effective. 
# Prefix secondary routes before Route build in RuntimeRoutesMapper

## Summary

Fix legacy secondary routes (e.g. `/horde/services/portal/smartmobile.php`) not matching under `RuntimeRoutesMapper` by prefixing secondary paths on the `RouteBuilder` before routes are built, instead of mutating `routePath` after build.

## Problem

### Symptom

After routing all apps through Rampage, requests to legacy smartmobile URLs return:

```text
No route matched: /horde/services/portal/smartmobile.php
```

### Configuration

The route is defined in `horde/config/routes.php` as a secondary path on `ResponsivePortal`:

```php
$mapper->buildRoute(uri: '/portal/', name: 'ResponsivePortal')
    ->withController(Portal\ResponsivePortalController::class)
    ->withDefaults(['HordeAuthType' => 'authenticate'])
    ->withMiddleware(DefaultStack::get())
    ->withSecondaryRoute('/services/portal/smartmobile.php')
    ->add();
```

Primary routes work (`/horde/portal/`) because `buildRoute()` prepends the app webroot before the `Route` object is created. Secondary paths stay app-relative unless handled explicitly.

## Root cause

A previous fix in `RuntimeRoutesMapper::addRoute()` built routes first, then updated `routePath` on secondary `Route` objects:

```php
$routeOrBuilder = $routeOrBuilder->build();
// ...
$route->routePath = $this->currentAppPrefix . '/' . ltrim($route->routePath, '/');
```

That updates the display path but not the match regex. `Horde\Routes\Route` builds `routeList` and `regexp` in the constructor from the path at build time. `createRegs()` does not rebuild them when `routePath` is changed later.

Result:

| Field | Value |
|-------|-------|
| `routePath` | `/horde/services/portal/smartmobile.php` (correct) |
| `regexp` | `^/services/portal/smartmobile\.php(/)?$` (wrong) |

Matching uses `regexp`, so the request never matches.

## Solution

Use the existing `RouteBuilder::prefixSecondaryPaths()` so secondary paths include the app webroot **before** `Route` construction:

- Override `addRoute()` to call `prefixSecondaryPaths($this->currentAppPrefix)` on the builder when `currentAppPrefix` is set, then delegate to `parent::addRoute()`.
- Override `addSecondary()` to prefix the path before calling `parent::addSecondary()` for legacy route definitions.

No changes to individual app `routes.php` files are required.

### Changed file

- `vendor/horde/core/src/RuntimeRoutesMapper.php`

## Affected URLs

All app-relative secondary routes loaded via `RuntimeRoutesMapper`, including:

- `/horde/services/portal/smartmobile.php` (Horde portal)
- `/{app}/smartmobile.php` and `/{app}/smartmobile` where defined (Nag, Turba, Ingo, Passwd, etc.)

## Test plan

- [ ] Deploy with this change
- [ ] Open `/horde/services/portal/smartmobile.php` while logged in — responsive portal loads (no “No route matched”)
- [ ] Open `/horde/portal/` — still works
- [ ] Spot-check other legacy smartmobile URLs (e.g. `/nag/smartmobile.php`, `/turba/smartmobile.php`)
- [ ] Optional CLI check:

```bash
php -r '
require "vendor/autoload.php";
use Horde\Core\Config\RegistryConfigLoader;
use Horde\Core\Config\Vhost;
use Horde\Core\RuntimeRoutesMapper;
use Horde\Http\ServerRequest;
define("HORDE_CONFIG_BASE", __DIR__ . "/var/config");
$rs = (new RegistryConfigLoader(HORDE_CONFIG_BASE, __DIR__, new Vhost()))->load();
$m = new RuntimeRoutesMapper($rs, new ServerRequest("GET", "http://localhost/horde/services/portal/smartmobile.php"));
$m->loadAllApps();
var_dump($m->routematch("/horde/services/portal/smartmobile.php") !== null);
'
```

Expected: `bool(true)`
