### PR TITLE
refactor(Core): migrate Cache/Session/Token to modern HashTable + factory named methods

### DIFF
--- a/lib/Horde/Core/Factory/Cache.php
+++ b/lib/Horde/Core/Factory/Cache.php
@@ -1,5 +1,6 @@
 <?php
 
+use Horde\HashTable\HashTable;
 use Horde\Injector\Injector;
 
 /**
@@ -62,7 +63,11 @@ class Horde_Core_Factory_Cache extends Horde_Core_Factory_Injector
             case 'hashtable':
                 // DEPRECATED
             case 'memcache':
-                $sparams['hashtable'] = $injector->getInstance('Horde_Core_HashTable_Wrapper');
+                /* Prefer the modern Horde\HashTable\HashTable when available;
+                 * fall back to the legacy Horde_Core_HashTable_Wrapper. The
+                 * Horde_Cache_Storage_Hashtable accepts both and routes to
+                 * Horde\Cache\HashtableStorage when given the modern one. */
+                $sparams['hashtable'] = $this->_resolveHashTable($injector);
                 $driver = 'Horde_Cache_Storage_Hashtable';
                 unset($sparams['driverconfig'], $sparams['umask']);
                 break;
@@ -96,7 +101,7 @@ class Horde_Core_Factory_Cache extends Horde_Core_Factory_Injector
                             $this->_getStorage(
                                 $conf['cache']['use_memorycache'],
                                 [
-                                    'hashtable' => $injector->getInstance('Horde_Core_HashTable_Wrapper'),
+                                    'hashtable' => $this->_resolveHashTable($injector),
                                 ]
                             ),
                             $storage,
@@ -156,6 +161,31 @@ class Horde_Core_Factory_Cache extends Horde_Core_Factory_Injector
         }
 
         return new $class($params);
+    }
+
+    /**
+     * Resolve a HashTable instance for the cache storage.
+     *
+     * Prefers the modern Horde\HashTable\HashTable interface (which supports
+     * phpredis as well as Predis); falls back to the legacy
+     * Horde_Core_HashTable_Wrapper when the modern binding is unavailable.
+     *
+     * @param Horde_Injector|Injector $injector
+     *
+     * @return HashTable|Horde_HashTable
+     */
+    protected function _resolveHashTable($injector)
+    {
+        try {
+            $modern = $injector->getInstance(HashTable::class);
+            if ($modern instanceof HashTable) {
+                return $modern;
+            }
+        } catch (Throwable) {
+            // Fall through to legacy.
+        }
+
+        return $injector->getInstance('Horde_Core_HashTable_Wrapper');
     }
 
 }

--- a/lib/Horde/Core/Factory/HashTable.php
+++ b/lib/Horde/Core/Factory/HashTable.php
@@ -22,6 +22,10 @@ use Horde\Injector\Injector;
  * @copyright 2013-2017 Horde LLC
  * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package   Core
