### PR TITLE
fix(activesync): map MeetingResponse InstanceId to RECURRENCE-ID

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3196,6 +3196,21 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             throw new Horde_ActiveSync_Exception('Unknown error locating vEvent.');
         }
 
+        // EAS 14.1+ may target a single occurrence of a recurring meeting.
+        if (!empty($response['instanceid'])
+            && $this->_version >= Horde_ActiveSync::VERSION_FOURTEENONE) {
+            try {
+                new Horde_Date($response['instanceid'], 'UTC');
+                $vEvent->setAttribute('RECURRENCE-ID', $response['instanceid']);
+            } catch (Horde_Date_Exception $e) {
+                $this->_logger->err(sprintf(
+                    'Invalid MeetingResponse InstanceId %s: %s',
+                    $response['instanceid'],
+                    $e->getMessage()
+                ));
+            }
+        }
+
         // Update the vCal so the response will be reflected when imported.
         $ident = $injector->getInstance('Horde_Core_Factory_Identity')->create($this->_user);
         //$cn = $ident->getValue('fullname');


### PR DESCRIPTION
# PR: Honor MeetingResponse InstanceId for recurring meetings

**Package:** `horde/core`  
**File:** `lib/Horde/Core/ActiveSync/Driver.php`  
**Author:** Torben Dannhauer <torben@dannhauer.de>

## Summary

Wire the EAS `MeetingResponse:InstanceId` element (already parsed in `horde/activesync`) through to calendar import by setting `RECURRENCE-ID` on the meeting-request vEvent before `calendar_import_vevent()`.

This lets Kronolith treat accept/decline/tentative responses to **one occurrence** of a recurring series correctly instead of applying them to the whole series.

## Problem

`Horde_ActiveSync_Request_MeetingResponse` stores `instanceid` from the client request (EAS 14.1+, commonly EAS 16.0), but `Horde_Core_ActiveSync_Driver::meetingResponse()` ignored it.

For recurring meeting invitations, the client sends the UTC timestamp of the **original occurrence** being answered. Without `RECURRENCE-ID` on the vEvent, Kronolith imports/updates the master event as if the user responded to the entire series.

## Solution

After parsing the iCalendar part of the meeting-request mail, and before updating the attendee and importing into Kronolith:

1. If `instanceid` is present **and** protocol version is ≥ 14.1 (`VERSION_FOURTEENONE`).
2. Validate the value as a UTC `Horde_Date`.
3. Set `RECURRENCE-ID` on the vEvent to that timestamp (EAS format, e.g. `20260613T070000Z`).
4. On invalid `InstanceId`, log an error and continue without `RECURRENCE-ID` (no request failure).

```php
// EAS 14.1+ may target a single occurrence of a recurring meeting.
if (!empty($response['instanceid'])
    && $this->_version >= Horde_ActiveSync::VERSION_FOURTEENONE) {
    try {
        new Horde_Date($response['instanceid'], 'UTC');
        $vEvent->setAttribute('RECURRENCE-ID', $response['instanceid']);
    } catch (Horde_Date_Exception $e) {
        $this->_logger->err(sprintf(
            'Invalid MeetingResponse InstanceId %s: %s',
            $response['instanceid'],
            $e->getMessage()
        ));
    }
}
```

## Spec references

| Document | Section | Relevance |
|----------|---------|-----------|
| [MS-ASCMD: Request (MeetingResponse)](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-ascmd/59ec13c7-c4e2-4292-a621-7db8781f57c2) | `InstanceId` optional child of `Request` | Identifies which occurrence is being answered |
| [MS-ASCMD: InstanceId (MeetingResponse)](https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-ascmd/) | EAS 14.1+ | Not supported on 12.1 / 14.0 |
| RFC 5545 / iTIP | `RECURRENCE-ID` | Standard way to scope a response to one instance |

## Version safety

| Protocol | Behavior |
|----------|----------|
| EAS &lt; 14.1 | Unchanged — `instanceid` is not sent/parsed for this path in practice; gate prevents new logic |
| EAS 14.1 – 16.x | `InstanceId` → `RECURRENCE-ID` when present |
| Non-recurring meetings | No `InstanceId` from client → existing flow unchanged |

## Out of scope (follow-up)

- **`search:LongId` in MeetingResponse** (EAS 16): parser stores `longid`, but `meetingResponse()` still requires `folderid` + `requestid`. Responding from Find/search results needs a separate spec-compliant path.
- **`SendResponse` / iTip mail**: already handled elsewhere in the same method; not modified here.

## Dependencies

- **Requires:** `horde/activesync` — `MeetingResponse.php` must pass `instanceid` in the `$response` array (already implemented).
- **Downstream:** Kronolith `import()` / `fromVEvent()` — existing `RECURRENCE-ID` handling.

## Test plan

- [ ] Accept a **non-recurring** meeting request (EAS 16) — calendar entry created as before.
- [ ] Accept **one instance** of a recurring series with `InstanceId` in the request — Kronolith stores/updates an exception for that date, not the whole series.
- [ ] Decline/tentative with `InstanceId` — attendee status scoped to the instance.
- [ ] Invalid `InstanceId` string — log line, meeting response still completes (master path).
- [ ] EAS 12.1 client (no `InstanceId`) — regression: unchanged behavior.

## Suggested commit message

```
fix(activesync): map MeetingResponse InstanceId to RECURRENCE-ID

EAS 14.1+ clients may send InstanceId when responding to a single
occurrence of a recurring meeting invitation. Validate the UTC
timestamp and set RECURRENCE-ID on the vEvent before calendar import
so Kronolith treats the response as an instance, not the whole series.
```
