### PR TITLE
refactor(session+auth): Adopt Horde_Pack natively in HordeSession; introduce AuthCredentialStore

### DIFF
--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -12,6 +12,7 @@
  * @package   Core
  */
 
+use Horde\Core\Auth\AuthCredentialStore;
 use Horde\Core\Config\ConfigMetadataProvider;
 use Horde\Core\Config\Driver\DriverRepository;
 use Horde\Core\Editor\TinymcePageBinder;
@@ -2545,46 +2546,29 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function setAuthCredential($credential, $value = null, $app = null)
     {
-        global $session;
-
         if (!$this->getAuth()) {
             return;
         }
 
+        $store = $this->_credentialStore();
+
         if (is_array($credential)) {
-            $credentials = $credential;
-        } else {
-            if (($credentials = $this->_getAuthCredentials($app)) === false) {
-                return;
-            }
-
-            if (!is_array($credentials)) {
-                $credentials = [];
-            }
-
-            $credentials[$credential] = $value;
+            $store->set($app, $credential);
+        } elseif (!$store->setOne($app, $credential, $value)) {
+            return;
         }
 
-        $entry = $credentials;
-        if (($base_app = $session->get('horde', 'auth/credentials'))
-            && ($session->get('horde', 'auth_app/' . $base_app) == $entry)) {
-            $entry = true;
+        // Resolve the app the store wrote against so the cache invalidation
+        // matches the slot. setOne()/set() fall back to the base app when
+        // $app is null; mirror that here.
+        $resolvedApp = $app ?? $this->_credentialBaseApp();
+        if ($resolvedApp === null) {
+            return;
         }
-
-        if (is_null($app)) {
-            $app = $base_app;
-        }
-
-        /* The auth_app key contains application-specific authentication.
-         * Session subkeys are the app names, values are an array containing
-         * credentials. If the value is true, application does not require any
-         * specific credentials. */
-        $session->set('horde', 'auth_app/' . $app, $entry, $session::ENCRYPT);
-        $session->set('horde', 'auth_app_init/' . $app, true);
 
         unset(
-            $this->_cache['existing'][$app],
-            $this->_cache['isauth'][$app]
+            $this->_cache['existing'][$resolvedApp],
+            $this->_cache['isauth'][$resolvedApp]
         );
     }
 
@@ -2597,24 +2581,33 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     protected function _getAuthCredentials($app)
     {
+        return $this->_credentialStore()->get($app);
+    }
+
+    /**
+     * Resolve the modern AuthCredentialStore for credentials persistence.
+     *
+     * Lazy-resolved from the global injector to keep Registry's existing
+     * construction unchanged. The store owns the `auth_app/<app>` and
+     * `auth_app_init/<app>` slots; Registry retains the `auth/credentials`
+     * base-app pointer plus its own per-app caches.
+     */
+    private function _credentialStore(): AuthCredentialStore
+    {
+        return $GLOBALS['injector']->getInstance(AuthCredentialStore::class);
+    }
+
+    /**
+     * Read the base-app pointer that {@see setAuth()} writes during login.
+     * Used by {@see setAuthCredential()} to mirror the legacy fall-back when
+     * no explicit app is supplied.
+     */
+    private function _credentialBaseApp(): ?string
+    {
         global $session;
+        $value = $session->get('horde', 'auth/credentials');
 
-        $base_app = $session->get('horde', 'auth/credentials');
-        if (is_null($base_app)) {
-            return false;
-        }
-
-        if (is_null($app)) {
-            $app = $base_app;
-        }
-
-        if (!$session->exists('horde', 'auth_app/' . $app)) {
-            return ($base_app != $app)
-                ? $this->_getAuthCredentials($base_app)
-                : false;
-        }
-
-        return $session->get('horde', 'auth_app/' . $app);
+        return is_string($value) ? $value : null;
     }
 
     /**

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -34,11 +34,16 @@ use Horde\Token\Token as ModernToken;
  *   and the $GLOBALS['session'] global stable while individual call sites
  *   migrate to the modern stack.
  * - Translate legacy calls to {@see HordeSession::getScoped()} et al.
- * - Hold the legacy ENCRYPT/TYPE_ARRAY/TYPE_OBJECT serialization invariants
- *   ({@see Horde_Pack}-packed values) so existing on-disk session payloads
- *   continue to decode.
  * - Cut tokens over to the HMAC-based {@see ModernToken} service in one
  *   place so the legacy stable-randomid contract is replaced atomically.
+ *
+ * Wire format ownership:
+ *   The modern {@see HordeSession} owns the legacy ENCRYPT/TYPE_ARRAY/TYPE_OBJECT
+ *   serialization invariants. Strings get a {@see HordeSession::NOT_SERIALIZED}
+ *   prefix; arrays and objects are {@see Horde_Pack}-packed; encrypted values
+ *   are encrypt-of-pack. The shim no longer pre-packs or pre-prefixes; it just
+ *   hands raw values to {@see HordeSession::setScoped()} /
+ *   {@see HordeSession::setEncrypted()} which encode for storage.
  *
  * Treatment of $_SESSION:
  *   $_SESSION is a dumb mirror, not the source of truth. The modern
@@ -75,7 +80,12 @@ class Horde_Session
     public const TYPE_OBJECT = 2;
     public const ENCRYPT = 4; /* @since 2.7.0 */
 
-    public const NOT_SERIALIZED = "\0";
+    /**
+     * Marker prefix for raw string values. Re-exported from
+     * {@see HordeSession::NOT_SERIALIZED} so legacy callers that reference
+     * `Horde_Session::NOT_SERIALIZED` keep working unchanged.
+     */
+    public const NOT_SERIALIZED = HordeSession::NOT_SERIALIZED;
 
     public const NONCE_ID = 'session_nonce'; /* @since 2.11.0 */
     public const TOKEN_ID = 'session_token';
@@ -121,12 +131,6 @@ class Horde_Session
     private ?ModernToken $explicitTokenService = null;
 
     /**
-     * The pack service used to preserve legacy ENCRYPT/TYPE_ARRAY/TYPE_OBJECT
-     * wire format inside session values.
-     */
-    private Horde_Pack $pack;
-
-    /**
      * Indicates that the session is active (read/write).
      */
     protected bool $_active = false;
@@ -166,12 +170,10 @@ class Horde_Session
      */
     public function __construct(
         ?HordeSession $modern = null,
-        ?ModernToken $tokenService = null,
-        ?Horde_Pack $pack = null
+        ?ModernToken $tokenService = null
     ) {
         $this->modern = $modern ?? $this->_resolveModern();
         $this->explicitTokenService = $tokenService;
-        $this->pack = $pack ?? $this->_resolvePack();
 
         /* Make sure the global session variable is initialised and points to
          * the array the shim mirrors into. */
@@ -205,19 +207,6 @@ class Horde_Session
             new SessionId($sid !== '' ? $sid : 'none'),
             $_SESSION ?? []
         );
-    }
-
-    /**
-     * Resolve the pack service at construction time, with the same legacy-
-     * test fallback as {@see _resolveModern()}.
-     */
-    private function _resolvePack(): Horde_Pack
-    {
-        if (isset($GLOBALS['injector'])) {
-            return $GLOBALS['injector']->getInstance('Horde_Pack');
-        }
-
-        return new Horde_Pack();
     }
 
     /**
@@ -505,10 +494,11 @@ class Horde_Session
     /**
      * Get the value of a session variable.
      *
-     * Reverses the legacy ENCRYPT/TYPE_ARRAY/TYPE_OBJECT serialization. Values
-     * stored under the legacy contract are wrapped Horde_Pack payloads (or
-     * NOT_SERIALIZED-prefixed strings for raw scalars); this method unwraps
-     * them.
+     * Encoding/decoding (Horde_Pack-packed values, NOT_SERIALIZED-prefixed
+     * strings) is owned by the modern {@see HordeSession}. The shim just
+     * delegates and applies the legacy mask-based default-value semantics
+     * (an absent value reads as [] under TYPE_ARRAY or stdClass under
+     * TYPE_OBJECT) on top.
      *
      * @param string $app    Application name.
      * @param string $name   Session variable name.
@@ -521,34 +511,10 @@ class Horde_Session
     public function get($app, $name, $mask = 0)
     {
         if ($this->modern->hasScoped($app, $name)) {
-            $value = $this->modern->getScoped($app, $name);
-            if (!is_string($value) || strlen($value) === 0) {
-                return $value;
-            }
-
             if ($this->modern->isEncrypted($app, $name)) {
-                /* getEncrypted returns the raw decrypted bytes (a Horde_Pack
-                 * payload under our contract). */
-                $decrypted = $this->modern->getEncrypted($app, $name);
-                if (!is_string($decrypted)) {
-                    return $decrypted;
-                }
-                try {
-                    return $this->pack->unpack($decrypted);
-                } catch (Horde_Pack_Exception $e) {
-                    return null;
-                }
+                return $this->modern->getEncrypted($app, $name);
             }
