### PR TITLE
refactor(session): Make registry properly delegate through the shim to modern session handlers

### DIFF
--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -17,6 +17,7 @@ use Horde\Core\Factory\TokenServiceFactory;
 use Horde\Core\Horde;
 use Horde\Core\Session\HordeSession;
 use Horde\Core\Session\HordeSessionFactory;
+use Horde\Core\Session\SessionLifecycle;
 use Horde\SessionHandler\SessionHandler as ModernSessionHandler;
 use Horde\SessionHandler\SessionId;
 use Horde\Token\Exception\TokenException;
@@ -210,6 +211,22 @@ class Horde_Session implements Horde_Shutdown_Task
     }
 
     /**
+     * Resolve the modern SessionLifecycle from the global injector.
+     *
+     * The shim wraps the lifecycle: setup/start/clean/destroy/regenerate/
+     * close all delegate the actual PHP-session work to it. Returns null
+     * for legacy/test contexts without an injector — the caller falls
+     * back to inline session_*() calls in that case.
+     */
+    private function _resolveLifecycle(): ?SessionLifecycle
+    {
+        if (isset($GLOBALS['injector'])) {
+            return $GLOBALS['injector']->getInstance(SessionLifecycle::class);
+        }
+        return null;
+    }
+
+    /**
      */
     public function __get($name)
     {
@@ -274,70 +291,77 @@ class Horde_Session implements Horde_Shutdown_Task
         $cache_limiter = null,
         $session_id = null
     ) {
-        global $conf, $injector;
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Delegate the PHP-session work (cookie params, ini tuning,
+            // save handler, cookie-domain guard, optional session_start)
+            // to the lifecycle. Pass start=false: the shim drives start()
+            // itself so its own bookkeeping (_active, _data, relogin
+            // guard) stays in lock-step with the rest of the shim's
+            // public surface.
+            $lifecycle->setup(
+                start: false,
+                cacheLimiter: $cache_limiter,
+                sessionId: $session_id,
+            );
+        } else {
+            // Fallback for legacy/test contexts without an injector. The
+            // shim opens the session directly; this branch matches the
+            // pre-delegation behaviour bit-for-bit so existing tests that
+            // bypass the injector keep working.
+            global $conf;
 
-        ini_set('url_rewriter.tags', 0);
+            ini_set('url_rewriter.tags', 0);
 
-        if (!empty($conf['cookie']['domain'])
-            && (strpos($conf['server']['name'], '.') === false)) {
-            throw new Horde_Exception(sprintf(
-                'Session cookies will not work because the server name "%s" '
-                . 'is a single-label hostname (no dot) but a cookie domain '
-                . '("%s") is configured. Browsers reject Domain= cookie '
-                . 'attributes on hostnames without a dot. This typically '
-                . 'affects http://localhost and other single-label hostnames. '
-                . 'Either: (1) use a fully qualified hostname like '
-                . 'http://horde.localhost or http://example.test, '
-                . '(2) clear $conf[\'cookie\'][\'domain\'] to let the browser '
-                . 'scope the cookie to the exact hostname, or '
-                . '(3) enable URL-based sessions by clearing '
-                . '$conf[\'session\'][\'use_only_cookies\'] (not recommended).',
-                (string) ($conf['server']['name'] ?? ''),
-                (string) $conf['cookie']['domain']
-            ));
+            if (!empty($conf['cookie']['domain'])
+                && (strpos($conf['server']['name'], '.') === false)) {
+                throw new Horde_Exception(sprintf(
+                    'Session cookies will not work because the server name "%s" '
+                    . 'is a single-label hostname (no dot) but a cookie domain '
+                    . '("%s") is configured. Browsers reject Domain= cookie '
+                    . 'attributes on hostnames without a dot. This typically '
+                    . 'affects http://localhost and other single-label hostnames. '
+                    . 'Either: (1) use a fully qualified hostname like '
+                    . 'http://horde.localhost or http://example.test, '
+                    . '(2) clear $conf[\'cookie\'][\'domain\'] to let the browser '
+                    . 'scope the cookie to the exact hostname, or '
+                    . '(3) enable URL-based sessions by clearing '
+                    . '$conf[\'session\'][\'use_only_cookies\'] (not recommended).',
+                    (string) ($conf['server']['name'] ?? ''),
+                    (string) $conf['cookie']['domain']
+                ));
+            }
+
+            if (!empty($conf['session']['timeout'])) {
+                ini_set('session.gc_maxlifetime', $conf['session']['timeout']);
+            }
+
+            session_set_cookie_params(
+                (int) ($conf['session']['timeout'] ?? 0),
+                (string) ($conf['cookie']['path'] ?? ''),
+                (string) ($conf['cookie']['domain'] ?? ''),
+                !empty($conf['use_ssl']) && $conf['use_ssl'] == 1,
+                true
+            );
+            session_cache_limiter(
+                is_null($cache_limiter)
+                    ? (string) ($conf['session']['cache_limiter'] ?? '')
+                    : $cache_limiter
+            );
+            session_name(urlencode((string) ($conf['session']['name'] ?? '')));
+            if ($session_id) {
+                session_id($session_id);
+            }
         }
 
-        if (!empty($conf['session']['timeout'])) {
-            ini_set('session.gc_maxlifetime', $conf['session']['timeout']);
+        /* Pin the shim's mirror to the addFinal() slot. This is the
+         * legacy-stack contract: regular Horde_Shutdown_Tasks may write
+         * through the shim's API; addFinal() runs last so those writes
+         * land in HordeSession before this mirror copies them back to
+         * $_SESSION. addFinal() is single-slot last-writer-wins. */
+        if (isset($GLOBALS['injector'])) {
+            $GLOBALS['injector']->getInstance('Horde_Shutdown')->addFinal($this);
         }
-
-        session_set_cookie_params(
-            (int) ($conf['session']['timeout'] ?? 0),
-            (string) ($conf['cookie']['path'] ?? ''),
-            (string) ($conf['cookie']['domain'] ?? ''),
-            !empty($conf['use_ssl']) && $conf['use_ssl'] == 1,
-            true
-        );
-        session_cache_limiter(
-            is_null($cache_limiter)
-                ? (string) ($conf['session']['cache_limiter'] ?? '')
-                : $cache_limiter
-        );
-        session_name(urlencode((string) ($conf['session']['name'] ?? '')));
-        if ($session_id) {
-            session_id($session_id);
-        }
-
-        /* Install the modern handler. The legacy
-         * Horde_Core_Factory_SessionHandler is no longer wire-bound; the modern
-         * SessionHandlerFactory already covers every backend except mongo. */
-        $modernHandler = $injector->getInstance(ModernSessionHandler::class);
-        session_set_save_handler($modernHandler, true);
-
-        /* Mirror the modern HordeSession payload back into $_SESSION before
-         * PHP runs its own session save. The shim treats $_SESSION as a
-         * write-only mirror at end-of-request: HordeSession owns the data,
-         * and PHP's native save handler serialises whatever sits in $_SESSION
-         * when it runs. Without a shutdown task here, only data written
-         * directly to $_SESSION (e.g. _b/_r) survives across requests, and
-         * scoped/encrypted writes that live in HordeSession are lost.
-         *
-         * Pinned to run after every regular Horde_Shutdown_Task so that any
-         * task writing through the shim (e.g. IMP's per-factory shutdown
-         * writers) lands in HordeSession before this mirror copies it back
-         * to $_SESSION. addFinal() is a single-slot last-writer-wins API
-         * reserved for this kind of framework-owned end-of-request work. */
-        $injector->getInstance('Horde_Shutdown')->addFinal($this);
 
         if ($start) {
             $this->start();
@@ -353,19 +377,26 @@ class Horde_Session implements Horde_Shutdown_Task
      */
     public function start()
     {
-        /* Limit session ID to 32 bytes. Session IDs are NOT cryptographically
-         * secure hashes. Instead, they are nothing more than a way to
-         * generate random strings. */
-        ini_set('session.hash_function', 0);
-        ini_set('session.hash_bits_per_character', 5);
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Lifecycle does session_start(), sets its own active flag,
+            // and rebuilds HordeSession over the now-populated $_SESSION.
+            $lifecycle->start();
+        } else {
+            // Fallback for legacy/test contexts without an injector.
+            ini_set('session.hash_function', 0);
+            ini_set('session.hash_bits_per_character', 5);
+            session_start();
+        }
 
-        session_start();
         $this->_active = true;
         $this->_data = &$_SESSION;
         $this->_rebuildModern();
 
         /* We have reopened a session. Check to make sure that authentication
-         * status has not changed in the meantime. */
+         * status has not changed in the meantime. The relogin guard is a
+         * legacy-stack concern; it lives here in the shim, NOT in
+         * SessionLifecycle. */
         if (!$this->_readonly
             && !is_null($this->_relogin)
             && (($GLOBALS['registry']->getAuth() !== false) !== $this->_relogin)) {
@@ -407,15 +438,24 @@ class Horde_Session implements Horde_Shutdown_Task
      */
     public function regenerate()
     {
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Lifecycle does mirror + session_regenerate_id(true) + writes
+            // the new _r deadline via HordeSession::setScoped() + clears
+            // lifecycle markers.
+            $lifecycle->regenerate();
+            $this->_data = &$_SESSION;
+            $this->_data[self::REGENERATE] = $this->modern->getScoped(self::REGENERATE, '');
+            return;
+        }
+
+        /* Fallback for legacy/test contexts without an injector. Mirrors
+         * the pre-delegation behaviour bit-for-bit. */
         $this->_mirrorToSession();
         session_regenerate_id(true);
         $regenAt = time() + $this->regenerate_interval;
         $this->_data[self::REGENERATE] = $regenAt;
         $this->modern->setScoped(self::REGENERATE, '', $regenAt);
-
-        /* Modern HordeSession handles re-encryption of values in its
-         * encryption map under the new $_SESSION id-derived key, if the
-         * factory wired encryptor/decryptor closures. */
     }
 
     /**
@@ -430,6 +470,27 @@ class Horde_Session implements Horde_Shutdown_Task
         if ($this->_cleansession) {
             return false;
         }
+
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Lifecycle does session_regenerate_id, session_unset,
+            // $_SESSION reset, rebuild HordeSession, initialiseTimestamps,
+            // Horde_Secret_Cbc::setKey, and clears lifecycle markers.
+            // It also sets its own _active flag and idempotency state.
+            $lifecycle->clean();
+
+            // Refresh the shim's bookkeeping to match the now-cleaned
+            // PHP session. _data must rebind to $_SESSION because
+            // session_unset() detached the previous binding; modern must
+            // be re-resolved because rebuildHordeSession() created a fresh
+            // singleton.
+            $this->_data = &$_SESSION;
+            $this->modern = $this->_resolveModern();
+            $this->_cleansession = true;
+            return true;
+        }
+
+        /* Fallback for legacy/test contexts without an injector. */
 
         // login.php and Auth_Application::transparent can call clean() before
         // setup() has opened the session. session_regenerate_id() then fails
@@ -448,10 +509,6 @@ class Horde_Session implements Horde_Shutdown_Task
         $this->_rebuildModern();
         $this->_start();
 
-        if (isset($GLOBALS['injector'])) {
-            $GLOBALS['injector']->getInstance('Horde_Secret_Cbc')->setKey();
-        }
-
         $this->_cleansession = true;
 
         return true;
@@ -466,8 +523,19 @@ class Horde_Session implements Horde_Shutdown_Task
     public function close()
     {
         $this->_active = false;
+        // The shim's relogin guard depends on this; record before we
+        // hand off to the lifecycle. Legacy concern, lives here.
         $this->_relogin = isset($GLOBALS['registry'])
             && ($GLOBALS['registry']->getAuth() !== false);
+
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Lifecycle does the mirror + session_write_close().
+            $lifecycle->close();
+            return;
+        }
+
+        /* Fallback for legacy/test contexts without an injector. */
         $this->_mirrorToSession();
         session_write_close();
     }
@@ -494,6 +562,19 @@ class Horde_Session implements Horde_Shutdown_Task
      */
     public function destroy()
     {
+        $lifecycle = $this->_resolveLifecycle();
+        if ($lifecycle !== null) {
+            // Lifecycle does session_destroy + $_SESSION reset + rebuild
+            // HordeSession + Horde_Secret_Cbc::clearKey + clears lifecycle
+            // markers. It also flips its own active flag and cleaned flag.
+            $lifecycle->destroy();
+            $this->_data = &$_SESSION;
+            $this->modern = $this->_resolveModern();
+            $this->_cleansession = true;
+            return;
+        }
+
+        /* Fallback for legacy/test contexts without an injector. */
         if (isset($_SESSION)) {
             session_destroy();
         }
@@ -501,9 +582,6 @@ class Horde_Session implements Horde_Shutdown_Task
         $this->_data = &$_SESSION;
         $this->_rebuildModern();
         $this->_cleansession = true;
-        if (isset($GLOBALS['injector'])) {
-            $GLOBALS['injector']->getInstance('Horde_Secret_Cbc')->clearKey();
-        }
     }
 
     /**

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -34,6 +34,13 @@ use Horde_Pack_Exception;
  *
  * Encryption closures are optional. Without them, encrypted read returns
  * raw values and encrypted write throws.
+ *
+ * Carries a pair of runtime intent flags ({@see scheduleRegeneration()},
+ * {@see markDestroyed()}). The flags are not data; they are not persisted.
+ * The actual lifecycle work (rotating the id, destroying the row, etc.)
+ * is the responsibility of {@see SessionLifecycle}, which reads the
+ * flags via {@see SessionLifecycle::processFlags()} and clears them via
+ * {@see clearLifecycleFlags()} after acting.
  */
 #[Factory(factory: HordeSessionFactory::class, method: 'create')]
 class HordeSession extends DefaultSession implements SessionMetaInterface, EncryptedValuesInterface
@@ -491,5 +498,19 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
     public function isDestroyed(): bool
     {
         return $this->destroyed;
+    }
+
+    /**
+     * Clear both lifecycle intent flags.
+     *
+     * @internal Called by lifecycle engines (currently
+     *           {@see SessionLifecycle}) after they have acted on the
+     *           markers. Application code should not call this directly;
+     *           intent setters set, executors clear.
+     */
+    public function clearLifecycleFlags(): void
+    {
+        $this->regenerationScheduled = false;
+        $this->destroyed = false;
     }
 }

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -41,6 +41,33 @@ use Horde_Shutdown_Task;
  * both flows leverage; it does not reach upward into Registry or sideways
  * into the shim.
  *
+ * Two flavours of lifecycle methods coexist:
+ *
+ * - **Synchronous executors** {@see clean()}, {@see destroy()},
+ *   {@see regenerate()}: act immediately, called when the caller knows
+ *   the right moment. Each clears HordeSession's intent markers after
+ *   acting so a downstream {@see processFlags()} call is a coherent
+ *   no-op.
+ *
+ * - **Engine** {@see processFlags()}: reads the lifecycle intent
+ *   markers carried by {@see HordeSession} and dispatches to the
+ *   matching synchronous executor. Canonical reader of those markers.
+ *   Other code paths SHOULD NOT read the markers directly. Always
+ *   called explicitly; never auto-fired from {@see shutdown()} or
+ *   any other implicit trigger. Lifecycle dispatch is visible at the
+ *   call site, not magic last-minute behaviour.
+ *
+ * Time-based vs intent-based regeneration:
+ *
+ * - {@see regenerationDue()} is a time-deadline check ("the regenerate-at
+ *   timestamp has passed"). Reads via {@see HordeSession}, not the
+ *   superglobal.
+ * - {@see HordeSession::shouldRegenerate()} is intent ("a controller
+ *   asked for it"). Read by {@see processFlags()}.
+ *
+ * The two are independent and compose: a caller can rotate when either
+ * fires.
+ *
  * Replaces the lifecycle role previously carried by the legacy
  * `Horde_Session` shim. Modern callers (Registry bootstrap, LoginService,
  * Auth_Application, Ajax/Application) consume this class directly. The shim
@@ -262,6 +289,11 @@ class SessionLifecycle implements Horde_Shutdown_Task
 
         $this->cleaned = true;
 
+        // Synchronous executor: any pending lifecycle intent has just been
+        // resolved synchronously; clear so downstream processFlags() is a
+        // coherent no-op.
+        $this->getSession()->clearLifecycleFlags();
+
         return true;
     }
 
@@ -281,6 +313,10 @@ class SessionLifecycle implements Horde_Shutdown_Task
         $this->active = false;
 
         $this->secret?->clearKey();
+
+        // Synchronous executor: clear pending intent so a downstream
+        // processFlags() call does not attempt to re-destroy.
+        $this->getSession()->clearLifecycleFlags();
     }
 
     /**
@@ -298,16 +334,62 @@ class SessionLifecycle implements Horde_Shutdown_Task
         // The shim's addFinal() shutdown task mirrors HordeSession to
         // $_SESSION for legacy code that reads the superglobal directly.
         $this->getSession()->setScoped(self::REGENERATE_KEY, '', $regenAt);
+
+        // Synchronous executor: clear pending intent so a downstream
+        // processFlags() call sees a coherent no-op.
+        $this->getSession()->clearLifecycleFlags();
+    }
+
+    /**
+     * Act on the lifecycle intent markers carried by {@see HordeSession}.
+     *
+     * Reads {@see HordeSession::shouldRegenerate()} and
+     * {@see HordeSession::isDestroyed()} and dispatches to the matching
+     * synchronous executor. The executor clears the markers via
+     * {@see HordeSession::clearLifecycleFlags()} as part of acting.
+     *
+     * Resolution policy: destruction wins over regeneration. A session
+     * being destroyed need not bother rotating its id.
+     *
+     * Idempotent: calling repeatedly with no markers set is a no-op.
+     *
+     * Canonical reader of the markers. Other code paths in this class
+     * and elsewhere SHOULD NOT read the markers directly. Setters can
+     * live anywhere; readers go through here so the dispatch policy is
+     * defined in one place.
+     *
+     * Always called explicitly by a caller that knows the right moment
+     * (e.g. a controller after authentication, a future PSR-15
+     * middleware, a logout handler). NEVER auto-fired from
+     * {@see shutdown()} or any other implicit trigger. Lifecycle
+     * dispatch is visible at the call site, not magic last-minute
+     * behaviour.
+     */
+    public function processFlags(HordeSession $session): void
+    {
+        if ($session->isDestroyed()) {
+            $this->destroy();
+            return;
+        }
+        if ($session->shouldRegenerate()) {
+            $this->regenerate();
+        }
     }
 
     /**
      * Whether the current session is past its regenerate-at deadline.
      *
      * Replaces the legacy `$session->regenerate_due` magic property.
+     *
+     * Reads via the modern {@see HordeSession}, not via `$_SESSION`:
+     * SessionLifecycle is the orchestrator over HordeSession + the PHP
+     * session module, not a parallel reader of the same data. Time-based
+     * (deadline) check, separate from {@see HordeSession::shouldRegenerate()}
+     * which is intent-based.
      */
     public function regenerationDue(): bool
     {
-        $regen = $_SESSION[self::REGENERATE_KEY] ?? null;
+        $regen = $this->getSession()->getScoped(self::REGENERATE_KEY, '');
         return is_int($regen) && time() >= $regen;
     }
 

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -33,9 +33,13 @@ use Horde_Shutdown_Task;
  * {@see HordeSession} (the per-request data layer) plus Horde-application
  * glue: PHP ini tuning, the cookie-domain/single-label-hostname guard, the
  * shutdown task that mirrors {@see HordeSession} payload back into
- * `$_SESSION`, optional {@see Horde_Secret_Cbc} re-keying on `clean()` /
- * `destroy()`, and the relogin auth-changed guard that arms in `close()` and
- * fires in `start()`.
+ * `$_SESSION`, and optional {@see Horde_Secret_Cbc} re-keying on `clean()` /
+ * `destroy()`.
+ *
+ * Registry-agnostic. The legacy stack's relogin auth-changed guard lives
+ * on the `Horde_Session` shim, not here. SessionLifecycle is the engine
+ * both flows leverage; it does not reach upward into Registry or sideways
+ * into the shim.
  *
  * Replaces the lifecycle role previously carried by the legacy
  * `Horde_Session` shim. Modern callers (Registry bootstrap, LoginService,
@@ -74,13 +78,6 @@ class SessionLifecycle implements Horde_Shutdown_Task
 
     /** Whether {@see clean()} has run this request. Idempotency guard. */
     private bool $cleaned = false;
-
-    /**
-     * Auth-state captured at {@see close()} so {@see start()} can detect a
-     * change-of-user across early-close-and-reopen sequences. Null = no
-     * relogin guard armed.
-     */
-    private ?bool $relogin = null;
 
     /** Whether {@see setup()} has installed the save handler this request. */
     private bool $handlerRegistered = false;
@@ -195,9 +192,13 @@ class SessionLifecycle implements Horde_Shutdown_Task
     /**
      * Open the actual PHP session.
      *
-     * Calls {@see session_start()}, marks the lifecycle active, rebuilds
+     * Calls {@see session_start()}, marks the lifecycle active, and rebuilds
      * the modern {@see HordeSession} instance from the now-populated
-     * `$_SESSION` payload, and runs the relogin auth-changed guard.
+     * `$_SESSION` payload.
+     *
+     * The relogin auth-changed guard for the legacy stack lives on the
+     * `Horde_Session` shim, where it belongs. SessionLifecycle is
+     * Registry-agnostic.
      */
     public function start(): void
     {
@@ -213,28 +214,6 @@ class SessionLifecycle implements Horde_Shutdown_Task
         // closures from HordeSessionFactory are preserved on the fresh
         // instance.
         $this->rebuildHordeSession();
-
-        // Relogin guard: if the auth state changed across an early-close
-        // -and-reopen, mark the legacy shim's data view read-only so any
-        // accidental writes during the rest of this request are dropped.
-        // The shim still owns the readonly flag — we just signal.
-        if ($this->relogin !== null && isset($GLOBALS['registry'])) {
-            $authedNow = $GLOBALS['registry']->getAuth() !== false;
-            if ($authedNow !== $this->relogin
-                && isset($GLOBALS['session'])
-                && property_exists($GLOBALS['session'], '_readonly')) {
-                // Best-effort flag flip on the shim. Out-of-tree code that
-                // mutates state inside this request will silently no-op.
-                // Matches the shim's prior behaviour bit-for-bit.
-                try {
-                    $r = new \ReflectionProperty($GLOBALS['session'], '_readonly');
-                    $r->setAccessible(true);
-                    $r->setValue($GLOBALS['session'], true);
-                } catch (\ReflectionException) {
-                    // Shim shape changed under us. Ignore.
-                }
-            }
-        }
     }
 
     /**
@@ -244,8 +223,6 @@ class SessionLifecycle implements Horde_Shutdown_Task
     public function close(): void
     {
         $this->active = false;
-        $this->relogin = isset($GLOBALS['registry'])
-            && ($GLOBALS['registry']->getAuth() !== false);
         $this->mirrorToSession();
         session_write_close();
     }
@@ -317,7 +294,9 @@ class SessionLifecycle implements Horde_Shutdown_Task
         $this->mirrorToSession();
         session_regenerate_id(true);
         $regenAt = time() + $this->regenerateInterval();
-        $_SESSION[self::REGENERATE_KEY] = $regenAt;
+        // The deadline is canonical on HordeSession via the scoped slot.
+        // The shim's addFinal() shutdown task mirrors HordeSession to
+        // $_SESSION for legacy code that reads the superglobal directly.
         $this->getSession()->setScoped(self::REGENERATE_KEY, '', $regenAt);
     }
 
@@ -414,17 +393,15 @@ class SessionLifecycle implements Horde_Shutdown_Task
      */
     private function initialiseTimestamps(): void
     {
-        if (isset($_SESSION[self::BEGIN_KEY])) {
+        $session = $this->getSession();
+
+        if ($session->getScoped(self::BEGIN_KEY, '') !== null) {
             return;
         }
 
         $now = time();
         $regenAt = $now + $this->regenerateInterval();
 
-        $_SESSION[self::BEGIN_KEY] = $now;
-        $_SESSION[self::REGENERATE_KEY] = $regenAt;
-
-        $session = $this->getSession();
         $session->setScoped(self::BEGIN_KEY, '', $now);
         $session->setScoped(self::REGENERATE_KEY, '', $regenAt);
     }

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -619,4 +619,27 @@ class HordeSessionTest extends TestCase
         self::assertFalse($session->shouldRegenerate());
         self::assertFalse($session->isDestroyed());
     }
+
+    #[Test]
+    public function testClearLifecycleFlagsClearsBoth(): void
+    {
+        $session = $this->createSession();
+        $session->scheduleRegeneration();
+        $session->markDestroyed();
+        $session->clearLifecycleFlags();
+        self::assertFalse($session->shouldRegenerate());
+        self::assertFalse($session->isDestroyed());
+    }
+
+    #[Test]
+    public function testClearLifecycleFlagsIsIdempotent(): void
+    {
+        // Clearing already-clear flags is a valid no-op for executors
+        // that always clear regardless of who set what.
+        $session = $this->createSession();
+        $session->clearLifecycleFlags();
+        $session->clearLifecycleFlags();
+        self::assertFalse($session->shouldRegenerate());
+        self::assertFalse($session->isDestroyed());
+    }
 }

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -113,62 +113,47 @@ class SessionLifecycleTest extends TestCase
     #[Test]
     public function testRegenerationDueIsFalseWhenDeadlineNotSet(): void
     {
-        $previous = $_SESSION ?? null;
-        $_SESSION = [];
-
-        try {
-            self::assertFalse($this->build()->regenerationDue());
-        } finally {
-            if ($previous === null) {
-                unset($_SESSION);
-            } else {
-                $_SESSION = $previous;
-            }
-        }
+        // Default HordeSession has no _r key set.
+        self::assertFalse($this->build()->regenerationDue());
     }
 
     #[Test]
     public function testRegenerationDueIsFalseWhenDeadlineInFuture(): void
     {
-        $previous = $_SESSION ?? null;
-        $_SESSION = ['_r' => time() + 3600];
-
-        try {
-            self::assertFalse($this->build()->regenerationDue());
-        } finally {
-            if ($previous === null) {
-                unset($_SESSION);
-            } else {
-                $_SESSION = $previous;
-            }
-        }
+        $session = new HordeSession(new SessionId('rd-test'), []);
+        $session->setScoped('_r', '', time() + 3600);
+        self::assertFalse($this->build(session: $session)->regenerationDue());
     }
 
     #[Test]
     public function testRegenerationDueIsTrueWhenDeadlineInPast(): void
     {
-        $previous = $_SESSION ?? null;
-        $_SESSION = ['_r' => time() - 1];
-
-        try {
-            self::assertTrue($this->build()->regenerationDue());
-        } finally {
-            if ($previous === null) {
-                unset($_SESSION);
-            } else {
-                $_SESSION = $previous;
-            }
-        }
+        $session = new HordeSession(new SessionId('rd-test'), []);
+        $session->setScoped('_r', '', time() - 1);
+        self::assertTrue($this->build(session: $session)->regenerationDue());
     }
 
     #[Test]
     public function testRegenerationDueIgnoresNonIntegerDeadlines(): void
     {
+        $session = new HordeSession(new SessionId('rd-test'), []);
+        $session->setScoped('_r', '', 'not-a-timestamp');
+        self::assertFalse($this->build(session: $session)->regenerationDue());
+    }
+
+    #[Test]
+    public function testRegenerationDueReadsViaHordeSessionNotSuperglobal(): void
+    {
+        // Layering: SessionLifecycle is the orchestrator; HordeSession owns
+        // session data reads. Putting the deadline only in $_SESSION must
+        // NOT make regenerationDue() see it.
         $previous = $_SESSION ?? null;
-        $_SESSION = ['_r' => 'not-a-timestamp'];
+        $_SESSION = ['_r' => time() - 1];
 
         try {
-            self::assertFalse($this->build()->regenerationDue());
+            $session = new HordeSession(new SessionId('rd-test'), []);
+            // No setScoped; HordeSession has no idea about the deadline.
+            self::assertFalse($this->build(session: $session)->regenerationDue());
         } finally {
             if ($previous === null) {
                 unset($_SESSION);
@@ -231,5 +216,169 @@ class SessionLifecycleTest extends TestCase
                 $_SESSION = $previous;
             }
         }
+    }
+
+    // ---------------------------------------------------------------
+    // processFlags()
+    //
+    // The dispatch policy is tested via a recording subclass that
+    // overrides the synchronous executors. Dispatching to the real
+    // executors requires a live PHP session (session_regenerate_id /
+    // session_destroy fail in CLI), which is the integration suite's
+    // territory. Unit tests stay focused on the policy: who gets
+    // called, in what order, and when nothing should happen.
+    // ---------------------------------------------------------------
+
+    private function buildRecording(?HordeSession $session = null): RecordingSessionLifecycle
+    {
+        $injector = new Injector(new TopLevel());
+        $session ??= new HordeSession(new SessionId('process-flags-test'), []);
+        $injector->setInstance(HordeSession::class, $session);
+        $handler = new SessionHandler(new BuiltinBackend());
+        return new RecordingSessionLifecycle($injector, $handler, new State([]));
+    }
+
+    #[Test]
+    public function testProcessFlagsNoOpWhenNoFlagsSet(): void
+    {
+        $session = new HordeSession(new SessionId('pf-noop'), []);
+        $lifecycle = $this->buildRecording($session);
+
+        $lifecycle->processFlags($session);
+
+        self::assertSame([], $lifecycle->calls);
+    }
+
+    #[Test]
+    public function testProcessFlagsDispatchesToRegenerateWhenFlagSet(): void
+    {
+        $session = new HordeSession(new SessionId('pf-regen'), []);
+        $session->scheduleRegeneration();
+        $lifecycle = $this->buildRecording($session);
+
+        $lifecycle->processFlags($session);
+
+        self::assertSame(['regenerate'], $lifecycle->calls);
+    }
+
+    #[Test]
+    public function testProcessFlagsDispatchesToDestroyWhenFlagSet(): void
+    {
+        $session = new HordeSession(new SessionId('pf-destroy'), []);
+        $session->markDestroyed();
+        $lifecycle = $this->buildRecording($session);
+
+        $lifecycle->processFlags($session);
+
+        self::assertSame(['destroy'], $lifecycle->calls);
+    }
+
+    #[Test]
+    public function testProcessFlagsPrefersDestroyOverRegenerate(): void
+    {
+        // Resolution policy: destruction wins. A session being destroyed
+        // need not bother rotating its id.
+        $session = new HordeSession(new SessionId('pf-both'), []);
+        $session->scheduleRegeneration();
+        $session->markDestroyed();
+        $lifecycle = $this->buildRecording($session);
+
+        $lifecycle->processFlags($session);
+
+        self::assertSame(['destroy'], $lifecycle->calls);
+    }
+
+    #[Test]
+    public function testProcessFlagsIsIdempotentOnRepeatedCall(): void
+    {
+        // Once executors clear flags after acting, a second processFlags()
+        // call sees no flags and dispatches nothing.
+        $session = new HordeSession(new SessionId('pf-idempotent'), []);
+        $session->scheduleRegeneration();
+        $lifecycle = $this->buildRecording($session);
+
+        $lifecycle->processFlags($session);
+        $lifecycle->processFlags($session);
+
+        self::assertSame(['regenerate'], $lifecycle->calls);
+    }
+
+    #[Test]
+    public function testShutdownDoesNotFireProcessFlags(): void
+    {
+        // Regression sentinel for the "no magic last-minute behaviour"
+        // rule. shutdown() mirrors only; lifecycle dispatch must be
+        // explicit, called by middleware or controllers, never auto-fired
+        // from a shutdown hook.
+        $session = new HordeSession(new SessionId('shutdown-no-dispatch'), []);
+        $session->scheduleRegeneration();
+        $session->markDestroyed();
+        $lifecycle = $this->buildRecording($session);
+
+        // Force active=true so shutdown() does its mirror; processFlags
+        // should still NOT fire.
+        $r = new \ReflectionProperty(SessionLifecycle::class, 'active');
+        $r->setAccessible(true);
+        $r->setValue($lifecycle, true);
+
+        $previous = $_SESSION ?? null;
+        $_SESSION = [];
+
+        try {
+            $lifecycle->shutdown();
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+
+        self::assertSame([], $lifecycle->calls);
+        self::assertTrue($session->shouldRegenerate());
+        self::assertTrue($session->isDestroyed());
+    }
+}
+
+/**
+ * Test double that records calls to the synchronous executors instead of
+ * invoking PHP's session module. Lets us verify processFlags()'s dispatch
+ * policy at unit-test scope without requiring a live session.
+ */
+class RecordingSessionLifecycle extends SessionLifecycle
+{
+    /** @var list<string> */
+    public array $calls = [];
+
+    public function clean(): bool
+    {
+        $this->calls[] = 'clean';
+        $this->getHordeSessionForTest()->clearLifecycleFlags();
+        return true;
+    }
+
+    public function destroy(): void
+    {
+        $this->calls[] = 'destroy';
+        $this->getHordeSessionForTest()->clearLifecycleFlags();
+    }
+
+    public function regenerate(): void
+    {
+        $this->calls[] = 'regenerate';
+        $this->getHordeSessionForTest()->clearLifecycleFlags();
+    }
+
+    /**
+     * Resolve the modern session via the same injector path the parent
+     * uses. A small accessor because the parent's getSession() is private.
+     */
+    private function getHordeSessionForTest(): HordeSession
+    {
+        $r = new \ReflectionMethod(parent::class, 'getSession');
+        $r->setAccessible(true);
+        /** @var HordeSession $session */
+        $session = $r->invoke($this);
+        return $session;
     }
 }


### PR DESCRIPTION
- Remove dependency on modern session code back into the registry
- Make legacy registry leverage the legacy session shim (auto-writes on request shutdown) which in turn delegates to the modern code
- keep the modern code free of magic - it is supposed to be run by middlewares or the legacy wrapper. Keep the magic there.