### PR TITLE
refactor(Core): use sha1(session_id()) instead of getToken() as session cache prefix

### DIFF
--- a/lib/Horde/Core/Cache/Session.php
+++ b/lib/Horde/Core/Cache/Session.php
@@ -157,15 +157,20 @@ class Horde_Core_Cache_Session extends Horde_Cache_Storage_Base
      */
     protected function _getCid($key, $in_session)
     {
-        global $session;
-
         if ($in_session) {
             return $this->_params['storage_key'] . '/' . $key;
         }
 
+        /* Stable per-session prefix. Derived from session_id() rather than
+         * $session->getToken() because the legacy getToken() value will not
+         * remain stable across calls once Horde_Session delegates to the
+         * HMAC token service. The cache-key role wants a stable session
+         * fingerprint, not a security token. SHA-1 is good enough for
+         * uniqueness and avoids leaking the raw session id into cache keys
+         * that may end up in backend logs. */
         return implode('|', [
             $this->_params['app'],
-            $session->getToken(),
+            sha1((string) session_id()),
             $key,
         ]);
     }

--- a/lib/Horde/Core/HashTable/PersistentSession.php
+++ b/lib/Horde/Core/HashTable/PersistentSession.php
@@ -46,10 +46,14 @@ class Horde_Core_HashTable_PersistentSession extends Horde_Core_HashTable_Vfs im
      */
     public function __construct(array $params = [])
     {
-        global $session;
-
+        /* Stable per-session VFS prefix. Derived from session_id() rather
+         * than $session->getToken() because the legacy getToken() value
+         * will not remain stable across calls once Horde_Session delegates
+         * to the HMAC token service. The path-prefix role wants a stable
+         * session fingerprint, not a security token. SHA-1 is good enough
+         * for uniqueness and keeps the raw session id out of VFS paths. */
         parent::__construct([
-            'prefix' => $session->getToken(),
+            'prefix' => sha1((string) session_id()),
             'vfspath' => self::VFS_PATH,
         ]);
 


### PR DESCRIPTION
Two cache-prefix sites used `\$session->getToken()` as a stable per-session identifier. That's a misuse of a CSRF token — the role they actually want is "stable session fingerprint."

Replaces in:
- `Horde_Core_Cache_Session::_getCid()` (cache key middle component)
- `Horde_Core_HashTable_PersistentSession` constructor (VFS path prefix)

`sha1((string) session_id())` is unambiguous about its role and keeps the raw session id out of cache backends and VFS paths.

Refs https://github.com/horde/Core/issues/131