### PR TITLE
fix/hordesession encryptor from injector

### DIFF
--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -67,7 +67,7 @@ use Horde\Token\Token as ModernToken;
  * @property-write array $session_data       Manually set session data (since
  *                                           2.5.0).
  */
-class Horde_Session
+class Horde_Session implements Horde_Shutdown_Task
 {
     /* Class constants. */
     public const BEGIN = '_b';
@@ -324,6 +324,15 @@ class Horde_Session
         $modernHandler = $injector->getInstance(ModernSessionHandler::class);
         session_set_save_handler($modernHandler, true);
 
+        /* Mirror the modern HordeSession payload back into $_SESSION before
+         * PHP runs its own session save. The shim treats $_SESSION as a
+         * write-only mirror at end-of-request: HordeSession owns the data,
+         * and PHP's native save handler serialises whatever sits in $_SESSION
+         * when it runs. Without a shutdown task here, only data written
+         * directly to $_SESSION (e.g. _b/_r) survives across requests, and
+         * scoped/encrypted writes that live in HordeSession are lost. */
+        Horde_Shutdown::add($this);
+
         if ($start) {
             $this->start();
             $this->_start();
@@ -447,6 +456,23 @@ class Horde_Session
             && ($GLOBALS['registry']->getAuth() !== false);
         $this->_mirrorToSession();
         session_write_close();
+    }
+
+    /**
+     * Shutdown task: mirror the modern session payload into $_SESSION so the
+     * native PHP save handler picks up scoped/encrypted writes when it runs
+     * automatically at request end.
+     *
+     * close() does the same thing but also explicitly calls
+     * session_write_close(). For requests that never call close() (the
+     * common write-mode path), this shutdown hook is what carries the
+     * modern data across to the persisted session.
+     */
+    public function shutdown()
+    {
+        if ($this->_active) {
+            $this->_mirrorToSession();
+        }
     }
 
     /**
@@ -815,12 +841,23 @@ class Horde_Session
      * preserved. Used by start() (after session_start populates $_SESSION),
      * clean() and destroy() (after $_SESSION is cleared), and by
      * __set('session_data') (after a foreign payload is swapped in).
+     *
+     * The freshly-built instance is also registered as the injector singleton
+     * so callers that resolve HordeSession via getInstance (e.g. modern
+     * AuthCredentialStore) see the same object the shim mirrors back to
+     * $_SESSION on close(). Without this, two HordeSession instances coexist:
+     * the shim's authoritative one and a stale singleton that silently swallows
+     * writes from modern callers.
      */
     private function _rebuildModern(): void
     {
         if (isset($GLOBALS['injector'])) {
             $this->modern = $GLOBALS['injector']->createInstance(
                 HordeSession::class
+            );
+            $GLOBALS['injector']->setInstance(
+                HordeSession::class,
+                $this->modern
             );
             return;
         }

--- a/src/Auth/AuthCredentialStore.php
+++ b/src/Auth/AuthCredentialStore.php
@@ -34,10 +34,10 @@ use Horde\Injector\Injector;
  * here. Both flows produce byte-identical writes at the same slot.
  *
  * The class deliberately does NOT touch:
- * - `('horde', 'auth/credentials')` — Registry's base-app pointer. Registry
+ * - `('horde', 'auth/credentials')`: Registry's base-app pointer. Registry
  *   continues to write that slot in `setAuth()`. The store only reads it.
  * - Registry's per-app authentication caches (`_cache['existing']`,
- *   `_cache['isauth']`) — those are Registry-internal state. The Registry
+ *   `_cache['isauth']`): those are Registry-internal state. The Registry
  *   facade clears them after delegating the persistence here.
  */
 #[Factory(factory: AuthCredentialStoreFactory::class, method: 'create')]
@@ -92,7 +92,7 @@ class AuthCredentialStore
         }
 
         if ($app === null) {
-            // No base app and no explicit app — nothing to anchor against.
+            // No base app and no explicit app: nothing to anchor against.
             return;
         }
 
@@ -141,7 +141,7 @@ class AuthCredentialStore
      * Returns false when no base app has been established (no authenticated
      * user per Registry's contract). Returns the credentials array when the
      * slot is present. Falls back to the base app's slot when the requested
-     * app's slot is absent — matching the legacy `_getAuthCredentials`
+     * app's slot is absent, matching the legacy `_getAuthCredentials`
      * resolver.
      *
      * @return array<string,mixed>|true|false

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -28,7 +28,7 @@ use Horde_Pack_Exception;
  * Stores data in the same two-level structure as the legacy Horde_Session:
  * $data[$app][$name] for application-scoped values, and $data['_b'],
  * $data['_e'], $data['_r'] for internal metadata. This makes it
- * wire-compatible with sessions created by the legacy handler — both
+ * wire-compatible with sessions created by the legacy handler. Both
  * produce the same $_SESSION layout when exposed through PHP's native
  * session machinery.
  *
@@ -94,7 +94,7 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
     }
 
     // ---------------------------------------------------------------