-
-            if (($value[0] ?? '') === self::NOT_SERIALIZED) {
-                return substr($value, 1);
-            }
-
-            try {
-                return $this->pack->unpack($value);
-            } catch (Horde_Pack_Exception $e) {
-                return null;
-            }
+            return $this->modern->getScoped($app, $name);
         }
 
         if ($subkeys = $this->_subkeys($app, $name)) {
@@ -578,18 +544,22 @@ class Horde_Session
     /**
      * Sets the value of a session variable.
      *
-     * Preserves the legacy wire format: arrays/objects/encrypted values are
-     * Horde_Pack-packed; raw strings are NOT_SERIALIZED-prefixed. Encrypted
-     * values are then handed to {@see HordeSession::setEncrypted()} which
-     * applies the configured encryptor closure and tracks them in the
-     * encryption map for re-encryption on session ID regeneration.
+     * Encoding (Horde_Pack-packing for arrays/objects, NOT_SERIALIZED prefix
+     * for strings, raw for other scalars) is owned by the modern
+     * {@see HordeSession}. The shim just routes the value to the right
+     * accessor: encrypted slots through {@see HordeSession::setEncrypted()},
+     * everything else through {@see HordeSession::setScoped()}.
+     *
+     * The TYPE_ARRAY/TYPE_OBJECT masks are no-ops at runtime — modern
+     * HordeSession infers the wire shape from the value type itself. The
+     * constants are kept for source-compat with callers that pass them.
      *
      * @param string $app    Application name.
      * @param string $name   Session variable name.
      * @param mixed $value   Session variable value.
      * @param integer $mask  One of:
-     *   - Horde_Session::TYPE_ARRAY: Force save as an array value.
-     *   - Horde_Session::TYPE_OBJECT: Force save as an object value.
+     *   - Horde_Session::TYPE_ARRAY: Force save as an array value (no-op).
+     *   - Horde_Session::TYPE_OBJECT: Force save as an object value (no-op).
      *   - Horde_Session::ENCRYPT: Encrypt the value. (since 2.7.0)
      */
     public function set($app, $name, $value, $mask = 0)
@@ -598,35 +568,14 @@ class Horde_Session
             return;
         }
 
