### PR TITLE
fix: Strip default port from Url

### DIFF
--- a/src/Uri/RouteUrlWriter.php
+++ b/src/Uri/RouteUrlWriter.php
@@ -62,6 +62,10 @@ class RouteUrlWriter
             ? 'https'
             : 'http';
 
+        // Strip default port to avoid redirect_uri mismatches with strict OIDC providers.
+        $defaultPort = $scheme === 'https' ? '443' : '80';
+        $host = preg_replace('/^(.+):' . $defaultPort . '$/', '$1', $host);
+
         return $scheme . '://' . $host . $path;
     }
 


### PR DESCRIPTION
Strip default port from Url to avoid redirect_uri mismatches with strict OIDC providers.