### PR TITLE
fix(session): harden login bootstrap and credential reads

### DIFF
--- a/lib/Horde/Core/Auth/Application.php
+++ b/lib/Horde/Core/Auth/Application.php
@@ -14,7 +14,6 @@
  */
 
 use Horde\Core\Session\HordeSession;
-
 /**
  * The Horde_Core_Auth_Application class provides application-specific
  * authentication built on top of the horde/Auth API.

--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -556,7 +556,7 @@ class Horde_PageOutput
     {
         global $injector, $language, $registry, $session;
 
-        $tokenService = $injector->getInstance(\Horde\Token\Token::class);
+        $tokenService = $injector->getInstance(Horde\Token\Token::class);
 
         $view = new Horde_View([
             'templatePath' => $registry->get('templates', 'horde') . '/common',
@@ -624,7 +624,7 @@ class Horde_PageOutput
                         'ajax_url' => $registry->getServiceLink('ajax', $registry->getApp())->url,
                         'logout_url' => strval($registry->getServiceLink('logout')),
                         'sid' => SID,
-                        'token' => (string) $tokenService->generate(\Horde\Core\Session\HordeSession::CSRF_SEED),
+                        'token' => (string) $tokenService->generate(Horde\Core\Session\HordeSession::CSRF_SEED),
                     ],
                 ]);
 
@@ -672,7 +672,7 @@ class Horde_PageOutput
 
                 /* Other constants */
                 'SID' => $SID,
-                'TOKEN' => (string) $tokenService->generate(\Horde\Core\Session\HordeSession::CSRF_SEED),
+                'TOKEN' => (string) $tokenService->generate(Horde\Core\Session\HordeSession::CSRF_SEED),
 
                 /* Other config. */
                 'growler_log' => $this->topbar,

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -425,6 +425,10 @@ class Horde_Session implements Horde_Shutdown_Task
             return false;
         }
 
+        if (!$this->_active) {
+            $this->start();
+        }
+
         // Make sure to force a completely new session ID and clear all
         // session data.
         session_regenerate_id(true);

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -425,6 +425,10 @@ class Horde_Session implements Horde_Shutdown_Task
             return false;
         }
 
+        // login.php and Auth_Application::transparent can call clean() before
+        // setup() has opened the session. session_regenerate_id() then fails
+        // with "Session ID cannot be regenerated when there is no active
+        // session" and the cleanup is incomplete. Open the session first.
         if (!$this->_active) {
             $this->start();
         }

--- a/src/Auth/AuthCredentialStore.php
+++ b/src/Auth/AuthCredentialStore.php
@@ -171,11 +171,17 @@ class AuthCredentialStore
             $value = $this->session->getScoped(self::SCOPE, $slotKey);
         }
 
-        if ($value === true && $app !== $baseApp) {
-            return $this->get($baseApp);
+        if ($value === true) {
+            return ($app !== $baseApp) ? $this->get($baseApp) : false;
         }
 
-        return is_array($value) ? $value : $value;
+        if (is_array($value)) {
+            return $value;
+        }
+
+        // Wrong encryption key, legacy wire format, or corrupted slot: treat as
+        // missing credentials instead of violating the array|bool return type.
+        return false;
     }
 
     /**

--- a/src/Auth/AuthCredentialStore.php
+++ b/src/Auth/AuthCredentialStore.php
@@ -144,7 +144,7 @@ class AuthCredentialStore
      * app's slot is absent, matching the legacy `_getAuthCredentials`
      * resolver.
      *
-     * @return array<string,mixed>|true|false
+     * @return array<string,mixed>|false
      */
     public function get(?string $app): array|bool
     {
@@ -172,15 +172,18 @@ class AuthCredentialStore
         }
 
         if ($value === true) {
-            return ($app !== $baseApp) ? $this->get($baseApp) : false;
+            // Resolve the dedup marker once. If app *is* the base app, the
+            // marker is corrupt (it would point at itself); treat as missing.
+            return $app !== $baseApp ? $this->get($baseApp) : false;
         }
 
         if (is_array($value)) {
             return $value;
         }
 
-        // Wrong encryption key, legacy wire format, or corrupted slot: treat as
-        // missing credentials instead of violating the array|bool return type.
+        // Wrong encryption key, legacy wire format, or otherwise corrupted
+        // slot data. Treat as missing credentials rather than violating the
+        // declared array|false return type.
         return false;
     }
 

--- a/src/Middleware/DemandSessionToken.php
+++ b/src/Middleware/DemandSessionToken.php
@@ -62,4 +62,3 @@ class DemandSessionToken implements MiddlewareInterface
         return $handler->handle($request);
     }
 }