-        if (($mask & self::ENCRYPT)
-            || is_object($value) || ($mask & self::TYPE_OBJECT)
-            || is_array($value) || ($mask & self::TYPE_ARRAY)) {
-            $opts = ['compress' => 0];
-            if (is_object($value) || ($mask & self::TYPE_OBJECT)) {
-                $opts['phpob'] = true;
-            }
-            $packed = $this->pack->pack($value, $opts);
-
-            if ($mask & self::ENCRYPT) {
-                $this->modern->setEncrypted($app, $name, $packed);
-                $this->sessionHandler->changed = true;
-                return;
-            }
-
-            $this->modern->setScoped($app, $name, $packed);
+        if ($mask & self::ENCRYPT) {
+            $this->modern->setEncrypted($app, $name, $value);
             $this->sessionHandler->changed = true;
             return;
         }
 
-        if (is_string($value)) {
-            $value = self::NOT_SERIALIZED . $value;
-        }
-
-        if (!$this->modern->hasScoped($app, $name)
-            || ($this->modern->getScoped($app, $name) !== $value)) {
-            $this->modern->setScoped($app, $name, $value);
-            $this->sessionHandler->changed = true;
-        }
+        $this->modern->setScoped($app, $name, $value);
+        $this->sessionHandler->changed = true;
     }
 
     /**

--- a/src/Auth/AuthCredentialStore.php
+++ b/src/Auth/AuthCredentialStore.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Injector\Attribute\Factory;
+use Horde\Injector\Injector;
+
+/**
+ * Persistence layer for authenticated-user credentials.
+ *
+ * Owns the legacy `('horde', 'auth_app/<app>')` slot pair: the encrypted
+ * credentials map and the `auth_app_init/<app>` companion flag. Reads and
+ * writes go through {@see HordeSession::getEncrypted()} /
+ * {@see HordeSession::setEncrypted()} so the on-disk wire format matches
+ * what the legacy `Horde_Session::set(..., ENCRYPT)` path produced.
+ *
+ * Modern callers consume this store directly. Legacy callers go through
+ * `Horde_Registry::setAuthCredential`/`getAuthCredential` which delegate
+ * here. Both flows produce byte-identical writes at the same slot.
+ *
+ * The class deliberately does NOT touch:
+ * - `('horde', 'auth/credentials')` — Registry's base-app pointer. Registry
+ *   continues to write that slot in `setAuth()`. The store only reads it.
+ * - Registry's per-app authentication caches (`_cache['existing']`,
+ *   `_cache['isauth']`) — those are Registry-internal state. The Registry
+ *   facade clears them after delegating the persistence here.
+ */
+#[Factory(factory: AuthCredentialStoreFactory::class, method: 'create')]
+class AuthCredentialStore
+{
+    /** Session scope under which auth slots live. */
+    private const SCOPE = 'horde';
+
+    /** Slot key prefix for encrypted credentials. */
+    private const CREDENTIALS_PREFIX = 'auth_app/';
+
+    /** Slot key prefix for the init flag. */
+    private const INIT_PREFIX = 'auth_app_init/';
+
+    /** Slot key for the base-app pointer (read-only here). */
+    private const BASE_APP_KEY = 'auth/credentials';
+
+    public function __construct(
+        private readonly HordeSession $session,
+    ) {}
+
+    /**
+     * Persist a credentials array for the given app.
+     *
+     * Implements the legacy dedup-against-base-app rule: when the entry being
+     * stored matches what is already stored at the base app's slot, persist
+     * `true` instead of duplicating the array. Callers reading via
+     * {@see get()} get the materialised credentials regardless.
+     *
+     * @param string             $app         App scope. When null, falls back
+     *                                        to the base app stored under
+     *                                        `auth/credentials`.
+     * @param array<string,mixed> $credentials Full credentials array.
+     */
+    public function set(?string $app, array $credentials): void
+    {
+        $baseApp = $this->baseApp();
+
+        $entry = $credentials;
+        if ($baseApp !== null) {
+            $existingForBase = $this->session->getEncrypted(
+                self::SCOPE,
+                self::CREDENTIALS_PREFIX . $baseApp,
+            );
+            if ($existingForBase == $entry) {
+                $entry = true;
+            }
+        }
+
+        if ($app === null) {
+            $app = $baseApp;
+        }
+
+        if ($app === null) {
+            // No base app and no explicit app — nothing to anchor against.
+            return;
+        }
+
+        if ($entry === true) {
+            $this->session->setScoped(
+                self::SCOPE,
+                self::CREDENTIALS_PREFIX . $app,
+                true,
+            );
+        } else {
+            $this->session->setEncrypted(
+                self::SCOPE,
+                self::CREDENTIALS_PREFIX . $app,
+                $entry,
+            );
+        }
+        $this->session->setScoped(self::SCOPE, self::INIT_PREFIX . $app, true);
+    }
+
+    /**
+     * Update a single credential within the given app's credentials array.
+     *
+     * Reads the current credentials, sets the named key to the supplied value,
+     * and persists the result via {@see set()}. Returns false if no base app
+     * is established (i.e. the user is not authenticated through Registry).
+     */
+    public function setOne(?string $app, string $credential, mixed $value): bool
+    {
+        $current = $this->get($app);
+        if ($current === false) {
+            return false;
+        }
+
+        if (!is_array($current)) {
+            $current = [];
+        }
+        $current[$credential] = $value;
+
+        $this->set($app, $current);
+        return true;
+    }
+
+    /**
+     * Recover the credentials array for the given app.
+     *
+     * Returns false when no base app has been established (no authenticated
+     * user per Registry's contract). Returns the credentials array when the
+     * slot is present. Falls back to the base app's slot when the requested
+     * app's slot is absent — matching the legacy `_getAuthCredentials`
+     * resolver.
+     *
+     * @return array<string,mixed>|true|false
+     */
+    public function get(?string $app): array|bool
+    {
+        $baseApp = $this->baseApp();
+        if ($baseApp === null) {
+            return false;
+        }
+
+        if ($app === null) {
+            $app = $baseApp;
+        }
+
+        $slotKey = self::CREDENTIALS_PREFIX . $app;
+        if (!$this->session->hasScoped(self::SCOPE, $slotKey)) {
+            // Per legacy semantics, fall back to the base app's slot once.
+            return $app !== $baseApp ? $this->get($baseApp) : false;
+        }
+
+        // The dedup rule stores `true` to mean "same credentials as base app".
+        // Materialise that here so callers always see an array.
+        if ($this->session->isEncrypted(self::SCOPE, $slotKey)) {
+            $value = $this->session->getEncrypted(self::SCOPE, $slotKey);
+        } else {
+            $value = $this->session->getScoped(self::SCOPE, $slotKey);
+        }
+
+        if ($value === true && $app !== $baseApp) {
+            return $this->get($baseApp);
+        }
+
+        return is_array($value) ? $value : $value;
+    }
+
+    /**
+     * Clear the stored credentials and init flag for the given app.
+     *
+     * Mirrors the slot removals `Horde_Registry::clearAuthApp` makes on logout.
+     */
+    public function clear(string $app): void
+    {
+        $this->session->removeScoped(
+            self::SCOPE,
+            self::CREDENTIALS_PREFIX . $app,
+        );
+        $this->session->removeScoped(self::SCOPE, self::INIT_PREFIX . $app);
+    }
+
+    /**
+     * Whether the given app has been initialised (auth_app_init/<app> = true).
+     */
+    public function isInitialized(string $app): bool
+    {
+        return $this->session->hasScoped(self::SCOPE, self::INIT_PREFIX . $app)
+            && $this->session->getScoped(self::SCOPE, self::INIT_PREFIX . $app) === true;
+    }
+
+    /**
+     * Resolve the base app stored at `auth/credentials`. Registry writes this
+     * during `setAuth()`. Returns null when nothing is set, matching the
+     * legacy `_getAuthCredentials` precondition.
+     */
+    private function baseApp(): ?string
+    {
+        $value = $this->session->getScoped(self::SCOPE, self::BASE_APP_KEY);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/src/Auth/AuthCredentialStoreFactory.php
+++ b/src/Auth/AuthCredentialStoreFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Injector\Injector;
+
+/**
+ * DI factory for {@see AuthCredentialStore}.
+ *
+ * Resolves the modern {@see HordeSession} from the injector and hands it to
+ * the store. Kept as a separate factory file (rather than an anonymous
+ * `#[Factory]` closure) so legacy `Horde_Injector` lookups against the FQCN
+ * resolve via the same code path as the modern `#[Factory]` attribute.
+ */
+class AuthCredentialStoreFactory
+{
+    public function create(Injector $injector): AuthCredentialStore
+    {
+        return new AuthCredentialStore(
+            $injector->getInstance(HordeSession::class),
+        );
+    }
+}

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -19,6 +19,8 @@ use Horde\Injector\Attribute\Factory;
 use Horde\SessionHandler\DefaultSession;
 use Horde\SessionHandler\Exception\SessionException;
 use Horde\SessionHandler\SessionId;
+use Horde_Pack;
+use Horde_Pack_Exception;
 
 /**
  * Horde-specific session implementation with scoped keys and encryption.
@@ -46,6 +48,14 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
      */
     public const CSRF_SEED = 'horde-session-csrf';
 
+    /**
+     * Marker prefix for raw string values stored via {@see setScoped()}.
+     * A string with this single-byte prefix is unambiguously a stored
+     * string; any other byte sequence is either a non-string scalar (raw)
+     * or a {@see Horde_Pack} payload.
+     */
+    public const NOT_SERIALIZED = "\0";
+
     /** Internal key for session begin timestamp. */
     private const BEGIN_KEY = '_b';
 
@@ -57,6 +67,13 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
 
     private ?Closure $encryptor;
     private ?Closure $decryptor;
+
+    /**
+     * Pack/unpack service used to serialise arrays, objects, and the
+     * plaintext side of encrypted values, matching the wire format
+     * produced by the legacy Horde_Session for cross-compatibility.
+     */
+    private Horde_Pack $pack;
 
     /**
      * @param SessionId    $id        Session identifier
@@ -73,6 +90,7 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
         parent::__construct($id, $data);
         $this->encryptor = $encryptor;
         $this->decryptor = $decryptor;
+        $this->pack = new Horde_Pack();
     }
 
     // ---------------------------------------------------------------
@@ -81,22 +99,78 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
 
     /**
      * Get a scoped value.
+     *
+     * Reverses the wire format applied by {@see setScoped()}:
+     * - A string starting with {@see NOT_SERIALIZED} is a stored raw string
+     *   minus the marker byte.
+     * - A non-string scalar is returned as-is (integers, floats, booleans
+     *   and null go on the wire raw).
+     * - Any other string is a {@see Horde_Pack} payload and gets unpacked.
+     * - If unpacking fails (the value is some other byte sequence), the raw
+     *   value is returned to remain robust against unknown shapes.
      */
     public function getScoped(string $app, string $name): mixed
     {
-        return $this->data[$app][$name] ?? null;
+        $raw = $this->data[$app][$name] ?? null;
+
+        if ($raw === null) {
+            return null;
+        }
+        if (!is_string($raw)) {
+            return $raw;
+        }
+        if ($raw === '') {
+            return $raw;
+        }
+        if ($raw[0] === self::NOT_SERIALIZED) {
+            return substr($raw, 1);
+        }
+
+        try {
+            return $this->pack->unpack($raw);
+        } catch (Horde_Pack_Exception) {
+            return $raw;
+        }
     }
 
     /**
      * Set a scoped value.
+     *
+     * Applies the wire format last week's Horde_Session produced:
+     * - Strings get a single-byte {@see NOT_SERIALIZED} prefix.
+     * - Arrays and objects get serialised via {@see Horde_Pack} (with
+     *   `phpob` opt set for objects).
+     * - Other scalars (int, float, bool, null) go on the wire raw.
      */
     public function setScoped(string $app, string $name, mixed $value): void
     {
+        $stored = $this->encodeForStorage($value);
+
         if (!isset($this->data[$app])) {
             $this->data[$app] = [];
         }
-        $this->data[$app][$name] = $value;
+        $this->data[$app][$name] = $stored;
         $this->dirty = true;
+    }
+
+    /**
+     * Encode a value for storage in the scoped or encrypted-plaintext
+     * positions, matching the legacy Horde_Session wire format.
+     */
+    private function encodeForStorage(mixed $value): mixed
+    {
+        if (is_string($value)) {
+            return self::NOT_SERIALIZED . $value;
+        }
+        if (is_array($value) || is_object($value)) {
+            $opts = ['compress' => 0];
+            if (is_object($value)) {
+                $opts['phpob'] = true;
+            }
+            return $this->pack->pack($value, $opts);
+        }
+
+        return $value;
     }
 
     /**
@@ -242,7 +316,11 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
 
         $decrypted = ($this->decryptor)($raw);
 
-        return unserialize($decrypted);
+        try {
+            return $this->pack->unpack($decrypted);
+        } catch (Horde_Pack_Exception) {
+            return $decrypted;
+        }
     }
 
     public function setEncrypted(string $app, string $name, mixed $value): void
@@ -251,8 +329,12 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
             throw new SessionException('No encryptor configured — cannot store encrypted value');
         }
 
-        $serialized = serialize($value);
-        $encrypted = ($this->encryptor)($serialized);
+        $opts = ['compress' => 0];
+        if (is_object($value)) {
+            $opts['phpob'] = true;
+        }
+        $packed = $this->pack->pack($value, $opts);
+        $encrypted = ($this->encryptor)($packed);
 
         // Store the encrypted value
         if (!isset($this->data[$app])) {

--- a/test/Unit/Auth/AuthCredentialStoreTest.php
+++ b/test/Unit/Auth/AuthCredentialStoreTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Auth;
+
+use Horde\Core\Auth\AuthCredentialStore;
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\SessionId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin AuthCredentialStore's behaviour against the legacy
+ * Horde_Registry::setAuthCredential / getAuthCredential / _getAuthCredentials
+ * trio it replaces.
+ */
+#[CoversClass(AuthCredentialStore::class)]
+class AuthCredentialStoreTest extends TestCase
+{
+    /**
+     * Build a HordeSession with an identity-shaped encryptor/decryptor pair
+     * plus the `auth/credentials` base-app pointer pre-populated.
+     */
+    private function sessionWithBaseApp(string $baseApp): HordeSession
+    {
+        $encryptor = static fn(string $p): string => 'ENC:' . $p;
+        $decryptor = static fn(string $c): string => substr($c, 4);
+
+        $session = new HordeSession(
+            new SessionId('store-test'),
+            [],
+            $encryptor,
+            $decryptor,
+        );
+        $session->setScoped('horde', 'auth/credentials', $baseApp);
+
+        return $session;
+    }
+
+    #[Test]
+    public function getReturnsFalseWhenNoBaseAppSet(): void
+    {
+        $encryptor = static fn(string $p): string => $p;
+        $decryptor = static fn(string $c): string => $c;
+        $session = new HordeSession(
+            new SessionId('no-base'),
+            [],
+            $encryptor,
+            $decryptor,
+        );
+        $store = new AuthCredentialStore($session);
+
+        self::assertFalse($store->get(null));
+        self::assertFalse($store->get('imp'));
+    }
+
+    #[Test]
+    public function setAndGetForBaseApp(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 's3cret']);
+
+        self::assertSame(['password' => 's3cret'], $store->get(null));
+        self::assertSame(['password' => 's3cret'], $store->get('horde'));
+    }
+
+    #[Test]
+    public function setMarksAppInitialized(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        self::assertFalse($store->isInitialized('horde'));
+
+        $store->set(null, ['password' => 's3cret']);
+
+        self::assertTrue($store->isInitialized('horde'));
+    }
+
+    #[Test]
+    public function setOneAppendsToExistingCredentials(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 's3cret']);
+
+        self::assertTrue($store->setOne(null, 'mode', 'imap'));
+
+        self::assertSame(
+            ['password' => 's3cret', 'mode' => 'imap'],
+            $store->get(null),
+        );
+    }
+
+    #[Test]
+    public function setOneReturnsFalseWhenNoBaseApp(): void
+    {
+        $encryptor = static fn(string $p): string => $p;
+        $decryptor = static fn(string $c): string => $c;
+        $session = new HordeSession(
+            new SessionId('no-base'),
+            [],
+            $encryptor,
+            $decryptor,
+        );
+        $store = new AuthCredentialStore($session);
+
+        self::assertFalse($store->setOne(null, 'password', 's3cret'));
+    }
+
+    #[Test]
+    public function dedupAgainstBaseAppStoresTrueForMatchingEntry(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $credentials = ['password' => 's3cret'];
+        $store->set(null, $credentials);
+
+        // imp app gets the same credentials as the base — should be stored
+        // as `true` per the dedup rule.
+        $store->set('imp', $credentials);
+
+        // Reading imp materialises the credentials by following the dedup
+        // pointer back to the base app.
+        self::assertSame($credentials, $store->get('imp'));
+
+        // The raw payload at imp's slot is `true` (dedup marker), not the
+        // credentials array.
+        $raw = $session->toPayload()['horde']['auth_app/imp'] ?? null;
+        self::assertTrue($raw);
+    }
+
+    #[Test]
+    public function dedupAgainstBaseAppStoresEntryForDifferentValues(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 'horde-pw']);
+
+        // imp gets different credentials — should be persisted as its own
+        // encrypted entry, not deduped.
+        $store->set('imp', ['password' => 'imp-pw']);
+
+        self::assertSame(['password' => 'horde-pw'], $store->get('horde'));
+        self::assertSame(['password' => 'imp-pw'], $store->get('imp'));
+
+        // The raw payload at imp is the encrypted entry, not `true`.
+        $raw = $session->toPayload()['horde']['auth_app/imp'] ?? null;
+        self::assertNotTrue($raw);
+        self::assertIsString($raw);
+    }
+
+    #[Test]
+    public function getFallsBackToBaseAppWhenAppSlotMissing(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 'horde-pw']);
+
+        // Asking for a never-written app falls back to the base app's slot.
+        self::assertSame(['password' => 'horde-pw'], $store->get('kronolith'));
+    }
+
+    #[Test]
+    public function getReturnsFalseWhenAppAndBaseBothMissing(): void
+    {
+        // Base app set but the slot was never written for it.
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        self::assertFalse($store->get('horde'));
+        self::assertFalse($store->get('imp'));
+    }
+
+    #[Test]
+    public function clearRemovesCredentialsAndInitFlag(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 's3cret']);
+        self::assertTrue($store->isInitialized('horde'));
+
+        $store->clear('horde');
+
+        self::assertFalse($store->isInitialized('horde'));
+        // get falls through to the base-app branch — no slot, so false.
+        self::assertFalse($store->get('horde'));
+    }
+
+    #[Test]
+    public function setUsesEncryptedStorageForCredentialsArray(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 'plain-text-secret']);
+
+        $payload = $session->toPayload();
+        $rawCredentials = $payload['horde']['auth_app/horde'] ?? null;
+
+        // The stored bytes go through the configured encryptor closure; in
+        // this fixture that's an identity prefix that proves the encryptor
+        // ran. The encryption map also records the slot.
+        self::assertIsString($rawCredentials);
+        self::assertStringStartsWith('ENC:', $rawCredentials);
+        self::assertTrue($session->isEncrypted('horde', 'auth_app/horde'));
+    }
+
+    #[Test]
+    public function initFlagWiredToScopedNotEncryptedSlot(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set(null, ['password' => 's3cret']);
+
+        // The init flag is a plain boolean stored unencrypted.
+        self::assertFalse($session->isEncrypted('horde', 'auth_app_init/horde'));
+        self::assertTrue($session->getScoped('horde', 'auth_app_init/horde'));
+    }
+}

