### PR TITLE
feat(core): wire EAS 16.0 Find command to IMP search backend

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -1776,6 +1776,21 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     }
 
     /**
+     * Resolve mailbox:uid for ItemOperations when the client sends a virtual
+     * folder id from unified Find search (e.g. iOS M&lt;uid&gt;).
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param integer $uid  IMAP message UID.
+     *
+     * @return string|null
+     */
+    public function resolveLongIdForUid(int $uid): ?string
+    {
+        return $this->_imap->resolveLongIdForUid($uid);
+    }
+
+    /**
      * Return the specified attachement data for an ITEMOPERATIONS request.
      *
      * @param string $filereference  The attachment identifier.
@@ -2318,7 +2333,6 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      *
      * @return Horde_ActiveSync_Search_Results  The search results.
      *
-     * @todo $params->deepTraversal is NOT YET SUPPORTED.
      */
     public function getSearchResults(Horde_ActiveSync_Search_Params $params): Horde_ActiveSync_Search_Results
     {
@@ -2380,6 +2394,55 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             total: $total,
             rows: $rows,
             status: 0 /* not yet used */
+        );
+    }
+
+    /**
+     * Returns Find command results.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Horde_ActiveSync_Find_Params $params      Find parameters.
+     * @param array                        $bodyprefs     Body preferences.
+     * @param integer                      $mimesupport MIME support flag.
+     *
+     * @return Horde_ActiveSync_Find_Results
+     */
+    public function getFindResults(
+        Horde_ActiveSync_Find_Params $params,
+        array $bodyprefs = [],
+        $mimesupport = 0
+    ): Horde_ActiveSync_Find_Results {
+        unset($bodyprefs, $mimesupport);
+
+        try {
+            $searchParams = Horde_ActiveSync_Find_QueryMapper::toSearchParams($params);
+            $results = $this->getSearchResults($searchParams);
+
+            if ($results->rows === null) {
+                return new Horde_ActiveSync_Find_Results(
+                    Horde_ActiveSync_Request_Find::STATUS_SUCCESS,
+                    Horde_ActiveSync_Request_Find::STORE_STATUS_SERVERERR,
+                    0,
+                    null
+                );
+            }
+
+            return new Horde_ActiveSync_Find_Results(
+                Horde_ActiveSync_Request_Find::STATUS_SUCCESS,
+                Horde_ActiveSync_Request_Find::STORE_STATUS_SUCCESS,
+                $results->total,
+                $results->rows
+            );
+        } catch (Horde_ActiveSync_Exception $e) {
+            $this->_logger->err($e->getMessage());
+        }
+
+        return new Horde_ActiveSync_Find_Results(
+            Horde_ActiveSync_Request_Find::STATUS_SUCCESS,
+            Horde_ActiveSync_Request_Find::STORE_STATUS_SERVERERR,
+            0,
+            null
         );
     }
 
@@ -3852,7 +3915,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      *
      * @param array $query          A query array. @see self::getSearchResults()
      * @param array $options        The search options (currently ignored).
-     * @param bool  $deepTraversal  If true, traverse sub folders (currently ignored)
+     * @param bool  $deepTraversal  If true, traverse sub-folders of the target mailbox.
      *
      * @return array|null           An array of search results or null on error
      *


### PR DESCRIPTION
# Wire EAS 16.0 Find command to IMP/IMAP backend

## Summary

Implements `Horde_Core_ActiveSync_Driver::getFindResults()` and `resolveLongIdForUid()` so the Horde ActiveSync Find handler can search mail and open results on EAS 16.0 clients (tested with iPhone).

This PR depends on the companion **`horde/activesync`** PR that adds the Find protocol handler, `Horde_ActiveSync_Find_*` types, and `Horde_ActiveSync_Driver_Base::getFindResults()`.

## Motivation

`Horde_ActiveSync_Request_Find` calls `getFindResults()` on the ActiveSync driver. The core IMP driver must map Find parameters to the existing Search/IMAP backend and support ItemOperations fetch when iOS uses a virtual All Mailboxes folder id (`M` + message UID, e.g. `M166562`).

## Changes

### `getFindResults()`

- Converts `Horde_ActiveSync_Find_Params` to `Horde_ActiveSync_Search_Params` via `Horde_ActiveSync_Find_QueryMapper`
- Delegates to existing `getSearchResults()` (shared IMAP search path, result cache, pagination)
- Maps success/error to `Horde_ActiveSync_Find_Results` with appropriate Find store status codes

### `resolveLongIdForUid()`

- Delegates to `Horde_ActiveSync_Imap_Adapter::resolveLongIdForUid()`
- Resolves `mailbox:uid` when ItemOperations receives a virtual folder id that is not in the device folder cache

## Files in this PR

**Modified**

- `lib/Horde/Core/ActiveSync/Driver.php`

## Architecture

```
Horde_ActiveSync_Request_Find
  → Horde_Core_ActiveSync_Driver::getFindResults()
      → Find\QueryMapper::toSearchParams()
      → getSearchResults() → Imap Adapter _doQuery()

ItemOperations (iOS virtual folder)
  → Horde_Core_ActiveSync_Driver::resolveLongIdForUid()
      → Imap Adapter::resolveLongIdForUid()
```

## Test plan

- [ ] Requires merged or dev-pinned `horde/activesync` Find PR
- [ ] PHPUnit: existing `Horde_Core_ActiveSync` tests still pass
- [ ] Manual test on EAS 16.0 client (iPhone):
  - [ ] Mailbox search returns results (Find command)
  - [ ] Tapping a result opens the message (ItemOperations, no “Folder not found in cache”)
  - [ ] Hits from subfolders appear in global search

## Related PR

- `horde/activesync`: Add EAS 16.0 Find command support (protocol, IMAP adapter, ItemOperations fallback)

## Suggested commit message

```
feat(core): wire EAS 16.0 Find command to IMP search backend

Implement getFindResults() by mapping Find params to the existing
getSearchResults() IMAP path via QueryMapper.

Add resolveLongIdForUid() so ItemOperations can open Find hits when
iOS sends a virtual All Mailboxes folder id (M + UID).
```

## Author

Torben Dannhauer <torben@dannhauer.de>
