### PR TITLE
fix(core): use ActiveSync user identity for meeting iTip reply

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3246,7 +3246,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                 throw new Horde_ActiveSync_Exception($e);
             }
 
-            $ident = $injector->getInstance('Horde_Core_Factory_Identity')->create($vEvent->creator);
+            // $ident was created above for the authenticated ActiveSync user.
             if (!$ident->getValue('from_addr')) {
                 throw new Horde_ActiveSync_Exception(_('You do not have an email address configured in your Personal Information Preferences.'));
             }


### PR DESCRIPTION
# Fix MeetingResponse iTip reply identity

## Summary

Fixes a PHP warning and broken iTip reply sending when an ActiveSync client accepts, declines, or tentatively accepts a meeting invitation with `SendResponse` enabled.

## Problem

In `meetingResponse()`, when sending the iTip reply email, the code recreated the sender identity with:

```php
$ident = $injector->getInstance('Horde_Core_Factory_Identity')->create($vEvent->creator);
```

`Horde_Icalendar_Vevent` has no `creator` property (that exists on Kronolith event objects, not parsed iCalendar components). This caused:

```
PHP ERROR: Undefined property: Horde_Icalendar_Vevent::$creator
```

The iTip reply to the organizer was not sent correctly.

## Solution

Reuse the `$ident` object already created earlier in the same method for the authenticated ActiveSync user:

```php
$ident = $injector->getInstance('Horde_Core_Factory_Identity')->create($this->_user);
```

This matches how IMP and Kronolith build `Horde_Itip_Resource_Identity` for meeting replies — the responding attendee is the logged-in user, not a property on the vEvent.

## Files changed

- `lib/Horde/Core/ActiveSync/Driver.php`

## Test plan

- [ ] Receive a meeting invitation by email on an EAS 16.0 device (iPhone)
- [ ] Accept, decline, or tentatively accept with “send response” / organizer notification enabled
- [ ] Verify no `Undefined property: Horde_Icalendar_Vevent::$creator` in `horde.log`
- [ ] Verify organizer receives the iTip reply (if `from_addr` is configured in Personal Information / identity settings)
- [ ] Verify the event is imported into Kronolith with the correct attendee status

## Suggested commit message

```
fix(core): use ActiveSync user identity for meeting iTip reply

Reuse the authenticated user's identity when sending MeetingResponse
iTip mail instead of the nonexistent Vevent::$creator property.
```

## Author

Torben Dannhauer <torben@dannhauer.de>
