### PR TITLE
Fix/misc

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -1422,11 +1422,15 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             $flags = $folder->flags();
             $categories = $folder->categories();
             foreach ($changes['modify'] as $uid) {
+                if (!isset($flags[$uid])) {
+                    continue;
+                }
+
                 $results[] = [
                     'id' => $uid,
                     'type' => Horde_ActiveSync::CHANGE_TYPE_FLAGS,
                     'flags' => $flags[$uid],
-                    'categories' => $categories[$uid],
+                    'categories' => $categories[$uid] ?? [],
                 ];
             }
         } else {

--- a/lib/Horde/Core/Prefs/Ui.php
+++ b/lib/Horde/Core/Prefs/Ui.php
@@ -768,9 +768,10 @@ class Horde_Core_Prefs_Ui
 
         try {
             $pconf = $registry->loadConfigFile('prefs.php', ['prefGroups', '_prefs'], $app);
+            $config = $pconf->config ?? [];
             $res = [
-                'prefGroups' => $pconf->config['prefGroups'],
-                '_prefs' => $pconf->config['_prefs'],
+                'prefGroups' => $config['prefGroups'] ?? [],
+                '_prefs' => $config['_prefs'] ?? [],
             ];
         } catch (Horde_Exception $e) {
             $res = [

--- a/src/Factory/LogHandlerFactory.php
+++ b/src/Factory/LogHandlerFactory.php
@@ -76,9 +76,8 @@ class LogHandlerFactory extends Horde_Core_Factory_Injector
 
                     case 'default':
                     default:
-                        // Match legacy Horde_Log_Handler_Stream + SimpleFormatter:
-                        // append a line break after the (pre-formatted) message.
-                        $formatters[] = new SimpleFormatter('%message%' . PHP_EOL);
+                        // Match legacy Horde_Log_Handler_Stream + SimpleFormatter.
+                        $formatters[] = new SimpleFormatter();
                         break;
 
                     case 'xml':


### PR DESCRIPTION
## Summary

Fix PHP warnings from missing optional Horde data and restore default log timestamps:

- Treat missing `prefGroups` and `_prefs` entries as empty arrays when loading app preferences.
- Make ActiveSync email change handling tolerate missing category data and skip modified UIDs without flag data.
- Restore the default logger formatter so standard log output includes timestamp and level again.

## Why

Some apps or config states may not define preference groups, and some ActiveSync IMAP change sets can include UIDs without complete flag/category metadata. These cases should not produce PHP `Undefined array key` warnings during normal operation.

The default PSR logger path was using a message-only formatter, which dropped the timestamp and log level from file logs. Using the default `SimpleFormatter` matches the legacy Horde log format.

## Test Plan

- Ran `php -l` on:
  - `vendor/horde/core/lib/Horde/Core/Prefs/Ui.php`
  - `vendor/horde/core/lib/Horde/Core/ActiveSync/Driver.php`
  - `vendor/horde/core/src/Factory/LogHandlerFactory.php`
- Verified no syntax errors.
- Smoke-tested default log formatting includes timestamp and level.