### PR TITLE
refactor(session): Port long-tail Horde_Session shim consumers off the shim

### DIFF
--- a/lib/Horde/Config.php
+++ b/lib/Horde/Config.php
@@ -18,6 +18,7 @@
 use Horde\Core\Config\ConfigMetadataProvider;
 use Horde\Core\Config\Legacy\LegacyConfigAdapter;
 use Horde\Core\Horde;
+use Horde\Core\Session\HordeSession;
 use Horde\Injector\Injector;
 use Horde\Util\Util;
 use Horde\Util\Variables;
@@ -351,7 +352,8 @@ class Horde_Config
         }
 
         /* Cannot write. Save to session. */
-        $GLOBALS['session']->set('horde', 'config/' . $this->_app, $php);
+        $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->setScoped('horde', 'config/' . $this->_app, $php);
 
         return false;
     }

--- a/lib/Horde/Core/Auth/Application.php
+++ b/lib/Horde/Core/Auth/Application.php
@@ -13,6 +13,8 @@
  * @package  Core
  */
 
+use Horde\Core\Session\HordeSession;
+
 /**
  * The Horde_Core_Auth_Application class provides application-specific
  * authentication built on top of the horde/Auth API.
@@ -738,7 +740,8 @@ class Horde_Core_Auth_Application extends Horde_Auth_Base
         ]);
 
         /* Only set the view mode on initial authentication */