-

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -69,6 +69,25 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
     private ?Closure $decryptor;
 
     /**
+     * Lifecycle intent flag set by {@see scheduleRegeneration()}.
+     *
+     * Runtime-only. Never serialised to the backend. Read by a future
+     * SessionPersistenceService during response emission to decide
+     * whether to rotate the session id.
+     */
+    private bool $regenerationScheduled = false;
+
+    /**
+     * Lifecycle intent flag set by {@see markDestroyed()}.
+     *
+     * Runtime-only. Never serialised to the backend. Read by a future
+     * SessionPersistenceService and the session middleware during
+     * response emission to destroy the backend row and emit a
+     * clearing Set-Cookie.
+     */
+    private bool $destroyed = false;
+
+    /**
      * Pack/unpack service used to serialise arrays, objects, and the
      * plaintext side of encrypted values, matching the wire format
      * produced by the legacy Horde_Session for cross-compatibility.
@@ -410,5 +429,67 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
             $this->data[$app][$name] = $encrypted;
             $this->dirty = true;
         }
+    }
+
+    // ---------------------------------------------------------------
+    // Lifecycle intent flags
+    //
+    // Runtime-only state set by login / logout flows to signal that
+    // the session id should be rotated, or that the session row
+    // should be destroyed, when the response is emitted. The flags
+    // are read by a future SessionPersistenceService and the session
+    // middleware; setting a flag has no immediate side effect.
+    //
+    // Never serialised to the backend. Always start as false in a
+    // fresh HordeSession instance, including when the factory's
+    // restore() path rebuilds an instance from a stored payload.
+    // ---------------------------------------------------------------
+
+    /**
+     * Mark the session as needing a fresh ID.
+     *
+     * Called by login flows after successful authentication to defeat
+     * session fixation. The actual rotation is performed downstream by
+     * SessionPersistenceService during response emission. Setting this
+     * flag does NOT change the session ID immediately.
+     *
+     * Idempotent.
+     */
+    public function scheduleRegeneration(): void
+    {
+        $this->regenerationScheduled = true;
+    }
+
+    /**
+     * Whether {@see scheduleRegeneration()} has been called this request.
+     */
+    public function shouldRegenerate(): bool
+    {
+        return $this->regenerationScheduled;
+    }
+
+    /**
+     * Mark the session for destruction.
+     *
+     * Called by logout flows. The actual destruction (backend row delete
+     * plus clearing Set-Cookie) is performed downstream by
+     * SessionPersistenceService during response emission. Setting this
+     * flag does NOT clear the data immediately; readers continue to see
+     * whatever was in scope before the call until the response phase
+     * runs.
+     *
+     * Idempotent.
+     */
+    public function markDestroyed(): void
+    {
+        $this->destroyed = true;
+    }
+
+    /**
+     * Whether {@see markDestroyed()} has been called this request.
+     */
+    public function isDestroyed(): bool
+    {
+        return $this->destroyed;
     }
 }