--- a/test/Unit/Session/HordeSessionFactoryTest.php
+++ b/test/Unit/Session/HordeSessionFactoryTest.php
@@ -109,10 +109,16 @@ class HordeSessionFactoryTest extends TestCase
     {
         $decryptor = fn(string $c): string => substr($c, 4);
 
+        // Encrypted plaintext is Horde_Pack-packed (matching the legacy
+        // Horde_Session::set(..., ENCRYPT) wire format). Reproduce that here
+        // rather than using bare serialize().
+        $pack = new \Horde_Pack();
+        $packed = $pack->pack('password', ['compress' => 0]);
+
         $factory = new HordeSessionFactory(null, $decryptor);
         $session = $factory->restore(new SessionId('dec-test'), [
             '_e' => ['horde' => ['auth_app/imp' => true]],
-            'horde' => ['auth_app/imp' => 'ENC:' . serialize('password')],
+            'horde' => ['auth_app/imp' => 'ENC:' . $packed],
         ]);
 
         self::assertTrue($session->isEncrypted('horde', 'auth_app/imp'));

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -131,8 +131,14 @@ class HordeSessionTest extends TestCase
 
         $payload = $session->toPayload();
 
-        self::assertSame('alice', $payload['horde']['auth/userId']);
-        self::assertSame('INBOX', $payload['imp']['mailbox']);
+        // String values go on the wire prefixed with NOT_SERIALIZED so the
+        // legacy Horde_Session can still distinguish them from packed shapes.
+        self::assertSame("\0alice", $payload['horde']['auth/userId']);
+        self::assertSame("\0INBOX", $payload['imp']['mailbox']);
+
+        // Round-trip via the public API recovers the original strings.
+        self::assertSame('alice', $session->getScoped('horde', 'auth/userId'));
+        self::assertSame('INBOX', $session->getScoped('imp', 'mailbox'));
     }
 
     #[Test]