-    // Scoped access — two-level $data[$app][$name]
+    // Scoped access: two-level $data[$app][$name]
     // ---------------------------------------------------------------
 
     /**
@@ -326,7 +326,7 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
     public function setEncrypted(string $app, string $name, mixed $value): void
     {
         if ($this->encryptor === null) {
-            throw new SessionException('No encryptor configured — cannot store encrypted value');
+            throw new SessionException('No encryptor configured. Cannot store encrypted value.');
         }
 
         $opts = ['compress' => 0];

--- a/src/Session/HordeSessionFactory.php
+++ b/src/Session/HordeSessionFactory.php
@@ -18,6 +18,7 @@ use Horde\Injector\Injector;
 use Horde\SessionHandler\DefaultSessionFactory;
 use Horde\SessionHandler\Session;
 use Horde\SessionHandler\SessionId;
+use Horde_Core_Secret_Cbc;
 
 /**
  * Factory that creates HordeSession instances with encryption closures.
@@ -54,14 +55,25 @@ class HordeSessionFactory extends DefaultSessionFactory
      * DI factory method: wrap the current PHP session in a HordeSession.
      *
      * Called by the injector when HordeSession is requested via
-     * its #[Factory] attribute. Encryption closures are not available
-     * through DI auto-wiring, so the returned session reads raw values.
+     * its #[Factory] attribute. Resolves Horde_Core_Secret_Cbc from the
+     * injector and wraps it in lazy closures so the per-session key is
+     * looked up at write/read time. setKey() is called during
+     * Horde_Session::clean() at login, after this factory has already
+     * built the session, so capturing the key eagerly would be wrong.
      */
     public function create(Injector $injector): HordeSession
     {
+        $secret = $injector->getInstance(Horde_Core_Secret_Cbc::class);
+        $encryptor = static fn (string $plaintext): string
+            => (string) $secret->write($secret->getKey(), $plaintext);
+        $decryptor = static fn (string $ciphertext): string
+            => (string) $secret->read($secret->getKey(), $ciphertext);
+
         return new HordeSession(
             new SessionId(session_id() ?: 'none'),
             $_SESSION ?? [],
+            $encryptor,
+            $decryptor,
         );
     }
 }

--- a/src/Session/HordeSessionFactory.php
+++ b/src/Session/HordeSessionFactory.php
@@ -18,7 +18,6 @@ use Horde\Injector\Injector;
 use Horde\SessionHandler\DefaultSessionFactory;
 use Horde\SessionHandler\Session;
 use Horde\SessionHandler\SessionId;