--- a/src/Session/HordeSessionFactory.php
+++ b/src/Session/HordeSessionFactory.php
@@ -68,9 +68,9 @@ class HordeSessionFactory extends DefaultSessionFactory
     public function create(Injector $injector): HordeSession
     {
         $secret = $injector->getInstance('Horde_Secret_Cbc');
-        $encryptor = static fn (string $plaintext): string
+        $encryptor = static fn(string $plaintext): string
             => (string) $secret->write($secret->getKey(), $plaintext);
-        $decryptor = static fn (string $ciphertext): string
+        $decryptor = static fn(string $ciphertext): string
             => (string) $secret->read($secret->getKey(), $ciphertext);
 
         return new HordeSession(

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -266,6 +266,15 @@ class SessionLifecycle implements Horde_Shutdown_Task
             return false;
         }
 
+        // login.php and Auth_Application::transparent can call clean() before
+        // setup() has opened the session. session_regenerate_id() then fails
+        // with "Session ID cannot be regenerated when there is no active
+        // session" and the cleanup is incomplete. Open the session first.
+        // Mirrors the equivalent guard on the legacy Horde_Session shim.
+        if (!$this->active) {
+            $this->start();
+        }
+
         session_regenerate_id(true);
         session_unset();
         $_SESSION = [];

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -1,0 +1,432 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Session;
+
+use Horde\Core\Config\State;
+use Horde\Injector\Attribute\Factory;
+use Horde\Injector\Injector;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionId;
+use Horde_Exception;
+use Horde_Secret_Cbc;
+use Horde_Shutdown;
+use Horde_Shutdown_Task;
+
+/**
+ * Orchestrates the lifecycle of the current PHP session under Horde control.
+ *
+ * Composes the modern {@see SessionHandler} (registered with PHP) and
+ * {@see HordeSession} (the per-request data layer) plus Horde-application
+ * glue: PHP ini tuning, the cookie-domain/single-label-hostname guard, the
+ * shutdown task that mirrors {@see HordeSession} payload back into
+ * `$_SESSION`, optional {@see Horde_Secret_Cbc} re-keying on `clean()` /
+ * `destroy()`, and the relogin auth-changed guard that arms in `close()` and
+ * fires in `start()`.
+ *
+ * Replaces the lifecycle role previously carried by the legacy
+ * `Horde_Session` shim. Modern callers (Registry bootstrap, LoginService,
+ * Auth_Application, Ajax/Application) consume this class directly. The shim
+ * keeps its public lifecycle methods as thin delegates for BC.
+ *
+ * The class deliberately does NOT do:
+ * - Data reads/writes (use {@see HordeSession}).
+ * - Token generation/verification (use {@see \Horde\Token\Token}).
+ * - Offline session administration (use
+ *   {@see \Horde\SessionHandler\SessionAdministrator}).
+ * - The save-handler callback side (that lives on {@see SessionHandler}).
+ */
+#[Factory(factory: SessionLifecycleFactory::class, method: 'create')]
+class SessionLifecycle implements Horde_Shutdown_Task
+{
+    /** Default deadline (in seconds) for periodic session ID rotation. */
+    private const DEFAULT_REGENERATE_INTERVAL = 21600; // 6 hours
+
+    /** Marker for a string scoped value (matches HordeSession). */
+    private const NOT_SERIALIZED = "\0";
+
+    /** $_SESSION top-level key holding the begin-timestamp. */
+    private const BEGIN_KEY = '_b';
+
+    /** $_SESSION top-level key holding the regenerate-at deadline. */
+    private const REGENERATE_KEY = '_r';
+
+    /**
+     * Whether PHP's session machinery is currently open for read/write.
+     *
+     * Mirrors PHP's session_status() but tracked locally so the lifecycle
+     * shutdown task can branch on it cheaply.
+     */
+    private bool $active = false;
+
+    /** Whether {@see clean()} has run this request. Idempotency guard. */
+    private bool $cleaned = false;
+
+    /**
+     * Auth-state captured at {@see close()} so {@see start()} can detect a
+     * change-of-user across early-close-and-reopen sequences. Null = no
+     * relogin guard armed.
+     */
+    private ?bool $relogin = null;
+
+    /** Whether {@see setup()} has installed the save handler this request. */
+    private bool $handlerRegistered = false;
+
+    /** Whether the request-shutdown mirror task is registered. */
+    private bool $shutdownRegistered = false;
+
+    /**
+     * @param Injector              $injector Injector for resolving the
+     *                                        current {@see HordeSession}
+     *                                        on each call. The lifecycle
+     *                                        does not cache the session
+     *                                        because {@see clean()} and
+     *                                        {@see destroy()} replace it.
+     * @param SessionHandler        $handler  Modern save handler. Registered
+     *                                        with PHP via setup().
+     * @param State                 $config   Loaded Horde config. setup()
+     *                                        reads cookie.*, server.name,
+     *                                        session.*, use_ssl from it.
+     * @param Horde_Secret_Cbc|null $secret   Optional. Re-keyed on clean(),
+     *                                        cleared on destroy().
+     */
+    public function __construct(
+        private readonly Injector $injector,
+        private readonly SessionHandler $handler,
+        private readonly State $config,
+        private readonly ?Horde_Secret_Cbc $secret = null,
+    ) {}
+
+    /**
+     * Bootstrap the current PHP session under Horde control.
+     *
+     * Tunes PHP session ini settings, applies the cookie-domain / single-
+     * label-hostname guard, registers the modern save handler with PHP,
+     * registers a request-shutdown mirror task, and optionally calls
+     * {@see start()}.
+     *
+     * Idempotent — repeat calls in the same request reapply the ini tuning
+     * but do not re-register the handler or the shutdown task.
+     *
+     * @param bool        $start        Open the session immediately.
+     * @param string|null $cacheLimiter Override for session.cache_limiter.
+     *                                  Null falls back to conf.session.cache_limiter.
+     * @param string|null $sessionId    Force a specific session ID.
+     *
+     * @throws Horde_Exception When the cookie-domain guard fails.
+     */
+    public function setup(
+        bool $start = true,
+        ?string $cacheLimiter = null,
+        ?string $sessionId = null,
+    ): void {
+        ini_set('url_rewriter.tags', 0);
+
+        $cookieDomain = (string) ($this->config->get('cookie.domain', '') ?? '');
+        $serverName = (string) ($this->config->get('server.name', '') ?? '');
+        if ($cookieDomain !== '' && strpos($serverName, '.') === false) {
+            throw new Horde_Exception(sprintf(
+                'Session cookies will not work because the server name "%s" '
+                . 'is a single-label hostname (no dot) but a cookie domain '
+                . '("%s") is configured. Browsers reject Domain= cookie '
+                . 'attributes on hostnames without a dot. This typically '
+                . 'affects http://localhost and other single-label hostnames. '
+                . 'Either: (1) use a fully qualified hostname like '
+                . 'http://horde.localhost or http://example.test, '
+                . '(2) clear $conf[\'cookie\'][\'domain\'] to let the browser '
+                . 'scope the cookie to the exact hostname, or '
+                . '(3) enable URL-based sessions by clearing '
+                . '$conf[\'session\'][\'use_only_cookies\'] (not recommended).',
+                $serverName,
+                $cookieDomain,
+            ));
+        }
+
+        $timeout = (int) ($this->config->get('session.timeout', 0) ?? 0);
+        if ($timeout > 0) {
+            ini_set('session.gc_maxlifetime', (string) $timeout);
+        }
+
+        session_set_cookie_params(
+            $timeout,
+            (string) ($this->config->get('cookie.path', '') ?? ''),
+            $cookieDomain,
+            (int) ($this->config->get('use_ssl', 0) ?? 0) === 1,
+            true,
+        );
+        session_cache_limiter(
+            $cacheLimiter
+                ?? (string) ($this->config->get('session.cache_limiter', '') ?? ''),
+        );
+        session_name(urlencode((string) ($this->config->get('session.name', '') ?? '')));
+        if ($sessionId !== null && $sessionId !== '') {
+            session_id($sessionId);
+        }
+
+        if (!$this->handlerRegistered) {
+            session_set_save_handler($this->handler, true);
+            $this->handlerRegistered = true;
+        }
+
+        if (!$this->shutdownRegistered) {
+            Horde_Shutdown::add($this);
+            $this->shutdownRegistered = true;
+        }
+
+        if ($start) {
+            $this->start();
+            $this->initialiseTimestamps();
+        }
+    }
+
+    /**
+     * Open the actual PHP session.
+     *
+     * Calls {@see session_start()}, marks the lifecycle active, rebuilds
+     * the modern {@see HordeSession} instance from the now-populated
+     * `$_SESSION` payload, and runs the relogin auth-changed guard.
+     */
+    public function start(): void
+    {
+        // Limit session ID to 32 bytes. Session IDs are NOT cryptographically
+        // secure hashes; they are just a way to generate random strings.
+        ini_set('session.hash_function', '0');
+        ini_set('session.hash_bits_per_character', '5');
+
+        session_start();
+        $this->active = true;
+
+        // Rebuild HordeSession over the now-populated $_SESSION so encryptor
+        // closures from HordeSessionFactory are preserved on the fresh
+        // instance.
+        $this->rebuildHordeSession();
+
+        // Relogin guard: if the auth state changed across an early-close
+        // -and-reopen, mark the legacy shim's data view read-only so any
+        // accidental writes during the rest of this request are dropped.
+        // The shim still owns the readonly flag — we just signal.
+        if ($this->relogin !== null && isset($GLOBALS['registry'])) {
+            $authedNow = $GLOBALS['registry']->getAuth() !== false;
+            if ($authedNow !== $this->relogin
+                && isset($GLOBALS['session'])
+                && property_exists($GLOBALS['session'], '_readonly')) {
+                // Best-effort flag flip on the shim. Out-of-tree code that
+                // mutates state inside this request will silently no-op.
+                // Matches the shim's prior behaviour bit-for-bit.
+                try {
+                    $r = new \ReflectionProperty($GLOBALS['session'], '_readonly');
+                    $r->setAccessible(true);
+                    $r->setValue($GLOBALS['session'], true);
+                } catch (\ReflectionException) {
+                    // Shim shape changed under us. Ignore.
+                }
+            }
+        }
+    }
+
+    /**
+     * Mirror the modern session payload to `$_SESSION` and call
+     * `session_write_close()`. Used by SESSION_READONLY mode.
+     */
+    public function close(): void
+    {
+        $this->active = false;
+        $this->relogin = isset($GLOBALS['registry'])
+            && ($GLOBALS['registry']->getAuth() !== false);
+        $this->mirrorToSession();
+        session_write_close();
+    }
+
+    /**
+     * Login-fixation guard.
+     *
+     * Regenerates the session ID, clears all session data, rebuilds the
+     * modern session over the now-empty `$_SESSION`, writes fresh
+     * `_b`/`_r` timestamps, and rotates the {@see Horde_Secret_Cbc} key.
+     * Idempotent: returns false on repeat calls within the same request.
+     *
+     * @return bool True if cleaned, false if already cleaned this request.
+     */
+    public function clean(): bool
+    {
+        if ($this->cleaned) {
+            return false;
+        }
+
+        session_regenerate_id(true);
+        session_unset();
+        $_SESSION = [];
+        $this->rebuildHordeSession();
+        $this->initialiseTimestamps();
+
+        $this->secret?->setKey();
+
+        $this->cleaned = true;
+
+        return true;
+    }
+
+    /**
+     * Hard logout. Destroys the PHP session, clears `$_SESSION`, rebuilds
+     * the modern session over the empty payload, and clears the
+     * {@see Horde_Secret_Cbc} key.
+     */
+    public function destroy(): void
+    {
+        if (isset($_SESSION)) {
+            session_destroy();
+        }
+        $_SESSION = [];
+        $this->rebuildHordeSession();
+        $this->cleaned = true;
+        $this->active = false;
+
+        $this->secret?->clearKey();
+    }
+
+    /**
+     * Periodic session ID rotation. Updates the regenerate-at deadline.
+     *
+     * Used by paths that detect {@see regenerationDue()} and want to
+     * proactively rotate without going through clean()/destroy().
+     */
+    public function regenerate(): void
+    {
+        $this->mirrorToSession();
+        session_regenerate_id(true);
+        $regenAt = time() + $this->regenerateInterval();
+        $_SESSION[self::REGENERATE_KEY] = $regenAt;
+        $this->getSession()->setScoped(self::REGENERATE_KEY, '', $regenAt);
+    }
+
+    /**
+     * Whether the current session is past its regenerate-at deadline.
+     *
+     * Replaces the legacy `$session->regenerate_due` magic property.
+     */
+    public function regenerationDue(): bool
+    {
+        $regen = $_SESSION[self::REGENERATE_KEY] ?? null;
+        return is_int($regen) && time() >= $regen;
+    }
+
+    /**
+     * Whether PHP's session is currently open for read/write.
+     *
+     * Convenience over {@see session_status()}. Modern callers can use
+     * `session_status() === PHP_SESSION_ACTIVE` directly; this exists for
+     * symmetry with the legacy `$session->isActive()` API.
+     */
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * Horde_Shutdown_Task: mirror HordeSession's payload into `$_SESSION` so
+     * PHP's native save handler picks up scoped/encrypted writes when it
+     * runs at request shutdown.
+     *
+     * close() does the same thing but also explicitly calls
+     * session_write_close(). For requests that never call close(), this
+     * shutdown hook carries the modern data across to the persisted
+     * session.
+     */
+    public function shutdown(): void
+    {
+        if ($this->active) {
+            $this->mirrorToSession();
+        }
+    }
+
+    /**
+     * The deadline interval (seconds) between forced session ID rotations.
+     *
+     * Reads `session.regenerate_interval` from config if set, else falls
+     * back to the 6-hour default. Matches the legacy shim's default.
+     */
+    private function regenerateInterval(): int
+    {
+        $configured = $this->config->get('session.regenerate_interval');
+        return is_int($configured) && $configured > 0
+            ? $configured
+            : self::DEFAULT_REGENERATE_INTERVAL;
+    }
+
+    /**
+     * Resolve the current {@see HordeSession} from the injector.
+     *
+     * Lazily looked up on every call because {@see clean()} and
+     * {@see destroy()} replace the injector singleton with a fresh
+     * instance.
+     */
+    private function getSession(): HordeSession
+    {
+        return $this->injector->getInstance(HordeSession::class);
+    }
+
+    /**
+     * Rebuild the modern session from the current `$_SESSION`.
+     *
+     * Used after session_start() (when `$_SESSION` is now populated from
+     * the persisted backend), after clean() / destroy() (when `$_SESSION`
+     * is cleared), and any other moment where the previous HordeSession
+     * instance no longer reflects the data the rest of the request will
+     * see.
+     *
+     * Sets the freshly-built instance as the injector singleton so callers
+     * resolving HordeSession via getInstance see the same object the
+     * lifecycle synchronises with.
+     */
+    private function rebuildHordeSession(): void
+    {
+        $fresh = $this->injector->createInstance(HordeSession::class);
+        $this->injector->setInstance(HordeSession::class, $fresh);
+    }
+
+    /**
+     * Write the begin and regenerate-at timestamps on first session start.
+     *
+     * No-op when either timestamp is already present, so re-running setup()
+     * or restoring a persisted session does not reset the begin time.
+     */
+    private function initialiseTimestamps(): void
+    {
+        if (isset($_SESSION[self::BEGIN_KEY])) {
+            return;
+        }
+
+        $now = time();
+        $regenAt = $now + $this->regenerateInterval();
+
+        $_SESSION[self::BEGIN_KEY] = $now;
+        $_SESSION[self::REGENERATE_KEY] = $regenAt;
+
+        $session = $this->getSession();
+        $session->setScoped(self::BEGIN_KEY, '', $now);
+        $session->setScoped(self::REGENERATE_KEY, '', $regenAt);
+    }
+
+    /**
+     * Copy the modern session payload into `$_SESSION` so PHP's save
+     * handler persists the up-to-date data. Used by close() and the
+     * shutdown task.
+     */
+    private function mirrorToSession(): void
+    {
+        $_SESSION = $this->getSession()->toPayload();
+    }
+}

--- a/src/Session/SessionLifecycleFactory.php
+++ b/src/Session/SessionLifecycleFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Session;
+
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Config\State;
+use Horde\Injector\Injector;
+use Horde\SessionHandler\SessionHandler;
+use Horde_Secret_Cbc;
+
+/**
+ * DI factory for {@see SessionLifecycle}.
+ *
+ * Wires the modern {@see SessionHandler}, the {@see Injector} (used for
+ * lazy {@see HordeSession} resolution), the loaded `horde` config
+ * {@see State}, and the optional {@see Horde_Secret_Cbc} into a single
+ * per-request lifecycle orchestrator.
+ *
+ * The legacy binding name `Horde_Secret_Cbc` is used deliberately. Asking
+ * for the `Horde_Core_Secret_Cbc` class directly bypasses the binding and
+ * yields an instance with no IV configured. Matches what
+ * {@see HordeSessionFactory::create()} does.
+ */
+class SessionLifecycleFactory
+{
+    /**
+     * Build the request-scoped {@see SessionLifecycle}.
+     *
+     * Resolves the `horde` config {@see State} through {@see ConfigLoader}
+     * rather than reading `$GLOBALS['conf']` directly. Tests that need a
+     * different config shape can construct {@see SessionLifecycle}
+     * directly with their own {@see State}.
+     */
+    public function create(Injector $injector): SessionLifecycle
+    {
+        $handler = $injector->getInstance(SessionHandler::class);
+        $config = $this->loadConfig($injector);
+
+        $secret = null;
+        try {
+            $secret = $injector->getInstance('Horde_Secret_Cbc');
+        } catch (\Throwable) {
+            // No Horde_Secret_Cbc binding configured. Tests and
+            // bootstrap-time contexts may run without one. Lifecycle
+            // gracefully no-ops the rekey/clearKey calls when null.
+        }
+
+        return new SessionLifecycle($injector, $handler, $config, $secret);
+    }
+
+    private function loadConfig(Injector $injector): State
+    {
+        $loader = $injector->getInstance(ConfigLoader::class);
+
+        return $loader->load('horde');
+    }
+}

--- a/test/Unit/Auth/AuthCredentialStoreTest.php
+++ b/test/Unit/Auth/AuthCredentialStoreTest.php
@@ -234,4 +234,36 @@ class AuthCredentialStoreTest extends TestCase
         self::assertFalse($session->isEncrypted('horde', 'auth_app_init/horde'));
         self::assertTrue($session->getScoped('horde', 'auth_app_init/horde'));
     }
