### PR TITLE
Rename 'desc' key to 'description' in task info

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -1447,7 +1447,7 @@ class Horde_Core_ActiveSync_Connector
                 $info = [
                     'name' => $name,
                     'color' => $share->get('color'),
-                    'desc' => $share->get('desc'),
+                    'description' => $share->get('desc'),
                 ];
                 $this->_registry->tasks->updateTasklist($id, $info);
                 break;


### PR DESCRIPTION
aligned it to kronolith and the others to not break Exchange Active Sync (EAS)