### PR TITLE
Fix/notes deletion

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -797,12 +797,14 @@ class Horde_Core_ActiveSync_Connector
     /**
      * Delete a note from the backend.
      *
-     * @param string $id  The task's uid
+     * @param string $id       The note's uid.
+     * @param string $notepad  The notepad id, if not using multiplex.
+     *
      * @since 5.1
      */
-    public function notes_delete($id)
+    public function notes_delete($id, $notepad = null)
     {
-        $this->_registry->notes->delete($id);
+        $this->_registry->notes->delete($id, $notepad);
     }
 
     /**

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -1959,22 +1959,28 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                 break;
 
             case Horde_ActiveSync::CLASS_NOTES:
-                try {
-                    $this->_connector->notes_delete($ids);
-                } catch (Horde_Exception $e) {
-                    $this->_logger->err($e->getMessage());
-                    // Since we don't get back successfully deleted ids and we can
-                    // can pass an array of ids to delete, we need to see what ids
-                    // were deleted if there was an error.
-                    // @todo For Horde 6, the API should return successfully
-                    // deleted ids.
-                    $success = [];
-                    foreach ($ids as $uid) {
-                        if ($mod_time = $this->_connector->tasks_getActionTimestamp($uid, 'delete', $folder_id)) {
-                            $success[] = $uid;
+                $results = [];
+                foreach ($ids as $uid) {
+                    try {
+                        $this->_connector->notes_delete($uid, $folder_id);
+                        $results[] = $uid;
+                    } catch (Horde_Exception_NotFound $e) {
+                        $this->_logger->err($e->getMessage());
+                        // Deleting a missing item is idempotent from the client
+                        // perspective, and should not block other deletes in
+                        // the same SYNC request.
+                        $results[] = $uid;
+                    } catch (Horde_Exception $e) {
+                        $this->_logger->err($e->getMessage());
+                        // Since we don't get back successfully deleted ids and we can
+                        // can pass an array of ids to delete, we need to see what ids
+                        // were deleted if there was an error.
+                        // @todo For Horde 6, the API should return successfully
+                        // deleted ids.
+                        if ($mod_time = $this->_connector->notes_getActionTimestamp($uid, 'delete', $folder_id)) {
+                            $results[] = $uid;
                         }
                     }
-                    $results = $success;
                 }
                 break;
             default:


### PR DESCRIPTION
## Summary

This updates the ActiveSync Notes delete path to work correctly with non-multiplexed Notes collections.

- Pass the active Notes folder/notepad id through `notes_delete()` so Mnemo can delete within the correct separate collection.
- Process Notes deletes per UID so one stale or already-missing item from the client does not prevent later deletes in the same `SYNC` request.
- Fix Notes delete recovery to query `notes_getActionTimestamp()` instead of the unrelated Tasks timestamp lookup.

## Test Plan

- Verified PHP syntax for `vendor/horde/core/lib/Horde/Core/ActiveSync/Driver.php`.
- Verified PHP syntax for `vendor/horde/core/lib/Horde/Core/ActiveSync/Connector.php`.
- Ran ActiveSync device tests:
  `vendor/bin/phpunit --bootstrap vendor/autoload.php vendor/horde/activesync/test/Horde/ActiveSync/DeviceTest.php`
- Ran core ActiveSync tests with required package mocks loaded:
  `OK (8 tests, 32 assertions)`