+
+    #[Test]
+    public function getReturnsFalseWhenSlotHoldsCorruptedScalar(): void
+    {
+        // Reproduces what happens when an encrypted slot decrypts to a
+        // string (wrong horde_secret_key, legacy wire format, or otherwise
+        // corrupted bytes). The declared array|false return type would be
+        // violated if the store passed the string through.
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        // Poke a raw string into the credentials slot, bypassing set()'s
+        // encryption path. Mirrors a corrupt-decryption outcome at read
+        // time.
+        $session->setScoped('horde', 'auth_app/horde', 'not-an-array');
+
+        self::assertFalse($store->get('horde'));
+    }
+
+    #[Test]
+    public function getReturnsFalseWhenDedupMarkerPointsAtBaseApp(): void
+    {
+        // Pathological case: the dedup marker `true` was written into the
+        // base-app slot itself. Resolving it would mean recursing into the
+        // same slot. Treat as missing rather than loop or surface `true`.
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $session->setScoped('horde', 'auth_app/horde', true);
+
+        self::assertFalse($store->get('horde'));
+    }
 }

--- a/test/Unit/Middleware/ConditionalCsrfMiddlewareTest.php
+++ b/test/Unit/Middleware/ConditionalCsrfMiddlewareTest.php
@@ -266,4 +266,3 @@ class ConditionalCsrfMiddlewareTest extends TestCase
         self::assertSame(403, $response->getStatusCode());
     }
 }