@@ -439,7 +445,11 @@ class HordeSessionTest extends TestCase
     {
         $decryptor = fn(string $c): string => substr($c, 4);
 
-        // Simulate a legacy session payload with encryption map
+        // Simulate a legacy session payload with encryption map. The legacy
+        // Horde_Session writes encrypt(Horde_Pack::pack($value)) for ENCRYPT
+        // slots; reproduce that exact wire shape here.
+        $pack = new \Horde_Pack();
+        $packed = $pack->pack('imp-password', ['compress' => 0]);
         $legacyPayload = [
             '_b' => 1700000000,
             '_e' => [
@@ -450,7 +460,7 @@ class HordeSessionTest extends TestCase
             'horde' => [
                 'auth/userId' => 'alice',
                 'auth/timestamp' => 1700000000,
-                'auth_app/imp' => 'ENC:' . serialize('imp-password'),
+                'auth_app/imp' => 'ENC:' . $packed,
             ],
         ];
 

--- a/test/Unit/Session/WireFormatCompatibilityTest.php
+++ b/test/Unit/Session/WireFormatCompatibilityTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Session;
+
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\SessionId;
+use Horde_Pack;
+use Horde_Session;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Pin the wire-format equivalence between the legacy Horde_Session shim and
+ * the modern HordeSession.
+ *
+ * After the Horde_Pack-native HordeSession refactor, the modern session owns
+ * the wire format previously produced by the legacy Horde_Session::set path.
+ * Both writers must produce identical bytes at $_SESSION[$app][$name] for the
+ * same input value, and both readers must recover the same PHP value from
+ * those bytes.
+ *
+ * The tests use the legacy shim's no-arg constructor path (which resolves
+ * dependencies via $GLOBALS['injector']) plus a hand-built HordeSession for
+ * the direct comparison.
+ */
+#[CoversClass(HordeSession::class)]
+#[CoversClass(Horde_Session::class)]
+class WireFormatCompatibilityTest extends TestCase
+{
+    /**
+     * Read the raw wire-format bytes at the slot using the modern session's
+     * payload accessor, bypassing the readers' decode logic. This is what
+     * actually lands in $_SESSION on shutdown.
+     */
+    private function rawAt(HordeSession $session, string $app, string $name): mixed
+    {
+        return $session->toPayload()[$app][$name] ?? null;
+    }
+
+    // ---------------------------------------------------------------
+    // Equivalence: shim::set(...) and modern::setScoped/setEncrypted
+    // produce identical bytes at the slot.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function legacyAndModernProduceIdenticalBytesForString(): void
+    {
+        $modernA = new HordeSession(new SessionId('a'));
+        $modernB = new HordeSession(new SessionId('b'));
+        $shim = new Horde_Session($modernB);
+
+        $modernA->setScoped('imp', 'mailbox', 'INBOX');
+        $shim->set('imp', 'mailbox', 'INBOX');
+
+        $this->assertSame(
+            $this->rawAt($modernA, 'imp', 'mailbox'),
+            $this->rawAt($modernB, 'imp', 'mailbox'),
+            'Modern and legacy writers should produce identical bytes for a string',
+        );
+        $this->assertSame("\0INBOX", $this->rawAt($modernA, 'imp', 'mailbox'));
+    }
+
+    #[Test]
+    public function legacyAndModernProduceIdenticalBytesForArray(): void
+    {
+        $modernA = new HordeSession(new SessionId('a'));
+        $modernB = new HordeSession(new SessionId('b'));
+        $shim = new Horde_Session($modernB);
+
+        $array = ['user' => 'alice', 'role' => 'admin', 'level' => 7];
+
+        $modernA->setScoped('horde', 'profile', $array);
+        $shim->set('horde', 'profile', $array);
+
+        $this->assertSame(
+            $this->rawAt($modernA, 'horde', 'profile'),
+            $this->rawAt($modernB, 'horde', 'profile'),
+            'Modern and legacy writers should produce identical bytes for an array',
+        );
+
+        // Sanity: round-trip both through Horde_Pack — same input should
+        // produce a deterministic packed shape.
+        $pack = new Horde_Pack();
+        $expected = $pack->pack($array, ['compress' => 0]);
+        $this->assertSame($expected, $this->rawAt($modernA, 'horde', 'profile'));
+    }
+
+    #[Test]
+    public function legacyAndModernProduceIdenticalBytesForObject(): void
+    {
+        $modernA = new HordeSession(new SessionId('a'));
+        $modernB = new HordeSession(new SessionId('b'));
+        $shim = new Horde_Session($modernB);
+
+        $obj = new stdClass();
+        $obj->user = 'alice';
+        $obj->role = 'admin';
+
+        $modernA->setScoped('horde', 'who', $obj);
+        $shim->set('horde', 'who', $obj);
+
+        $this->assertSame(
+            $this->rawAt($modernA, 'horde', 'who'),
+            $this->rawAt($modernB, 'horde', 'who'),
+            'Modern and legacy writers should produce identical bytes for an object',
+        );
+
+        $pack = new Horde_Pack();
+        $expected = $pack->pack($obj, ['compress' => 0, 'phpob' => true]);
+        $this->assertSame($expected, $this->rawAt($modernA, 'horde', 'who'));
+    }
+
+    #[Test]
+    public function legacyAndModernStoreIntegerRaw(): void
+    {
+        $modernA = new HordeSession(new SessionId('a'));
+        $modernB = new HordeSession(new SessionId('b'));
+        $shim = new Horde_Session($modernB);
+
+        $modernA->setScoped('horde', 'count', 42);
+        $shim->set('horde', 'count', 42);
+
+        $this->assertSame(42, $this->rawAt($modernA, 'horde', 'count'));
+        $this->assertSame(42, $this->rawAt($modernB, 'horde', 'count'));
+    }
+
+    #[Test]
+    public function legacyAndModernProduceIdenticalEncryptedBytesForArray(): void
+    {
+        // Identity encryptor/decryptor — pin the plaintext shape, not the
+        // encryption algorithm.
+        $encryptor = static fn(string $p): string => 'ENC:' . $p;
+        $decryptor = static fn(string $c): string => substr($c, 4);
+
+        $modernA = new HordeSession(new SessionId('a'), [], $encryptor, $decryptor);
+        $modernB = new HordeSession(new SessionId('b'), [], $encryptor, $decryptor);
+        $shim = new Horde_Session($modernB);
+
+        $credentials = ['password' => 's3cret', 'mode' => 'imap'];
+
+        $modernA->setEncrypted('horde', 'auth_app/imp', $credentials);
+        $shim->set('horde', 'auth_app/imp', $credentials, Horde_Session::ENCRYPT);
+
+        $this->assertSame(
+            $this->rawAt($modernA, 'horde', 'auth_app/imp'),
+            $this->rawAt($modernB, 'horde', 'auth_app/imp'),
+            'Encrypted plaintext shape must match between legacy and modern writers',
+        );
+
+        // The plaintext side is Horde_Pack-packed.
+        $pack = new Horde_Pack();
+        $expectedPacked = $pack->pack($credentials, ['compress' => 0]);
+        $this->assertSame(
+            'ENC:' . $expectedPacked,
+            $this->rawAt($modernA, 'horde', 'auth_app/imp'),
+        );
+
+        // Both readers recover the original.
+        $this->assertSame($credentials, $modernA->getEncrypted('horde', 'auth_app/imp'));
+        $this->assertSame($credentials, $modernB->getEncrypted('horde', 'auth_app/imp'));
+    }
+
+    // ---------------------------------------------------------------
+    // Cross-reader: bytes written via either writer round-trip through
+    // either reader.
+    // ---------------------------------------------------------------
+
+    public static function roundTripValues(): array
+    {
+        return [
+            'string' => ['hello'],
+            'empty string' => [''],
+            'string with null bytes' => ["a\0b\0c"],
+            'integer' => [42],
+            'zero' => [0],
+            'negative integer' => [-7],
+            'float' => [3.14],
+            'boolean true' => [true],
+            'boolean false' => [false],
+            'array of strings' => [['a', 'b', 'c']],
+            'associative array' => [['user' => 'alice', 'role' => 'admin']],
+            'nested array' => [['outer' => ['inner' => 'value']]],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('roundTripValues')]
+    public function modernWriteShimRead(mixed $value): void
+    {
+        $modern = new HordeSession(new SessionId('round-trip'));
+        $shim = new Horde_Session($modern);
+
+        $modern->setScoped('app', 'key', $value);
+
+        $this->assertSame($value, $shim->get('app', 'key'));
+    }
+
+    #[Test]
+    #[DataProvider('roundTripValues')]
+    public function shimWriteModernRead(mixed $value): void
+    {
+        $modern = new HordeSession(new SessionId('round-trip'));
+        $shim = new Horde_Session($modern);
+
+        $shim->set('app', 'key', $value);
+
+        $this->assertSame($value, $modern->getScoped('app', 'key'));
+    }
+
+    // ---------------------------------------------------------------
+    // Recorded-format readability: an on-disk payload taken from a
+    // pre-shim Horde_Session writer is readable by the modern reader.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function preShimRecordedPayloadStillReadable(): void
+    {
+        // Reproduce what last week's pre-shim Horde_Session::set wrote:
+        // - strings: NOT_SERIALIZED-prefixed
+        // - arrays/objects: Horde_Pack::pack
+        // - other scalars: raw
+        $pack = new Horde_Pack();
+        $recorded = [
+            '_b' => 1700000000,
+            '_e' => [
+                'horde' => ['auth_app/imp' => true],
+            ],
+            'horde' => [
+                'auth/userId' => "\0alice",
+                'auth/timestamp' => 1700000000,
+                'profile' => $pack->pack(['role' => 'admin'], ['compress' => 0]),
+                'auth_app/imp' => 'ENC:' . $pack->pack(
+                    ['password' => 'secret'],
+                    ['compress' => 0],
+                ),
+            ],
+            'imp' => [
+                'mailbox' => "\0INBOX",
+            ],
+        ];
+
+        $decryptor = static fn(string $c): string => substr($c, 4);
+        $session = new HordeSession(
+            new SessionId('recorded'),
+            $recorded,
+            null,
+            $decryptor,
+        );
+
+        $this->assertSame('alice', $session->getScoped('horde', 'auth/userId'));
+        $this->assertSame(1700000000, $session->getScoped('horde', 'auth/timestamp'));
+        $this->assertSame(['role' => 'admin'], $session->getScoped('horde', 'profile'));
+        $this->assertSame('INBOX', $session->getScoped('imp', 'mailbox'));
+        $this->assertSame(
+            ['password' => 'secret'],
+            $session->getEncrypted('horde', 'auth_app/imp'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`HordeSession` now owns the legacy on-disk wire format (NOT_SERIALIZED-prefixed strings, Horde_Pack-packed arrays and objects, raw non-string scalars, encrypt-of-pack for encrypted slots). The `Horde_Session` shim becomes a thin facade that delegates without pre-packing or pre-prefixing. `DefaultSession` in `horde/SessionHandler` stays Horde-domain-free.

`Horde\Core\Auth\AuthCredentialStore` is a new focused class that owns the `('horde','auth_app/<app>')` encrypted-credentials slot plus the `auth_app_init/<app>` companion. `Horde_Registry::setAuthCredential`/`getAuthCredential`/`_getAuthCredentials` delegate to it. Public API and observable behaviour unchanged.

Modern callers reading via `setScoped`/`getScoped`/`setEncrypted`/`getEncrypted` or via `AuthCredentialStore` get back native PHP values transparently. In-flight sessions on deploy keep working byte-for-byte.

## Downstream

A follow-up PR on `horde/base` uses `AuthCredentialStore` to fix `AuthenticationService::issueTokensForAuthenticatedUser` (a pre-existing HTTP 500 defect). That PR must not release before this Core change ships.

Refs horde/Core#131