### PR TITLE
Ensure info is an array before processing

### DIFF
--- a/lib/Horde/Core/Perms/Ui.php
+++ b/lib/Horde/Core/Perms/Ui.php
@@ -245,6 +245,9 @@ class Horde_Core_Perms_Ui
             return false;
         }
 
+        if (!is_array($info)) {
+            $info = [];
+        }
         $info = $this->_form->getInfo($this->_vars, $info);
         return $info;
     }
@@ -446,6 +449,9 @@ class Horde_Core_Perms_Ui
         if (!$this->_form->validate($this->_vars)) {
             return false;
         }
+        if (!is_array($info)) {
+            $info = [];
+        }
         $info = $this->_form->getInfo($this->_vars, $info);
         if ($this->_type == 'matrix') {
             /* Collapse the array for default/guest/creator. */
@@ -514,6 +520,9 @@ class Horde_Core_Perms_Ui
 
         if ($form_submit == Horde_Core_Translation::t('Delete')) {
             if ($this->_form->validate($this->_vars)) {
+                if (!is_array($info)) {
+                    $info = [];
+                }
                 return $this->_form->getInfo($this->_vars, $info);
             }
         } elseif (!empty($form_submit)) {


### PR DESCRIPTION
## Fix permission add form crash after strict ArrayUtils typing update

### Why
Adding child permissions from the administration UI could trigger a fatal `TypeError` after recent updates:
`Horde\Util\ArrayUtils::setElement(): Argument #1 ($array) must be of type array, null given`.

The permissions UI validators were passing an uninitialized `$info` by reference into `Horde_Form->getInfo()`. With stricter typing in `ArrayUtils::setElement(array &$array, ...)`, this now fails when `$info` is `null`.

### What changed
- Updated `vendor/horde/core/lib/Horde/Core/Perms/Ui.php` to normalize `$info` before `getInfo()`:
  - `validateAddForm(&$info)`
  - `validateEditForm(&$info)`
  - `validateDeleteForm(&$info)`
- Added:
  - `if (!is_array($info)) { $info = []; }`
  before calling `getInfo()`.

### Result
- Prevents fatal errors when `$info` is unset/null.
- Restores expected behavior when clicking **Add** in Administration → Permissions.
- Also hardens edit/delete validator paths against the same null-by-reference issue.

### Validation
- `php -l vendor/horde/core/lib/Horde/Core/Perms/Ui.php` passes with no syntax errors.
- Lint check for modified file reports no issues.

### Repro steps (before fix)
1. Go to Administration → Permissions.
2. Open “Add child permission”.
3. Click **Add**.
4. Fatal TypeError occurs in `ArrayUtils::setElement()`.

### Verification steps (after fix)
1. Repeat the same flow.
2. Confirm permission is added or validation feedback is shown without fatal error.