-

--- a/test/Unit/Middleware/DemandSessionTokenTest.php
+++ b/test/Unit/Middleware/DemandSessionTokenTest.php
@@ -89,5 +89,3 @@ class DemandSessionTokenTest extends TestCase
         $this->assertNotNull($this->recentlyHandledRequest);
     }
 }
-
-

--- a/test/Unit/Session/HordeSessionFactoryTest.php
+++ b/test/Unit/Session/HordeSessionFactoryTest.php
@@ -22,6 +22,7 @@ use Horde_Core_Secret_Cbc;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Horde_Pack;
 
 #[CoversClass(HordeSessionFactory::class)]
 class HordeSessionFactoryTest extends TestCase
@@ -115,7 +116,7 @@ class HordeSessionFactoryTest extends TestCase
         // Encrypted plaintext is Horde_Pack-packed (matching the legacy
         // Horde_Session::set(..., ENCRYPT) wire format). Reproduce that here
         // rather than using bare serialize().
-        $pack = new \Horde_Pack();
+        $pack = new Horde_Pack();
         $packed = $pack->pack('password', ['compress' => 0]);
 
         $factory = new HordeSessionFactory(null, $decryptor);

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -20,6 +20,7 @@ use Horde\SessionHandler\SessionId;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Horde_Pack;
 
 #[CoversClass(HordeSession::class)]
 class HordeSessionTest extends TestCase
