### PR TITLE
feat(mail): Factory_Mail: add smtp_credentials hook for XOAUTH2 and custom SMTP auth

### DIFF
--- a/lib/Horde/Core/Factory/Mail.php
+++ b/lib/Horde/Core/Factory/Mail.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright 2013-2026 Horde LLC (http://www.horde.org/)
  *
@@ -101,13 +100,42 @@ class Horde_Core_Factory_Mail extends Horde_Core_Factory_Base
          * running from CLI with 'user_admin' registry flag, which sets
          * the authentication name but not the credentials. */
         if (strcasecmp($transport, 'smtp') === 0) {
-            if ($registry->isAuthenticated()
-                && strlen((string) ($auth = $registry->getAuth()))) {
-                if (!empty($params['username_auth'])) {
-                    $params['username'] = $auth;
-                }
-                if (!empty($params['password_auth'])) {
-                    $params['password'] = $registry->getAuthCredential('password');
+            if ($registry->isAuthenticated() &&
+                strlen((string) ($auth = $registry->getAuth()))) {
+                /* Try to get SMTP credentials via hook (e.g. for XOAUTH2 support). */
+                try {
+                    $hooks = $this->_injector->getInstance('Horde_Core_Hooks');
+                    $smtp_creds = $hooks->callHook('smtp_credentials', 'horde', [$auth]);
+
+                    // Hook returned XOAUTH2 credentials
+                    if (isset($smtp_creds['xoauth2_token'])) {
+                        $params['xoauth2_token'] = $smtp_creds['xoauth2_token'];
+                        if (isset($smtp_creds['username'])) {
+                            $params['username'] = $smtp_creds['username'];
+                        }
+                        // Don't set password when using XOAUTH2
+                    } else {
+                        // Hook returned regular credentials
+                        if (isset($smtp_creds['username'])) {
+                            $params['username'] = $smtp_creds['username'];
+                        } elseif (!empty($params['username_auth'])) {
+                            $params['username'] = $auth;
+                        }
+
+                        if (isset($smtp_creds['password'])) {
+                            $params['password'] = $smtp_creds['password'];
+                        } elseif (!empty($params['password_auth'])) {
+                            $params['password'] = $registry->getAuthCredential('password');
+                        }
+                    }
+                } catch (Horde_Exception_HookNotSet $e) {
+                    // No hook defined, use default username/password
+                    if (!empty($params['username_auth'])) {
+                        $params['username'] = $auth;
+                    }
+                    if (!empty($params['password_auth'])) {
+                        $params['password'] = $registry->getAuthCredential('password');
+                    }
                 }
             }
 


### PR DESCRIPTION
  #### Summary                                                                    
                                                                                  
  This PR adds support for a new  smtp_credentials  hook in                       
   Horde_Core_Factory_Mail::getConfig() . The hook follows the same               
  pattern as the existing  imap_preauthenticate  and  transport_auth              
  hooks: it allows third-party code to inject custom SMTP credentials,            
  including  Horde_Smtp_Password_Xoauth2  objects for XOAUTH2                     
  authentication, without modifying core code.                                    
                                                                                  
  #### Context                                                                    
                                                                                  
  Horde's SMTP factory currently retrieves credentials exclusively from           
   $registry->getAuthCredential('password') . In OAuth2/OIDC deployments          
  no password is available — authentication uses bearer tokens. The SMTP          
  layer already supports XOAUTH2 via  Horde_Smtp_Password_Xoauth2                 
  (introduced in  horde/Smtp  1.3.0), but there is no way for external            
  code to inject a token into the factory without patching core.                  
                                                                                  
  This hook is a prerequisite for a forthcoming OIDC authentication driver        
  for Horde, which needs to supply a fresh XOAUTH2 token for every SMTP           
  connection. Without this hook, SMTP sending is broken in XOAUTH2-only           
  deployments. The hook is optional and strictly additive: installations          
  that do not define it continue to behave exactly as before.                     
                                                                                  
  #### Changes                                                                    
                                                                                  
   lib/Horde/Core/Factory/Mail.php  —  getConfig()  now calls the                 
   smtp_credentials  hook (via  Horde_Core_Hooks::callHook() ) when               
  building SMTP parameters for an authenticated user:                             
                                                                                  
  • If the hook returns  ['xoauth2_token' => $obj, 'username' => $user] ,         
  those values are set directly in  $params . No password is set,                 
  because  Horde_Smtp  selects XOAUTH2 when  xoauth2_token  is present.           
  • If the hook returns regular credentials ( username ,  password ),             
  those override the  username_auth / password_auth  defaults.                    
  • If the hook throws  Horde_Exception_HookNotSet  (hook not defined),           
  the existing  username_auth / password_auth  logic runs unchanged.              
  This is the only code path executed by installations that do not                
  define the hook.                                                                
                                                                                  
  #### Hook contract                                                              
                                                                                  
    /**                                                                           
     * Provide SMTP credentials for the authenticated user.                       
     *                                                                            
     * @param string $username  The authenticated Horde username.                 
     *                                                                            
     * @return array  One of:                                                     
     *   - XOAUTH2: ['xoauth2_token' => Horde_Smtp_Password_Xoauth2,              
     *               'username'      => string]                                   
     *   - Regular: ['username' => string, 'password' => string]                  
     *                                                                            
     * @throws Horde_Exception_HookNotSet  To fall back to default behaviour.     
     */                                                                           
    public function smtp_credentials(string $username): array                     
                                                                                  
  #### Backward compatibility                                                     
                                                                                  
  Strictly additive. The hook is called inside a  try/catch  for                  
   Horde_Exception_HookNotSet ; if the hook is absent or throws that              
  exception, the existing behaviour is preserved verbatim. No existing            
  configuration or hook file is affected.                                         
                                                                                  
  #### Tests                                                                      
                                                                                  
  No new unit tests in this PR. The hook call is a thin delegation; the           
  credential logic in the hook implementation is tested with the OIDC             
  driver.  Horde_Smtp_Password_Xoauth2  itself is tested in  horde/Smtp . 