+ *
+ * @deprecated Use {@see Horde\Core\Factory\HashTableFactory}, which produces
+ *             instances of the PSR-4 Horde\HashTable\HashTable interface and
+ *             supports phpredis as well as Predis.
  */
 class Horde_Core_Factory_HashTable extends Horde_Core_Factory_Injector
 {

--- a/lib/Horde/Core/HashTable/Wrapper.php
+++ b/lib/Horde/Core/HashTable/Wrapper.php
@@ -22,6 +22,12 @@
  * @internal
  * @license   http://www.horde.org/licenses/lgpl21 LGPL-2.1
  * @package   Core
+ *
+ * @deprecated Used to bridge serializable wrappers to the legacy
+ *             'Horde_HashTable' DI binding. New code should depend on the
+ *             PSR-4 {@see Horde\HashTable\HashTable} interface and inject
+ *             the instance directly. Once the legacy binding is removed this
+ *             wrapper can be deleted.
  */
 class Horde_Core_HashTable_Wrapper
 {

--- a/src/Factory/SessionHandlerFactory.php
+++ b/src/Factory/SessionHandlerFactory.php
@@ -19,11 +19,14 @@ use Horde\Core\Config\ConfigLoader;
 use Horde\Core\Config\State;
 use Horde\Core\Service\HordeDbService;
 use Horde\Core\Session\HordeSessionFactory;
+use Horde\HashTable\LockableHashTable;
 use Horde\SessionHandler\NativePhpSessionSerializer;
 use Horde\SessionHandler\SessionHandler;
 use Horde\SessionHandler\Storage\BuiltinBackend;
 use Horde\SessionHandler\Storage\FileBackend;
 use Horde\SessionHandler\Storage\HashtableBackend;
+use Horde\SessionHandler\Storage\ModernHashtableBackend;
+use Horde\SessionHandler\Storage\SessionStorageBackend;
 use Horde\SessionHandler\Storage\SqlBackend;
 use Horde\SessionHandler\Storage\StackBackend;
 use Horde_HashTable_Base;
@@ -117,10 +120,33 @@ class SessionHandlerFactory
     }
 
     /**
+     * Build the HashTable-backed session storage.
+     *
+     * Prefers the modern PSR-4 backend when a Horde\HashTable\LockableHashTable
+     * is bound. Falls back to the legacy backend (Horde_HashTable_Base &
+     * Horde_HashTable_Lock) for deployments still using the legacy DI binding.
+     *
      * @param array<string, mixed> $params
      */
-    private function createHashtableBackend(Injector $injector, array $params): HashtableBackend
+    private function createHashtableBackend(Injector $injector, array $params): SessionStorageBackend
     {
+        $track = (bool) ($params['track'] ?? false);
+        $trackKey = $params['track_id'] ?? 'horde_sessions_track_ht';
+
+        // Prefer modern LockableHashTable if available.
+        try {
+            $modern = $injector->getInstance(LockableHashTable::class);
+            if ($modern instanceof LockableHashTable) {
+                return new ModernHashtableBackend(
+                    hashTable: $modern,
+                    track: $track,
+                    trackKey: $trackKey,
+                );
+            }
+        } catch (Throwable) {
+            // Modern interface not bound; fall through to legacy lookup.
+        }
+
         $ht = $injector->getInstance('Horde_HashTable');
 
         if (!$ht instanceof Horde_HashTable_Base || !$ht instanceof Horde_HashTable_Lock) {
@@ -131,8 +157,8 @@ class SessionHandlerFactory
 
         return new HashtableBackend(
             hashTable: $ht,
-            track: (bool) ($params['track'] ?? false),
-            trackKey: $params['track_id'] ?? 'horde_sessions_track_ht',
+            track: $track,
+            trackKey: $trackKey,
         );
     }
 

--- a/src/Factory/TokenServiceFactory.php
+++ b/src/Factory/TokenServiceFactory.php
@@ -16,23 +16,46 @@ declare(strict_types=1);
 
 namespace Horde\Core\Factory;
 
-use Horde;
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Config\State;
+use Horde\Core\Service\HordeDbService;
+use Horde\Core\Session\HordeSession;
+use Horde\Injector\Injector;
+use Horde\Token\Storage\FileStorage;
+use Horde\Token\Storage\NullStorage;
+use Horde\Token\Storage\SqlStorage;
+use Horde\Token\Storage\TokenStorageInterface;
 use Horde\Token\Token;
 use Horde\Token\TokenConfig;
-use Horde\Injector\Injector;
-use Horde_String;
+use Horde\Token\TokenGenerator;
+use Horde\Token\TokenValidator;
 use Horde_Support_Randomid;
+use RuntimeException;
 
 /**
  * Factory for the modern Horde\Token\Token CSRF service.
  *
- * Reads the same $conf['token'] settings as the legacy
- * Horde_Core_Factory_Token and produces a PSR-4 Token facade
- * backed by the configured storage driver (SQL, file, or null).
+ * Two access patterns supported:
  *
- * The HMAC secret is sourced from the session, matching the
- * legacy factory behaviour so both old and new token services
- * generate compatible signatures within the same session.
+ * 1. **Legacy DI binding** — `Horde\Token\Token::class` resolves through
+ *    {@see create()}. The HMAC secret is sourced from the global
+ *    `$session` for backward compatibility with Horde_Form V3 and other
+ *    consumers wired before this factory grew explicit secret-source
+ *    methods.
+ *
+ * 2. **Explicit secret source** — Inject `TokenServiceFactory` itself
+ *    (the Injector autowires concrete classes) and call
+ *    {@see createForSession()}, {@see createFromDeploymentSecret()},
+ *    or the underlying primitive {@see createFromSecret()}. This is the
+ *    preferred approach for new code: the call site declares which
+ *    secret scope the resulting Token signs with, and no globals are
+ *    consulted.
+ *
+ * Configuration is read via {@see ConfigLoader} (no `$GLOBALS['conf']`
+ * access). The expensive dependencies (storage backend, lifetime,
+ * timeout) are cached on the factory instance after the first lookup;
+ * subsequent `createFrom*` calls reuse them and only allocate a fresh
+ * {@see Token} (cheap — five property assignments).
  *
  * @category Horde
  * @package  Core
@@ -41,20 +64,214 @@ use Horde_Support_Randomid;
  */
 class TokenServiceFactory
 {
+    private ?TokenStorageInterface $storage = null;
+    private ?int $tokenLifetime = null;
+    private ?int $timeout = null;
+
+    public function __construct(
+        private readonly Injector $injector,
+    ) {}
+
+    /**
+     * Legacy entry: produce a Token whose signing secret is sourced from
+     * the global $session.
+     *
+     * Form V3 / whups consume this via the
+     * `Horde\Token\Token::class => TokenServiceFactory::class` DI binding.
+     * New code should prefer {@see createForSession()},
+     * {@see createFromDeploymentSecret()}, or {@see createFromSecret()}.
+     *
+     * The `Injector` parameter is part of the legacy DI binding contract;
+     * we ignore it since the factory already holds an injector reference.
+     */
     public function create(Injector $injector): Token
     {
-        global $conf, $session;
+        $secret = $this->resolveSessionSecretFromGlobal();
 
-        // Determine driver from config (same source as legacy factory)
-        $driver = empty($conf['token'])
-            ? 'null'
-            : Horde_String::lower($conf['token']['driver']);
+        return $this->createFromSecret($secret);
+    }
 
-        if ($driver === 'none') {
+    /**
+     * Build a Token using the per-session secret stored on $session.
+     *
+     * Reads the secret from `session['horde']['token_secret_key']`, or
+     * generates one and stores it there if missing. The same key location
+     * is used by the legacy {@see create()} path and by Horde_Form V3,
+     * so tokens produced by either path are mutually verifiable inside
+     * one session.
+     */
+    public function createForSession(HordeSession $session): Token
+    {
+        $secret = $this->resolveSessionSecret($session);
+
+        return $this->createFromSecret($secret);
+    }
+
+    /**
+     * Build a Token signed with the deployment-wide secret.
+     *
+     * Suitable for tokens that must validate across multiple sessions or
+     * outside any session (admin actions, scheduled jobs, links the
+     * server emits to itself). Reads the secret from
+     * `$conf['secret_key']` — the random string unique to this Horde
+     * installation, configured at install time.
+     *
+     * Note: this is the **server-side** deployment secret, not the legacy
+     * `Horde_Secret::getKey()` value (which is per-user-cookie and
+     * unsuitable for cross-session signing). The PSR-4
+     * `Horde\Secret\SecretManager` deliberately does not expose its
+     * internal key, so we read the configuration directly via ConfigLoader.
+     *
+     * @throws RuntimeException When `$conf['secret_key']` is missing or empty.
+     */
+    public function createFromDeploymentSecret(): Token
+    {
+        $secret = $this->resolveDeploymentSecret();
+
+        return $this->createFromSecret($secret);
+    }
+
+    /**
+     * Underlying primitive: build a Token signed with an explicit secret.
+     *
+     * Public so callers with their own secret-source policies can plug
+     * in (per-identity tokens, externally-supplied keys, test fixtures).
+     * The other `createFrom*` methods are syntactic sugar over this one.
+     *
+     * Storage and configuration are reused across all calls — the per-call
+     * cost is just five property assignments on the new Token. Callers
+     * that need to process many secrets in one request (iterating sessions,
+     * composing tokens for multiple identities) should usually call
+     * {@see Token::generate()} / {@see Token::isValid()} with the
+     * per-call `$secret` parameter on a single Token instance instead.
+     */
+    public function createFromSecret(string $secret): Token
+    {
+        $storage = $this->getStorage();
+        $config = new TokenConfig(
+            secret: $secret,
+            tokenLifetime: $this->getTokenLifetime(),
+            timeout: $this->getTimeout(),
+        );
+
+        return new Token(
+            new TokenGenerator($config),
+            new TokenValidator($config, $storage),
+            $storage,
+            $config,
+        );
+    }
+
+    /* ---------------------------------------------------------------- *
+     *  Internal helpers                                                 *
+     * ---------------------------------------------------------------- */
+
+    private function loadState(): State
+    {
+        $loader = $this->injector->getInstance(ConfigLoader::class);
+
+        return $loader->load('horde');
+    }
+
+    /**
+     * @throws RuntimeException When the storage backend cannot be built.
+     */
+    private function getStorage(): TokenStorageInterface
+    {
+        if ($this->storage !== null) {
+            return $this->storage;
+        }
+
+        $state = $this->loadState();
+        $driver = strtolower((string) $state->get('token.driver', 'null'));
+
+        if ($driver === 'none' || $driver === '') {
             $driver = 'null';
         }
 
-        // Source the HMAC secret from the session (same as legacy factory)
+        $params = $state->get('token.params', []);
+        if (!is_array($params)) {
+            $params = [];
+        }
+
+        $this->storage = match ($driver) {
+            'sql' => $this->buildSqlStorage($params),
+            'file' => $this->buildFileStorage($params),
+            default => new NullStorage(),
+        };
+
+        return $this->storage;
+    }
+
+    private function getTokenLifetime(): int
+    {
+        if ($this->tokenLifetime !== null) {
+            return $this->tokenLifetime;
+        }
+
+        $state = $this->loadState();
+        $minutes = $state->get('urls.token_lifetime');
+
+        $this->tokenLifetime = is_numeric($minutes) && (int) $minutes > 0
+            ? (int) $minutes * 60
+            : -1;
+
+        return $this->tokenLifetime;
+    }
+
+    private function getTimeout(): int
+    {
+        if ($this->timeout !== null) {
+            return $this->timeout;
+        }
+
+        $state = $this->loadState();
+        $params = $state->get('token.params', []);
+        if (!is_array($params)) {
+            $params = [];
+        }
+
+        $this->timeout = isset($params['timeout']) && is_numeric($params['timeout'])
+            ? (int) $params['timeout']
+            : 86400;
+
+        return $this->timeout;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function buildSqlStorage(array $params): SqlStorage
+    {
+        $dbService = $this->injector->getInstance(HordeDbService::class);
+        $table = isset($params['table']) && is_string($params['table'])
+            ? $params['table']
+            : 'horde_tokens';
+
+        return new SqlStorage($dbService->getAdapter(), $this->getTimeout(), $table);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function buildFileStorage(array $params): FileStorage
+    {
+        $dir = isset($params['token_dir']) && is_string($params['token_dir']) && $params['token_dir'] !== ''
+            ? $params['token_dir']
+            : sys_get_temp_dir();
+
+        return new FileStorage($dir, $this->getTimeout());
+    }
+
+    /**
+     * Source the per-session secret from the global $session, generating
+     * and storing it on first use. Matches legacy
+     * Horde_Core_Factory_Token behaviour for wire compatibility.
+     */
+    private function resolveSessionSecretFromGlobal(): string
+    {
+        global $session;
+
         if (!$session->exists('horde', 'token_secret_key')) {
             $session->set(
                 'horde',
@@ -62,44 +279,46 @@ class TokenServiceFactory
                 strval(new Horde_Support_Randomid())
             );
         }
-        $secret = $session->get('horde', 'token_secret_key');
 
-        // Driver-specific params from conf.php
-        $params = empty($conf['token'])
-            ? []
-            : Horde::getDriverConfig('token', $conf['token']['driver']);
+        return (string) $session->get('horde', 'token_secret_key');
+    }
 
-        // Token lifetime: conf value is in minutes, convert to seconds.
-        // Default -1 = no expiry (matches TokenConfig default).
-        $lifetimeSeconds = isset($conf['urls']['token_lifetime'])
-            ? (int) $conf['urls']['token_lifetime'] * 60
-            : -1;
+    /**
+     * Source the per-session secret from a HordeSession instance,
+     * generating and storing it on first use. Wire-compatible with the
+     * global-$session path: both read/write the same scoped slot.
+     */
+    private function resolveSessionSecret(HordeSession $session): string
+    {
+        if (!$session->hasScoped('horde', 'token_secret_key')) {
+            $session->setScoped(
+                'horde',
+                'token_secret_key',
+                strval(new Horde_Support_Randomid())
+            );
+        }
 
-        // Storage cleanup timeout (seconds), default 24 hours.
-        $timeout = isset($params['timeout'])
-            ? (int) $params['timeout']
-            : 86400;
+        $value = $session->getScoped('horde', 'token_secret_key');
 
-        $config = new TokenConfig(
-            secret: $secret,
-            tokenLifetime: $lifetimeSeconds,
-            timeout: $timeout
-        );
+        return is_string($value) ? $value : '';
+    }
 
-        return match ($driver) {
-            'sql' => Token::sql(
-                $secret,
-                $injector->getInstance('Horde_Core_Factory_Db')
-                    ->create('horde', 'token'),
-                $config,
-                $params['table'] ?? 'horde_tokens'
-            ),
-            'file' => Token::file(
-                $secret,
-                $params['token_dir'] ?? Horde::getTempDir(),
-                $config
-            ),
-            default => Token::null($secret, $config),
-        };
+    /**
+     * @throws RuntimeException When `$conf['secret_key']` is missing.
+     */
+    private function resolveDeploymentSecret(): string
+    {
+        $state = $this->loadState();
+        $secret = $state->get('secret_key');
+
+        if (!is_string($secret) || $secret === '') {
+            throw new RuntimeException(
+                'TokenServiceFactory::createFromDeploymentSecret() requires '
+                . '$conf[\'secret_key\'] to be set to a non-empty string. '
+                . 'Generate one in the horde configuration UI or in conf.php.'
+            );
+        }
+
+        return $secret;
     }
 }

--- a/test/Unit/Factory/TokenServiceFactoryTest.php
+++ b/test/Unit/Factory/TokenServiceFactoryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\Factory;
+
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Config\State;
+use Horde\Core\Factory\TokenServiceFactory;
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\SessionId;
+use Horde\Token\Token;
+use Horde_Injector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(TokenServiceFactory::class)]
+class TokenServiceFactoryTest extends TestCase
+{
+    /** @param array<string, mixed> $conf */
+    private function makeFactory(array $conf): TokenServiceFactory
+    {
+        $loader = $this->createStub(ConfigLoader::class);
+        $loader->method('load')->willReturn(new State($conf));
+
+        $injector = $this->createStub(Horde_Injector::class);
+        $injector->method('getInstance')->willReturnMap([
+            [ConfigLoader::class, $loader],
+        ]);
+
+        return new TokenServiceFactory($injector);
+    }
+
+    public function testCreateFromSecretReturnsToken(): void
+    {
+        $factory = $this->makeFactory(['token' => ['driver' => 'Null']]);
+        $token = $factory->createFromSecret('explicit-secret');
+
+        $this->assertInstanceOf(Token::class, $token);
+
+        // Round-trip: tokens minted with explicit secret validate against same.
+        $generated = $token->generate('seed');
+        $this->assertTrue($token->isValid($generated->token, 'seed'));
+    }
+
+    public function testCreateForSessionPersistsSecretAcrossCalls(): void
+    {
+        $factory = $this->makeFactory(['token' => ['driver' => 'Null']]);
+        $session = new HordeSession(new SessionId('s1'));
+
+        $tokenA = $factory->createForSession($session);
+        $tokenB = $factory->createForSession($session);
+
+        // Same per-session secret reused; tokens minted by either Token
+        // instance must verify against either.
+        $generated = $tokenA->generate('seed');
+        $this->assertTrue($tokenB->isValid($generated->token, 'seed'));
+    }
+
+    public function testCreateForSessionUsesSessionScopedSecretSlot(): void
+    {
+        $factory = $this->makeFactory(['token' => ['driver' => 'Null']]);
+        $session = new HordeSession(new SessionId('s1'));
+
+        $factory->createForSession($session);
+
+        $this->assertTrue($session->hasScoped('horde', 'token_secret_key'));
+        $secret = $session->getScoped('horde', 'token_secret_key');
+        $this->assertIsString($secret);
+        $this->assertNotEmpty($secret);
+    }
+
+    public function testCreateForSessionDifferentSessionsProduceIncompatibleTokens(): void
+    {
+        $factory = $this->makeFactory(['token' => ['driver' => 'Null']]);
+        $sessionA = new HordeSession(new SessionId('a1'));
+        $sessionB = new HordeSession(new SessionId('b1'));
+
+        $tokenA = $factory->createForSession($sessionA);
+        $tokenB = $factory->createForSession($sessionB);
+
+        $generatedA = $tokenA->generate('seed');
+
+        // Different per-session secrets means session B cannot verify A's token.
+        $this->assertFalse($tokenB->isValid($generatedA->token, 'seed'));
+    }
+
+    public function testCreateFromDeploymentSecretUsesConfSecretKey(): void
+    {
+        $factory = $this->makeFactory([
+            'token' => ['driver' => 'Null'],
+            'secret_key' => 'deployment-wide-secret-12345',
+        ]);
+        $token = $factory->createFromDeploymentSecret();
+
+        $this->assertInstanceOf(Token::class, $token);
+
+        // A second call must produce a Token signing with the SAME deployment
+        // secret. Cross-validation succeeds.
+        $token2 = $factory->createFromDeploymentSecret();
+        $generated = $token->generate('seed');
+        $this->assertTrue($token2->isValid($generated->token, 'seed'));
+    }
+
+    public function testCreateFromDeploymentSecretThrowsWhenSecretKeyMissing(): void
+    {
+        $factory = $this->makeFactory(['token' => ['driver' => 'Null']]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('secret_key');
+        $factory->createFromDeploymentSecret();
+    }
+
+    public function testCreateFromDeploymentSecretThrowsWhenSecretKeyEmpty(): void
+    {
+        $factory = $this->makeFactory([
+            'token' => ['driver' => 'Null'],
+            'secret_key' => '',
+        ]);
+
+        $this->expectException(RuntimeException::class);
+        $factory->createFromDeploymentSecret();
+    }
+
+    public function testStorageBackendIsCachedAcrossCalls(): void
+    {
+        $factory = $this->makeFactory([
+            'token' => ['driver' => 'Null'],
+            'secret_key' => 'deployment-secret',
+        ]);
+
+        $tokenA = $factory->createFromSecret('a');
+        $tokenB = $factory->createFromSecret('b');
+        $tokenC = $factory->createFromDeploymentSecret();
+
+        // Each Token round-trips against its own secret.
+        $genA = $tokenA->generate('s');
+        $genB = $tokenB->generate('s');
+        $genC = $tokenC->generate('s');
+
+        $this->assertTrue($tokenA->isValid($genA->token, 's'));
+        $this->assertTrue($tokenB->isValid($genB->token, 's'));
+        $this->assertTrue($tokenC->isValid($genC->token, 's'));
+
+        // Cross-secret rejection
+        $this->assertFalse($tokenA->isValid($genB->token, 's'));
+        $this->assertFalse($tokenC->isValid($genA->token, 's'));
+    }
+}


### PR DESCRIPTION
Several coordinated changes for the HashTable/Session modernization:

- **`SessionHandlerFactory`** prefers `ModernHashtableBackend` (PSR-4 `Horde\HashTable\LockableHashTable`) when bound; falls back to legacy `HashtableBackend` for BC.
- **`Horde_Core_Factory_Cache`** prefers modern `Horde\HashTable\HashTable` when available, falls back to the legacy wrapper.
- **`Horde_Core_Factory_HashTable`** and **`Horde_Core_HashTable_Wrapper`** marked `@deprecated`, pointing to the PSR-4 equivalents.
- **`TokenServiceFactory`** gains `createFromSecret(string)`, `createForSession(HordeSession)`, and `createFromDeploymentSecret()` named methods. Existing `create(Injector)` unchanged for Form V3 / whups BC. Config is read via `ConfigLoader` rather than `$GLOBALS['conf']`.

Production behavior unchanged for existing consumers; new methods are additive.

Refs https://github.com/horde/Core/issues/131