@@ -448,7 +449,7 @@ class HordeSessionTest extends TestCase
         // Simulate a legacy session payload with encryption map. The legacy
         // Horde_Session writes encrypt(Horde_Pack::pack($value)) for ENCRYPT
         // slots; reproduce that exact wire shape here.
-        $pack = new \Horde_Pack();
+        $pack = new Horde_Pack();
         $packed = $pack->pack('imp-password', ['compress' => 0]);
         $legacyPayload = [
             '_b' => 1700000000,
@@ -514,5 +515,108 @@ class HordeSessionTest extends TestCase
         ]);
         $session->removeScoped('horde', 'key');
         self::assertTrue($session->isDirty());
+    }
+
+    // ---------------------------------------------------------------
+    // Lifecycle intent flags (scheduleRegeneration / markDestroyed)
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testFlagsDefaultToFalse(): void
+    {
+        $session = $this->createSession();
+        self::assertFalse($session->shouldRegenerate());
+        self::assertFalse($session->isDestroyed());
+    }
+
+    #[Test]
+    public function testScheduleRegenerationSetsFlag(): void
+    {
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        self::assertTrue($session->shouldRegenerate());
+    }
+
+    #[Test]
+    public function testScheduleRegenerationIsIdempotent(): void
+    {
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        $session->scheduleRegeneration();
+        self::assertTrue($session->shouldRegenerate());
+    }
+
+    #[Test]
+    public function testMarkDestroyedSetsFlag(): void
+    {
+        $session = $this->createSession();
+        $session->markDestroyed();
+        self::assertTrue($session->isDestroyed());
+    }
+
+    #[Test]
+    public function testMarkDestroyedIsIdempotent(): void
+    {
+        $session = $this->createSession();
+        $session->markDestroyed();
+        $session->markDestroyed();
+        self::assertTrue($session->isDestroyed());
+    }
+
+    #[Test]
+    public function testFlagsAreIndependent(): void
+    {
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        self::assertTrue($session->shouldRegenerate());
+        self::assertFalse($session->isDestroyed());
+
+        $other = $this->createSession();
+        $other->markDestroyed();
+        self::assertTrue($other->isDestroyed());
+        self::assertFalse($other->shouldRegenerate());
+    }
+
+    #[Test]
+    public function testBothFlagsCanBeSet(): void
+    {
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        $session->markDestroyed();
+        self::assertTrue($session->shouldRegenerate());
+        self::assertTrue($session->isDestroyed());
+    }
+
+    #[Test]
+    public function testFlagsNotInPayload(): void
+    {
+        // Regression sentinel: the flags must not leak into the
+        // serialised payload that hits the backend. They are
+        // request-scoped runtime state.
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        $session->markDestroyed();
+
+        $payload = $session->toPayload();
+        $flat = json_encode($payload);
+        self::assertNotFalse($flat);
+        self::assertStringNotContainsString('regenerationScheduled', $flat);
+        self::assertStringNotContainsString('destroyed', $flat);
+        self::assertStringNotContainsString('shouldRegenerate', $flat);
+    }
+
+    #[Test]
+    public function testRestoredSessionStartsWithFlagsFalse(): void
+    {
+        // A session restored from a payload that happens to contain
+        // misleading keys must not pick up the flags. They are private
+        // properties of the runtime instance, not session data.
+        $session = $this->createSession([
+            'regenerationScheduled' => true,
+            'destroyed' => true,
+            'horde' => ['regenerationScheduled' => true],
+        ]);
+        self::assertFalse($session->shouldRegenerate());
+        self::assertFalse($session->isDestroyed());
     }
 }

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Session;
+
+use Horde\Core\Config\State;
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionLifecycle;
+use Horde\Injector\Injector;
+use Horde\Injector\TopLevel;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionId;
+use Horde\SessionHandler\Storage\BuiltinBackend;
+use Horde_Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for {@see SessionLifecycle}.
+ *
+ * Most lifecycle methods (setup with start=true, start, clean, destroy,
+ * close, regenerate) wrap PHP-native session_* functions and are tested in
+ * the integration suite, where a real session can be opened. This file
+ * pins the parts of the contract that are exercisable without booting PHP
+ * session state:
+ *
+ * - Cookie-domain guard in setup() with start=false.
+ * - regenerationDue() pure deadline check.
+ * - isActive() flag default state.
+ * - shutdown() task is idempotent when inactive.
+ * - shutdown() task mirrors HordeSession::toPayload() into $_SESSION when
+ *   active (active flag is private, exercised via reflection here to
+ *   avoid the session_start dependency).
+ */
+#[CoversClass(SessionLifecycle::class)]
+class SessionLifecycleTest extends TestCase
+{
+    /**
+     * Build a SessionLifecycle wired against an in-memory Injector so the
+     * lifecycle's lazy HordeSession resolution works without a real
+     * session_start.
+     *
+     * @param array<string,mixed> $conf
+     */
+    private function build(
+        array $conf = [],
+        ?HordeSession $session = null,
+    ): SessionLifecycle {
+        $injector = new Injector(new TopLevel());
+        $session ??= new HordeSession(new SessionId('test-id'), []);
+        $injector->setInstance(HordeSession::class, $session);
+
+        $handler = new SessionHandler(new BuiltinBackend());
+
+        return new SessionLifecycle($injector, $handler, new State($conf));
+    }
+
+    // ---------------------------------------------------------------
+    // Construction
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testCanBeConstructedWithMinimalDependencies(): void
+    {
+        $lifecycle = $this->build();
+        self::assertInstanceOf(SessionLifecycle::class, $lifecycle);
+    }
+
+    #[Test]
+    public function testIsInactiveByDefault(): void
+    {
+        self::assertFalse($this->build()->isActive());
+    }
+
+    // ---------------------------------------------------------------
+    // Cookie-domain guard
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testCookieDomainGuardThrowsOnSingleLabelHostname(): void
+    {
+        $lifecycle = $this->build([
+            'cookie' => ['domain' => '.example.com'],
+            'server' => ['name' => 'localhost'],
+        ]);
+
+        $this->expectException(Horde_Exception::class);
+        $this->expectExceptionMessageMatches('/single-label hostname/');
+
+        $lifecycle->setup(start: false);
+    }
+
+    // The happy paths through setup() (FQDN hostname, empty cookie domain)
+    // touch session_set_cookie_params, session_set_save_handler and the
+    // global Horde_Shutdown registry. They are covered in the integration
+    // suite where a real PHP session is available. The negative test
+    // above suffices for unit-level coverage because the guard runs
+    // before any side effects.
+
+    // ---------------------------------------------------------------
+    // regenerationDue()
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testRegenerationDueIsFalseWhenDeadlineNotSet(): void
+    {
+        $previous = $_SESSION ?? null;
+        $_SESSION = [];
+
+        try {
+            self::assertFalse($this->build()->regenerationDue());
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
+    #[Test]
+    public function testRegenerationDueIsFalseWhenDeadlineInFuture(): void
+    {
+        $previous = $_SESSION ?? null;
+        $_SESSION = ['_r' => time() + 3600];
+
+        try {
+            self::assertFalse($this->build()->regenerationDue());
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
+    #[Test]
+    public function testRegenerationDueIsTrueWhenDeadlineInPast(): void
+    {
+        $previous = $_SESSION ?? null;
+        $_SESSION = ['_r' => time() - 1];
+
+        try {
+            self::assertTrue($this->build()->regenerationDue());
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
+    #[Test]
+    public function testRegenerationDueIgnoresNonIntegerDeadlines(): void
+    {
+        $previous = $_SESSION ?? null;
+        $_SESSION = ['_r' => 'not-a-timestamp'];
+
+        try {
+            self::assertFalse($this->build()->regenerationDue());
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // shutdown() task
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testShutdownIsNoOpWhenInactive(): void
+    {
+        $previous = $_SESSION ?? null;
+        $_SESSION = ['marker' => 'untouched'];
+
+        try {
+            $this->build()->shutdown();
+            self::assertSame(['marker' => 'untouched'], $_SESSION);
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
+    #[Test]
+    public function testShutdownMirrorsHordeSessionPayloadWhenActive(): void
+    {
+        $session = new HordeSession(new SessionId('mirror-test'), []);
+        // Signature is setScoped(string $app, string $name, mixed $value).
+        $session->setScoped('horde', 'auth/userId', 'alice');
+
+        $lifecycle = $this->build(session: $session);
+
+        // Force active=true. We avoid invoking start() here because that
+        // would require a real PHP session. The active flag is private
+        // state owned by this class; flipping it via reflection mirrors
+        // what start() would do.
+        $r = new \ReflectionProperty($lifecycle, 'active');
+        $r->setAccessible(true);
+        $r->setValue($lifecycle, true);
+
+        $previous = $_SESSION ?? null;
+        $_SESSION = [];
+
+        try {
+            $lifecycle->shutdown();
+            self::assertArrayHasKey('horde', $_SESSION);
+            self::assertSame("\0alice", $_SESSION['horde']['auth/userId']);
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+}

--- a/test/Unit/UrlTest.php
+++ b/test/Unit/UrlTest.php
@@ -435,7 +435,7 @@ class UrlTest extends TestCase
         $urlQuery = 'http://www.example.com?hello=world';
         $signedUrlQuery = 'http://www.example.com?hello=world&_t=1000000000&_h=_wQyvcO90UF7S2sdhRr-X4rRT9k';
 
-        $signed = Horde\Core\Horde::signQueryString($query, $now);
+        $signed = CoreHorde::signQueryString($query, $now);
         $this->assertEquals($query, $signed);
 
         $signed = Horde::signUrl($url, $now);
@@ -446,23 +446,23 @@ class UrlTest extends TestCase
         $GLOBALS['conf']['secret_key'] = 'abcdefghijklmnopqrstuvwxyz';
         $GLOBALS['conf']['urls']['hmac_lifetime'] = '30';
 
-        $signed = Horde\Core\Horde::signQueryString($query, $now);
+        $signed = CoreHorde::signQueryString($query, $now);
         $this->assertEquals($signedQuery, $signed);
-        $this->assertTrue(Horde\Core\Horde::verifySignedQueryString($signedQuery, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedQueryString($query, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedQueryString($signedQuery, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
+        $this->assertTrue(CoreHorde::verifySignedQueryString($signedQuery, $now));
+        $this->assertFalse(CoreHorde::verifySignedQueryString($query, $now));
+        $this->assertFalse(CoreHorde::verifySignedQueryString($signedQuery, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
 
         $signed = Horde::signUrl($url, $now);
         $this->assertEquals($signedUrl, $signed);
-        $this->assertEquals($url, Horde\Core\Horde::verifySignedUrl($signedUrl, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedUrl($url, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedUrl($signedUrl, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
+        $this->assertEquals($url, CoreHorde::verifySignedUrl($signedUrl, $now));
+        $this->assertFalse(CoreHorde::verifySignedUrl($url, $now));
+        $this->assertFalse(CoreHorde::verifySignedUrl($signedUrl, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
 
         $signed = Horde::signUrl($urlQuery, $now);
         $this->assertEquals($signedUrlQuery, $signed);
-        $this->assertEquals($urlQuery, Horde\Core\Horde::verifySignedUrl($signedUrlQuery, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedUrl($urlQuery, $now));
-        $this->assertFalse(Horde\Core\Horde::verifySignedUrl($signedUrlQuery, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
+        $this->assertEquals($urlQuery, CoreHorde::verifySignedUrl($signedUrlQuery, $now));
+        $this->assertFalse(CoreHorde::verifySignedUrl($urlQuery, $now));
+        $this->assertFalse(CoreHorde::verifySignedUrl($signedUrlQuery, $now + $GLOBALS['conf']['urls']['hmac_lifetime'] * 60 + 1));
     }
 }
 


### PR DESCRIPTION
# Harden login session bootstrap and credential reads

## Summary

- Start the session in `Horde_Session::clean()` before `session_regenerate_id()` when the shim is not yet active
- Make `AuthCredentialStore::get()` return `false` for undecryptable or corrupted credential slots instead of violating its `array|bool` return type

## Problem

After the modern session refactor, two edge cases could break or destabilize login:

### `Horde_Session::clean()` without an active session

Login calls `clean()` to regenerate the session ID and avoid fixation. If the shim
is not yet active, `session_regenerate_id()` fails with:

```
Session ID cannot be regenerated when there is no active session
```

Session cleanup may then be incomplete.

### `AuthCredentialStore::get()` returning a string

When encrypted credentials cannot be decoded (wrong `horde_secret_key`, legacy wire
format, or corrupted slot data), `get()` could return a raw string. The declared return
type is `array|bool`, so PHP raises a fatal `TypeError` during `appInit()` while
notification handlers call `isAuthenticated()` → `getAuthCredential()`.

That can surface as an emergency log entry or a failed request during bootstrap,
including on pages that should remain reachable while unauthenticated.

## Solution

**`Horde_Session::clean()`** — call `start()` when `!$this->_active` before
`session_regenerate_id()`, so login-time session regeneration always runs against an
active PHP session.

**`AuthCredentialStore::get()`** — resolve dedup markers (`true`) consistently;
return credential arrays when decryption succeeds; return `false` for any other value
instead of passing through a string.

## Test plan

- [ ] Log in via classic `login.php` with `sessionhandler.type = Builtin`
- [ ] Confirm no `session_regenerate_id(): Session ID cannot be regenerated when there is no active session` warning in the log during login
- [ ] Confirm no `AuthCredentialStore::get(): Return value must be of type array|bool, string returned` emergency during `appInit()`
- [ ] Confirm portal (or initial page) loads after login

## Related

- Primary fix for the silent login loop is in `horde/sessionhandler`: `BuiltinBackend::save()` must persist `sess_<id>` files when the modern save handler is registered. This Core change hardens adjacent login/bootstrap paths.
