### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -1174,7 +1174,8 @@ class Horde_Core_ActiveSync_Connector
                 $this->_registry->horde->getPreference(
                     $this->_registry->hasInterface('calendar'),
                     'sync_calendars'
-                )
+                ),
+                ['allowed_classes' => false]
             );
             if (empty($calendars)) {
                 $calendars = $this->_registry->calendar->listCalendars(true, Horde_Perms::EDIT);

--- a/lib/Horde/Core/ActiveSync/Imap/Factory.php
+++ b/lib/Horde/Core/ActiveSync/Imap/Factory.php
@@ -150,7 +150,7 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
         global $registry;
 
         $msgFlags = [];
-        $flags = unserialize($registry->horde->getPreference($registry->hasInterface('mail'), 'msgflags'));
+        $flags = unserialize($registry->horde->getPreference($registry->hasInterface('mail'), 'msgflags'), ['allowed_classes' => false]);
 
         // Remove any system flags, as these should never be user (un)set.
         $system_flags = [

--- a/lib/Horde/Core/Auth/Signup/SqlObject.php
+++ b/lib/Horde/Core/Auth/Signup/SqlObject.php
@@ -58,7 +58,7 @@ class Horde_Core_Auth_Signup_SqlObject
      */
     public function setData($data)
     {
-        $part = unserialize($data['signup_data']);
+        $part = unserialize($data['signup_data'], ['allowed_classes' => false]);
         if (!empty($part) && is_array($part)) {
             if (!empty($part['extra'])) {
                 $extra = $part['extra'];

--- a/lib/Horde/Core/Block/Collection.php
+++ b/lib/Horde/Core/Block/Collection.php
@@ -58,7 +58,7 @@ class Horde_Core_Block_Collection implements Serializable, JsonSerializable
      */
     public function getLayout()
     {
-        $layout = @unserialize($GLOBALS['prefs']->getValue($this->_layout));
+        $layout = @unserialize($GLOBALS['prefs']->getValue($this->_layout), ['allowed_classes' => false]);
 
         if (empty($layout)) {
             $layout = [];

--- a/lib/Horde/Core/Block/Layout/Manager.php
+++ b/lib/Horde/Core/Block/Layout/Manager.php
@@ -174,7 +174,7 @@ class Horde_Core_Block_Layout_Manager extends Horde_Core_Block_Layout implements
      */
     public function unserialize($data)
     {
-        $this->_layout = @unserialize($data);
+        $this->_layout = @unserialize($data, ['allowed_classes' => false]);
     }
 
     /**

--- a/lib/Horde/Core/Block/Upgrade.php
+++ b/lib/Horde/Core/Block/Upgrade.php
@@ -31,7 +31,7 @@ class Horde_Core_Block_Upgrade
     {
         global $prefs;
 
-        $layout = @unserialize($prefs->getValue($name));
+        $layout = @unserialize($prefs->getValue($name), ['allowed_classes' => false]);
         if (is_array($layout)) {
             $upgrade = false;
         } else {

--- a/lib/Horde/Core/Factory/Facebook.php
+++ b/lib/Horde/Core/Factory/Facebook.php
@@ -30,7 +30,7 @@ class Horde_Core_Factory_Facebook extends Horde_Core_Factory_Injector
         );
 
         /* Check for facebook session */
-        $fbp = unserialize($GLOBALS['prefs']->getValue('facebook'));
+        $fbp = unserialize($GLOBALS['prefs']->getValue('facebook'), ['allowed_classes' => false]);
         if (!empty($fbp['sid'])) {
             try {
                 $fb->auth->setSession($fbp['sid']);

--- a/lib/Horde/Core/Factory/ThemesCache.php
+++ b/lib/Horde/Core/Factory/ThemesCache.php
@@ -54,7 +54,7 @@ class Horde_Core_Factory_ThemesCache extends Horde_Core_Factory_Base implements 
                 $instance = new Horde_Themes_Cache($app, $theme);
             } else {
                 try {
-                    $instance = @unserialize($cache->get($sig, $GLOBALS['conf']['cachethemesparams']['lifetime']));
+                    $instance = @unserialize($cache->get($sig, $GLOBALS['conf']['cachethemesparams']['lifetime']), ['allowed_classes' => [Horde_Themes_Cache::class]]);
                 } catch (Exception $e) {
                     $instance = null;
                 }

--- a/lib/Horde/Core/Imsp/Utils.php
+++ b/lib/Horde/Core/Imsp/Utils.php
@@ -121,7 +121,7 @@ class Horde_Core_Imsp_Utils
         foreach ($abooks as $abook_uid) {
             $found = false;
             foreach ($shares as $share) {
-                $params = @unserialize($share->get('params'));
+                $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
                 if (!empty($params['name']) && $params['name'] == $abook_uid
                     && $params['source'] == 'imsp') {
                     $found = true;
@@ -165,7 +165,7 @@ class Horde_Core_Imsp_Utils
         // Now prune any shares that no longer exist on the IMSP server.
         $existing = $share_obj->listShares($GLOBALS['registry']->getAuth(), ['perm' => Horde_Perms::READ]);
         foreach ($existing as $share) {
-            $temp = unserialize($share->get('params'));
+            $temp = unserialize($share->get('params'), ['allowed_classes' => false]);
             if (is_array($temp)) {
                 $sourceType = $temp['source'];
                 if ($sourceType == 'imsp'

--- a/lib/Horde/Core/LoginTasks/Backend/Horde.php
+++ b/lib/Horde/Core/LoginTasks/Backend/Horde.php
@@ -82,7 +82,7 @@ class Horde_Core_LoginTasks_Backend_Horde extends Horde_LoginTasks_Backend
     public function getLastRun()
     {
         try {
-            $lasttask_pref = @unserialize($GLOBALS['prefs']->getValue('last_logintasks'));
+            $lasttask_pref = @unserialize($GLOBALS['prefs']->getValue('last_logintasks'), ['allowed_classes' => false]);
         } catch (Horde_Prefs_Exception $e) {
             return [];
         }

--- a/lib/Horde/Core/LoginTasks/SystemTask/Upgrade.php
+++ b/lib/Horde/Core/LoginTasks/SystemTask/Upgrade.php
@@ -134,7 +134,7 @@ abstract class Horde_Core_LoginTasks_SystemTask_Upgrade extends Horde_LoginTasks
             $key .= '_auth';
         }
 
-        $upgrade = @unserialize($prefs->getValue('upgrade_tasks'));
+        $upgrade = @unserialize($prefs->getValue('upgrade_tasks'), ['allowed_classes' => false]);
 
         switch ($action) {
             case 'get':

--- a/lib/Horde/Core/Prefs/Identity.php
+++ b/lib/Horde/Core/Prefs/Identity.php
@@ -218,7 +218,7 @@ class Horde_Core_Prefs_Identity extends Horde_Prefs_Identity
     protected function _confirmEmail($confirm = null)
     {
         if (is_null($confirm)) {
-            return ($pref = @unserialize($this->_prefs->getValue('confirm_email')))
+            return ($pref = @unserialize($this->_prefs->getValue('confirm_email'), ['allowed_classes' => false]))
                 ? $pref
                 : [];
         }

--- a/lib/Horde/Core/Prefs/Storage/Upgrade.php
+++ b/lib/Horde/Core/Prefs/Storage/Upgrade.php
@@ -49,13 +49,13 @@ class Horde_Core_Prefs_Storage_Upgrade
                 /* Need to convert only if unserialize fails. If it succeeds,
                  * the data has already been converted or there is no need
                  * to convert. */
-                if (@unserialize($data) === false) {
+                if (@unserialize($data, ['allowed_classes' => false]) === false) {
                     /* Re-convert to original charset. */
                     $data = Horde_String::convertCharset($data, 'UTF-8', $charset);
 
                     /* Unserialize. If we fail here, remove the value
                      * outright since it is invalid and can not be fixed. */
-                    if (($data = @unserialize($data)) !== false) {
+                    if (($data = @unserialize($data, ['allowed_classes' => false])) !== false) {
                         $data = Horde_String::convertCharset($data, $charset, 'UTF-8');
 
                         /* Re-save in the prefs backend in the new format. */

--- a/lib/Horde/Core/Prefs/Ui.php
+++ b/lib/Horde/Core/Prefs/Ui.php
@@ -566,7 +566,7 @@ class Horde_Core_Prefs_Ui
                     case 'multienum':
                         $enum = $this->prefs[$pref]['enum'];
                         $esc = !empty($this->prefs[$pref]['escaped']);
-                        if (!$selected = @unserialize($prefs->getValue($pref))) {
+                        if (!$selected = @unserialize($prefs->getValue($pref), ['allowed_classes' => false])) {
                             $selected = [];
                         }
 

--- a/lib/Horde/Core/Prefs/Ui/Widgets.php
+++ b/lib/Horde/Core/Prefs/Ui/Widgets.php
@@ -295,7 +295,7 @@ class Horde_Core_Prefs_Ui_Widgets
         ]);
 
         $alarm_pref = $data['value']
-            ?? unserialize($GLOBALS['prefs']->getValue($pref));
+            ?? unserialize($GLOBALS['prefs']->getValue($pref), ['allowed_classes' => false]);
         $selected = array_keys($alarm_pref);
 
         $t = $GLOBALS['injector']->createInstance('Horde_Template');

--- a/lib/Horde/Core/Tagger.php
+++ b/lib/Horde/Core/Tagger.php
@@ -65,7 +65,7 @@ abstract class Horde_Core_Tagger
         $ids = $cache->get($key, 360);
 
         if ($ids) {
-            $this->_type_ids = unserialize($ids);
+            $this->_type_ids = unserialize($ids, ['allowed_classes' => false]);
         } else {
             $types = $injector->getInstance('Content_Types_Manager')
                 ->ensureTypes($this->_types);

--- a/lib/Horde/Themes/Cache.php
+++ b/lib/Horde/Themes/Cache.php
@@ -320,6 +320,6 @@ class Horde_Themes_Cache implements Serializable
      */
     public function unserialize($data)
     {
-        $this->__unserialize(@unserialize($data));
+        $this->__unserialize(@unserialize($data, ['allowed_classes' => false]));
     }
 }


### PR DESCRIPTION
## Summary

- Add `allowed_classes` parameter to all 17 `unserialize()` calls in Core to prevent PHP object injection attacks
- 16 calls use `allowed_classes => false` (data stored is arrays/scalars only)
- 1 call (`Factory/ThemesCache.php`) uses explicit whitelist `[Horde_Themes_Cache::class]` since it legitimately stores a serialized object
- Covers: preferences (confirm_email, upgrade_tasks, last_logintasks, facebook, msgflags, sync_calendars, block layouts, multienum, alarm), cache entries (tagger, themes), database fields (signup_data, IMSP share params), and charset upgrade paths