-use Horde_Core_Secret_Cbc;
 
 /**
  * Factory that creates HordeSession instances with encryption closures.
@@ -55,15 +54,20 @@ class HordeSessionFactory extends DefaultSessionFactory
      * DI factory method: wrap the current PHP session in a HordeSession.
      *
      * Called by the injector when HordeSession is requested via
-     * its #[Factory] attribute. Resolves Horde_Core_Secret_Cbc from the
-     * injector and wraps it in lazy closures so the per-session key is
-     * looked up at write/read time. setKey() is called during
-     * Horde_Session::clean() at login, after this factory has already
-     * built the session, so capturing the key eagerly would be wrong.
+     * its #[Factory] attribute. Resolves the configured Horde_Secret_Cbc
+     * service from the injector (the binding registered in
+     * DefaultInjectorBindings carries the IV from $conf['secret_key'])
+     * and wraps it in lazy closures so the per-session key is read at
+     * write/read time. setKey() runs during Horde_Session::clean() at
+     * login, after this factory has already built the session, so
+     * capturing the key eagerly would be wrong. The legacy binding name
+     * `Horde_Secret_Cbc` is used deliberately. Asking for the
+     * `Horde_Core_Secret_Cbc` class directly bypasses the factory and
+     * yields an instance with no IV configured.
      */
     public function create(Injector $injector): HordeSession
     {
-        $secret = $injector->getInstance(Horde_Core_Secret_Cbc::class);
+        $secret = $injector->getInstance('Horde_Secret_Cbc');
         $encryptor = static fn (string $plaintext): string
             => (string) $secret->write($secret->getKey(), $plaintext);
         $decryptor = static fn (string $ciphertext): string

--- a/test/Unit/Session/HordeSessionFactoryTest.php
+++ b/test/Unit/Session/HordeSessionFactoryTest.php
@@ -14,8 +14,11 @@ namespace Horde\Core\Test\Unit\Session;
 use Horde\Core\Session\HordeSession;
 use Horde\Core\Session\HordeSessionFactory;
 use Horde\Core\Session\SessionMetaInterface;
+use Horde\Injector\Injector;
+use Horde\Injector\TopLevel;
 use Horde\SessionHandler\DefaultSessionFactory;
 use Horde\SessionHandler\SessionId;
+use Horde_Core_Secret_Cbc;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -133,5 +136,87 @@ class HordeSessionFactoryTest extends TestCase
 
         self::assertInstanceOf(HordeSession::class, $session);
         self::assertNull($session->getAuthenticatedUser());
+    }
+
+    /**
+     * Regression: the DI auto-wire path used to construct a HordeSession
+     * with null encryptor/decryptor, which made setEncrypted() throw on
+     * every login (Horde_Registry::setAuthCredential delegates here through
+     * AuthCredentialStore). The factory must resolve Horde_Core_Secret_Cbc
+     * from the injector and wrap it in lazy closures so the per-session
+     * key is read at call time, not at factory time.
+     */
+    #[Test]
+    public function testCreateWiresEncryptionClosuresFromInjector(): void
+    {
+        $secret = $this->createMock(Horde_Core_Secret_Cbc::class);
+        $secret->expects(self::exactly(2))
+            ->method('getKey')
+            ->willReturn('the-session-key');
+        $secret->expects(self::once())
+            ->method('write')
+            ->willReturnCallback(static function (string $k, string $p): string {
+                self::assertSame('the-session-key', $k);
+                return 'CT:' . $p;
+            });
+        $secret->expects(self::once())
+            ->method('read')
+            ->willReturnCallback(static function (string $k, string $c): string {
+                self::assertSame('the-session-key', $k);
+                return substr($c, 3);
+            });
+
+        $injector = new Injector(new TopLevel());
+        $injector->setInstance(Horde_Core_Secret_Cbc::class, $secret);
+
+        $factory = new HordeSessionFactory();
+        $session = $factory->create($injector);
+
+        $session->setEncrypted('horde', 'auth_app/imp', ['user' => 'alice']);
+        self::assertSame(['user' => 'alice'], $session->getEncrypted('horde', 'auth_app/imp'));
+    }
+
+    /**
+     * The closures must defer key resolution until call time. Horde_Session::clean()
+     * calls Horde_Core_Secret_Cbc::setKey() during login, after the factory has
+     * already built the session. Capturing the key at factory time would lock
+     * in the pre-login key.
+     */
+    #[Test]
+    public function testCreateClosuresResolveKeyLazily(): void
+    {
+        $keys = ['first-key', 'second-key'];
+        $callIndex = 0;
+
+        $secret = $this->createMock(Horde_Core_Secret_Cbc::class);
+        $secret->expects(self::exactly(2))
+            ->method('getKey')
+            ->willReturnCallback(
+                static function () use (&$callIndex, $keys): string {
+                    return $keys[$callIndex++] ?? 'overflow';
+                }
+            );
+        $observedKeys = [];
+        $secret->expects(self::exactly(2))
+            ->method('write')
+            ->willReturnCallback(
+                static function (string $key, string $plaintext) use (&$observedKeys): string {
+                    $observedKeys[] = $key;
+                    return 'CT:' . $plaintext;
+                }
+            );
+
+        $injector = new Injector(new TopLevel());
+        $injector->setInstance(Horde_Core_Secret_Cbc::class, $secret);
+
+        $factory = new HordeSessionFactory();
+        $session = $factory->create($injector);
+
+        // Two writes against the same session: the key changes between calls,
+        // proving the closure asks the secret for getKey() each time.
+        $session->setEncrypted('horde', 'auth_app/imp', 'one');
+        $session->setEncrypted('horde', 'auth_app/turba', 'two');
+
+        self::assertSame(['first-key', 'second-key'], $observedKeys);
     }
 }

--- a/test/Unit/Session/HordeSessionFactoryTest.php
+++ b/test/Unit/Session/HordeSessionFactoryTest.php
@@ -167,7 +167,7 @@ class HordeSessionFactoryTest extends TestCase
             });
 
         $injector = new Injector(new TopLevel());
-        $injector->setInstance(Horde_Core_Secret_Cbc::class, $secret);
+        $injector->setInstance('Horde_Secret_Cbc', $secret);
 
         $factory = new HordeSessionFactory();
         $session = $factory->create($injector);
@@ -207,7 +207,7 @@ class HordeSessionFactoryTest extends TestCase
             );
 
         $injector = new Injector(new TopLevel());
-        $injector->setInstance(Horde_Core_Secret_Cbc::class, $secret);
+        $injector->setInstance('Horde_Secret_Cbc', $secret);
 
         $factory = new HordeSessionFactory();
         $session = $factory->create($injector);


### PR DESCRIPTION
- **refactor: Get the AuthCredentialStore encryptor via injector**
- **refactor: Explicitly flush the HordeSession to the backend on request shutdown.**