-        if (!$GLOBALS['session']->exists('horde', 'view')) {
+        if (!$GLOBALS['injector']->getInstance(HordeSession::class)
+            ->hasScoped('horde', 'view')) {
             $this->_setView();
         }
 

--- a/lib/Horde/Core/Block/Layout/Manager.php
+++ b/lib/Horde/Core/Block/Layout/Manager.php
@@ -1,5 +1,8 @@
 <?php
 
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Exception\TokenException;
+use Horde\Token\Token;
 use Horde\Util\Util;
 
 /**
@@ -216,7 +219,18 @@ class Horde_Core_Block_Layout_Manager extends Horde_Core_Block_Layout implements
                 // Save the changes made to a block and continue editing.
             case 'save-resume':
                 // Check form token.
-                $GLOBALS['session']->checkToken(Util::getFormData('token'));
+                $tokenService = $GLOBALS['injector']->getInstance(Token::class);
+                try {
+                    $valid = $tokenService->isValid(
+                        (string) Util::getFormData('token'),
+                        HordeSession::CSRF_SEED
+                    );
+                } catch (TokenException $e) {
+                    throw new Horde_Exception('Invalid token!');
+                }
+                if (!$valid) {
+                    throw new Horde_Exception('Invalid token!');
+                }
 
                 // Get requested block type.
                 [$newapp, $newtype] = explode(':', Util::getFormData('app'));

--- a/lib/Horde/Core/Factory/Prefs.php
+++ b/lib/Horde/Core/Factory/Prefs.php
@@ -25,6 +25,7 @@
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 use Horde\Core\Horde;
+use Horde\Core\Session\HordeSession;
 
 class Horde_Core_Factory_Prefs extends Horde_Core_Factory_Base
 {
@@ -197,8 +198,9 @@ class Horde_Core_Factory_Prefs extends Horde_Core_Factory_Base
      */
     protected function _notifyError($e)
     {
-        if (!$GLOBALS['session']->get('horde', 'no_prefs')) {
-            $GLOBALS['session']->set('horde', 'no_prefs', true);
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
+        if (!$session->getScoped('horde', 'no_prefs')) {
+            $session->setScoped('horde', 'no_prefs', true);
             if (isset($GLOBALS['notification'])) {
                 $GLOBALS['notification']->push(Horde_Core_Translation::t('The preferences backend is currently unavailable and your preferences have not been loaded. You may continue to use the system with default preferences.'));
                 Horde::log($e);

--- a/lib/Horde/Core/LoginTasks.php
+++ b/lib/Horde/Core/LoginTasks.php
@@ -10,10 +10,14 @@
  * did not receive this file, see http://www.horde.org/licenses/lgpl21.
  *
  * @author   Michael Slusarz <slusarz@horde.org>
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
  * @category Horde
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  * @package  Core
  */
+
+use Horde\Core\Session\HordeSession;
+
 class Horde_Core_LoginTasks extends Horde_LoginTasks
 {
     /**
@@ -42,7 +46,8 @@ class Horde_Core_LoginTasks extends Horde_LoginTasks
         }
 
         if (($this->_app != 'horde')
-            && ($GLOBALS['session']->get('horde', 'logintasks') !== true)) {
+            && ($GLOBALS['injector']->getInstance(HordeSession::class)
+                ->getScoped('horde', 'logintasks') !== true)) {
             $GLOBALS['injector']->getInstance('Horde_Core_Factory_LoginTasks')->create('horde')->runTasks($opts);
         }
 

--- a/lib/Horde/Core/LoginTasks/Backend/Horde.php
+++ b/lib/Horde/Core/LoginTasks/Backend/Horde.php
@@ -11,9 +11,13 @@
  *
  * @author   Michael Slusarz <slusarz@horde.org>
  * @author   Gunnar Wrobel <wrobel@pardus.de>
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
  * @category Horde
  * @package  Core
  */
+
+use Horde\Core\Session\HordeSession;
+
 class Horde_Core_LoginTasks_Backend_Horde extends Horde_LoginTasks_Backend
 {
     /**
@@ -42,7 +46,8 @@ class Horde_Core_LoginTasks_Backend_Horde extends Horde_LoginTasks_Backend
      */
     public function getTasklistFromCache()
     {
-        return $GLOBALS['session']->get($this->_app, 'logintasks');
+        return $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->getScoped($this->_app, 'logintasks');
     }
 
     /**
@@ -53,7 +58,8 @@ class Horde_Core_LoginTasks_Backend_Horde extends Horde_LoginTasks_Backend
      */
     public function storeTasklistInCache($tasklist)
     {
-        $GLOBALS['session']->set($this->_app, 'logintasks', $tasklist);
+        $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->setScoped($this->_app, 'logintasks', $tasklist);
     }
 
     /**

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -59,6 +59,8 @@ use Horde\Core\Factory\SecretManagerFactory;
 use Horde\Core\Service\OAuthHttpClientService;
 use Horde\Core\Service\OAuthProviderConfigRepository;
 use Horde\Core\Service\OAuthTokenService;
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Token;
 use Horde\Db\Adapter as DbAdapter;
 use Horde\Horde\Factory\OAuthHttpClientServiceFactory as BaseOAuthHttpClientServiceFactory;
 use Horde\Horde\Factory\OAuthTokenServiceFactory as BaseOAuthTokenServiceFactory;
@@ -716,15 +718,18 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function rebuild()
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
         $app = $this->getApp();
 
         $this->applications = $this->_apiList = $this->_cache['conf'] = $this->_cache['ob'] = $this->_interfaces = [];
 
-        $session->remove('horde', 'nls/');
-        $session->remove('horde', 'registry/');
-        $session->remove('horde', self::REGISTRY_CACHE);
+        foreach ($session->keysForApp('horde') as $key) {
+            if (str_starts_with($key, 'nls/') || str_starts_with($key, 'registry/')) {
+                $session->removeScoped('horde', $key);
+            }
+        }
+        $session->removeScoped('horde', self::REGISTRY_CACHE);
 
         $this->_loadApplications();
 
@@ -805,12 +810,12 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     protected function _cacheId($hash = null)
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
         if (!is_null($hash)) {
             $hash = hash('md5', $hash);
-            $session->set('horde', self::REGISTRY_CACHE, $hash);
-        } elseif (!($hash = $session->get('horde', self::REGISTRY_CACHE))) {
+            $session->setScoped('horde', self::REGISTRY_CACHE, $hash);
+        } elseif (!($hash = $session->getScoped('horde', self::REGISTRY_CACHE))) {
             return false;
         }
 
@@ -1513,7 +1518,12 @@ class Horde_Registry implements Horde_Shutdown_Task
                     $app = 'horde';
                 }
                 return Horde::url('services/ajax.php/' . $app . '/', $full, $opts)
-                           ->add('token', $GLOBALS['session']->getToken());
+                           ->add(
+                               'token',
+                               (string) $GLOBALS['injector']
+                                   ->getInstance(Token::class)
+                                   ->generate(HordeSession::CSRF_SEED)
+                           );
 
             case 'cache':
                 $opts['append_session'] = -1;
@@ -2073,7 +2083,8 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function setView($view = self::VIEW_BASIC)
     {
-        $GLOBALS['session']->set('horde', 'view', $view);
+        $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->setScoped('horde', 'view', $view);
     }
 
     /**
@@ -2083,10 +2094,10 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function getView()
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
-        return $session->exists('horde', 'view')
-            ? $session->get('horde', 'view')
+        return $session->hasScoped('horde', 'view')
+            ? $session->getScoped('horde', 'view')
             : self::VIEW_BASIC;
     }
 
@@ -2196,7 +2207,7 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function clearAuth($destroy = true)
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
         /* Do application logout tasks. */
         /* @todo: Replace with exclusively registered logout tasks. */
@@ -2212,14 +2223,21 @@ class Horde_Registry implements Horde_Shutdown_Task
         $logout->run();
 
         // @suspicious shouldn't this be 'auth/'
-        $session->remove('horde', 'auth');
-        $session->remove('horde', 'auth_app/');
+        $session->removeScoped('horde', 'auth');
+        foreach ($session->keysForApp('horde') as $key) {
+            if (str_starts_with($key, 'auth_app/')) {
+                $session->removeScoped('horde', $key);
+            }
+        }
 
         $this->_cache['auth'] = null;
         $this->_cache['existing'] = $this->_cache['isauth'] = [];
 
         if ($destroy) {
-            $session->destroy();
+            // session_destroy() is a lifecycle operation that the shim
+            // wraps; HordeSession does not yet expose a lifecycle surface,
+            // so this stays on the shim until the shim itself is removed.
+            $GLOBALS['session']->destroy();
         }
     }
 
@@ -2232,17 +2250,20 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function clearAuthApp($app)
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
-        if ($session->get('horde', 'auth/credentials') == $app) {
+        if ($session->getScoped('horde', 'auth/credentials') == $app) {
             return false;
         }
 
         if ($this->isAuthenticated(['app' => $app, 'notransparent' => true])) {
             $this->callAppMethod($app, 'logout');
-            $session->remove($app);
-            $session->remove('horde', 'auth_app/' . $app);
-            $session->remove('horde', 'auth_app_init/' . $app);
+            // Wipe the app's entire session scope.
+            foreach ($session->keysForApp($app) as $key) {
+                $session->removeScoped($app, $key);
+            }
+            // Drop the credentials slots via the canonical store.
+            $this->_credentialStore()->clear($app);
         }
 
         unset(
@@ -2379,7 +2400,9 @@ class Horde_Registry implements Horde_Shutdown_Task
         if (empty($options['app'])
             || ($options['app'] == 'horde')
             || ($options['reason'] == Horde_Auth::REASON_LOGOUT)) {
-            $params['horde_logout_token'] = $GLOBALS['session']->getToken();
+            $params['horde_logout_token'] = (string) $GLOBALS['injector']
+                ->getInstance(Token::class)
+                ->generate(HordeSession::CSRF_SEED);
         }
 
         if (isset($options['app'])) {
@@ -2459,23 +2482,19 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function getAuth($format = null)
     {
-        global $session;
-
         if (is_null($format) && !is_null($this->_cache['auth'])) {
             return $this->_cache['auth'];
         }
 
-        if (!isset($session)) {
-            return false;
-        }
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
         if ($format == 'original') {
-            return $session->exists('horde', 'auth/authId')
-                ? $session->get('horde', 'auth/authId')
+            return $session->hasScoped('horde', 'auth/authId')
+                ? $session->getScoped('horde', 'auth/authId')
                 : false;
         }
 
-        $user = $session->get('horde', 'auth/userId');
+        $user = $session->getScoped('horde', 'auth/userId');
         if (is_null($user)) {
             return false;
         }
@@ -2506,7 +2525,8 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function passwordChangeRequested()
     {
-        return (bool) $GLOBALS['session']->get('horde', 'auth/change');
+        return (bool) $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->getScoped('horde', 'auth/change');
     }
 
     /**
@@ -2604,8 +2624,8 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     private function _credentialBaseApp(): ?string
     {
-        global $session;
-        $value = $session->get('horde', 'auth/credentials');
+        $value = $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->getScoped('horde', 'auth/credentials');
 
         return is_string($value) ? $value : null;
     }
@@ -2903,9 +2923,18 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function getAuthInfo()
     {
-        global $session;
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
 
-        return $session->get('horde', 'auth/', $session::TYPE_ARRAY);
+        // Reproduce the legacy "prefix get" semantics: read all keys
+        // starting with "auth/" under the horde scope, return them as a
+        // map of suffix => value.
+        $info = [];
+        foreach ($session->keysForApp('horde') as $key) {
+            if (str_starts_with($key, 'auth/')) {
+                $info[substr($key, 5)] = $session->getScoped('horde', $key);
+            }
+        }
+        return $info;
     }
 
     /**
@@ -2917,11 +2946,13 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function getAuthApps()
     {
-        global $session;
-
-        return array_keys(
-            $session->get('horde', 'auth_app/', $session::TYPE_ARRAY)
-        );
+        $apps = [];
+        foreach ($GLOBALS['injector']->getInstance(HordeSession::class)->keysForApp('horde') as $key) {
+            if (str_starts_with($key, 'auth_app/')) {
+                $apps[] = substr($key, 9);
+            }
+        }
+        return $apps;
     }
 
     /* NLS functions. */
@@ -2966,9 +2997,11 @@ class Horde_Registry implements Horde_Shutdown_Task
      */
     public function preferredLang($lang = null)
     {
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
+
         /* Check if we have a language set in the session */
-        if ($GLOBALS['session']->exists('horde', 'language')) {
-            return basename($GLOBALS['session']->get('horde', 'language'));
+        if ($session->hasScoped('horde', 'language')) {
+            return basename($session->getScoped('horde', 'language'));
         }
 
         /* If language pref exists, we should use that. */
@@ -3039,7 +3072,8 @@ class Horde_Registry implements Horde_Shutdown_Task
             $lang = $this->preferredLang();
         }
 
-        $GLOBALS['session']->set('horde', 'language', $lang);
+        $GLOBALS['injector']->getInstance(HordeSession::class)
+            ->setScoped('horde', 'language', $lang);
 
         $changed = false;
         if (isset($GLOBALS['language'])) {
@@ -3103,7 +3137,12 @@ class Horde_Registry implements Horde_Shutdown_Task
             return;
         }
 
-        $GLOBALS['session']->remove('horde', 'nls/');
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
+        foreach ($session->keysForApp('horde') as $key) {
+            if (str_starts_with($key, 'nls/')) {
+                $session->removeScoped('horde', $key);
+            }
+        }
     }
 
     /**

--- a/lib/Horde/Registry/Application.php
+++ b/lib/Horde/Registry/Application.php
@@ -14,6 +14,7 @@
  */
 
 use Horde\Backup;
+use Horde\Core\Session\HordeSession;
 use Horde\Util\Variables;
 
 /**
@@ -533,8 +534,9 @@ class Horde_Registry_Application implements Horde_Shutdown_Task
      */
     final public function updateSessVars()
     {
+        $session = $GLOBALS['injector']->getInstance(HordeSession::class);
         foreach ($this->_sessVars as $key => $val) {
-            $GLOBALS['session']->set($this->_app, $key, $val);
+            $session->setScoped($this->_app, $key, $val);
         }
         $this->_sessVars = [];
     }


### PR DESCRIPTION
Eight commits, one per file. Each Group-G-shaped: data sites move to `HordeSession::getScoped`/`setScoped`/`hasScoped`/`removeScoped`/`keysForApp`. Token sites move to `Horde\Token\Token` via DI with the canonical `HordeSession::CSRF_SEED` seed. `Registry::clearAuthApp` routes the `auth_app/<app>` slot drop through the canonical `AuthCredentialStore::clear()`.

Cuts horde/Core's active shim sites from 33 to 8. The remaining eight (3 bootstrap publication, 2 lifecycle, 2 admin-path $_SESSION swap, 1 `regenerate_due` property) are the deferred categories the consolidated cutover doc lists.

Refs horde/Core#131