### PR TITLE
feat: Horde 6 modern session handling infrastructure

### DIFF
--- a/src/Auth/AuthCredentialStore.php
+++ b/src/Auth/AuthCredentialStore.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Horde\Core\Auth;
 
+use DateTimeImmutable;
 use Horde\Core\Session\HordeSession;
 use Horde\Injector\Attribute\Factory;
 use Horde\Injector\Injector;
@@ -51,6 +52,18 @@ class AuthCredentialStore
 
     /** Slot key prefix for the init flag. */
     private const INIT_PREFIX = 'auth_app_init/';
+
+    /** Slot key prefix for {@see HasCredentialsState} per app. */
+    private const STATE_PREFIX = 'auth_app_state/';
+
+    /** Slot key prefix for the int timestamp of the last state transition. */
+    private const STATE_AT_PREFIX = 'auth_app_state_at/';
+
+    /** Slot key prefix for {@see InvalidationReason} when state is Invalidated. */
+    private const STATE_REASON_PREFIX = 'auth_app_state_reason/';
+
+    /** Slot key prefix for optional free-text detail accompanying the reason. */
+    private const STATE_DETAIL_PREFIX = 'auth_app_state_detail/';
 
     /** Slot key for the base-app pointer (read-only here). */
     private const BASE_APP_KEY = 'auth/credentials';
@@ -110,6 +123,21 @@ class AuthCredentialStore
             );
         }
         $this->session->setScoped(self::SCOPE, self::INIT_PREFIX . $app, true);
+        $this->writeState($app, HasCredentialsState::Present);
+    }
+
+    /**
+     * Persist a credentials array for the given app.
+     *
+     * Preferred name. Forwards to {@see set()} which keeps its existing
+     * signature for legacy callers (Registry) but performs the same work
+     * including marking the state as {@see HasCredentialsState::Present}.
+     *
+     * @param array<string,mixed> $credentials
+     */
+    public function setCredentials(string $app, array $credentials): void
+    {
+        $this->set($app, $credentials);
     }
 
     /**
@@ -191,6 +219,9 @@ class AuthCredentialStore
      * Clear the stored credentials and init flag for the given app.
      *
      * Mirrors the slot removals `Horde_Registry::clearAuthApp` makes on logout.
+     * Also clears the per-app state slots so a subsequent {@see getState()}
+     * read returns {@see HasCredentialsState::NeverHad} (the implicit
+     * default) rather than reporting stale state.
      */
     public function clear(string $app): void
     {
@@ -199,6 +230,10 @@ class AuthCredentialStore
             self::CREDENTIALS_PREFIX . $app,
         );
         $this->session->removeScoped(self::SCOPE, self::INIT_PREFIX . $app);
+        $this->session->removeScoped(self::SCOPE, self::STATE_PREFIX . $app);
+        $this->session->removeScoped(self::SCOPE, self::STATE_AT_PREFIX . $app);
+        $this->session->removeScoped(self::SCOPE, self::STATE_REASON_PREFIX . $app);
+        $this->session->removeScoped(self::SCOPE, self::STATE_DETAIL_PREFIX . $app);
     }
 
     /**
@@ -220,5 +255,177 @@ class AuthCredentialStore
         $value = $this->session->getScoped(self::SCOPE, self::BASE_APP_KEY);
 
         return is_string($value) ? $value : null;
+    }
+
+    // ---------------------------------------------------------------
+    // Per-app credential state (HasCredentialsState + InvalidationReason)
+    //
+    // The legacy slot pair (`auth_app/<app>` + `auth_app_init/<app>`) only
+    // distinguishes "credentials present" from "absent". The state slots
+    // below add a third distinction: "absent because invalidated" with a
+    // typed reason. Apps that need to surface a precise reauth prompt
+    // (IMP after IMAP rejects the password, etc.) read via
+    // {@see getOrExplain()} or {@see getState()}.
+    // ---------------------------------------------------------------
+
+    /**
+     * Mark the app's credentials as invalidated.
+     *
+     * Removes the cleartext from the encrypted slot (the credentials are
+     * no longer trustworthy) but keeps the per-app metadata so callers
+     * see {@see HasCredentialsState::Invalidated} with a reason on the
+     * next read.
+     *
+     * Idempotent: a second call updates the timestamp and reason without
+     * raising.
+     */
+    public function markInvalidated(
+        string $app,
+        InvalidationReason $reason,
+        ?string $detail = null,
+    ): void {
+        $this->session->removeScoped(self::SCOPE, self::CREDENTIALS_PREFIX . $app);
+        $this->writeState($app, HasCredentialsState::Invalidated, $reason, $detail);
+    }
+
+    /**
+     * Mark the app's credentials as never having been provided this
+     * request, e.g. when {@see RememberMeMiddleware} mints a session
+     * from a remember-me token.
+     *
+     * Equivalent to clearing the slot but signposts the absence as
+     * deliberate (the user IS identified) rather than as a never-touched
+     * default.
+     *
+     * Most callers can rely on the implicit default: an absent
+     * `auth_app_state/<app>` slot is read as {@see HasCredentialsState::NeverHad}.
+     * Calling this method is useful when the caller wants to record the
+     * timestamp of the transition for audit purposes.
+     */
+    public function markNeverHad(string $app): void
+    {
+        $this->session->removeScoped(self::SCOPE, self::CREDENTIALS_PREFIX . $app);
+        $this->writeState($app, HasCredentialsState::NeverHad);
+    }
+
+    /**
+     * Read the current per-app credential state.
+     *
+     * Returns {@see HasCredentialsState::NeverHad} when no state has
+     * been recorded for the app: that's the safe default for
+     * unknown / absent state. Apps that need to distinguish that from
+     * an explicit "never had" intent should consult
+     * {@see getStateMetadata()} for the timestamp.
+     */
+    public function getState(string $app): HasCredentialsState
+    {
+        $raw = $this->session->getScoped(self::SCOPE, self::STATE_PREFIX . $app);
+        if (!is_string($raw)) {
+            return HasCredentialsState::NeverHad;
+        }
+        return HasCredentialsState::tryFrom($raw) ?? HasCredentialsState::NeverHad;
+    }
+
+    /**
+     * Read the per-app credential state plus its transition metadata.
+     *
+     * Returns null when no state has been recorded. The implicit
+     * "absent = NeverHad" inference applied by {@see getState()} does
+     * NOT apply here: callers asking for metadata want to know whether
+     * a transition happened, and a missing slot means it didn't.
+     */
+    public function getStateMetadata(string $app): ?CredentialStateMetadata
+    {
+        $rawState = $this->session->getScoped(self::SCOPE, self::STATE_PREFIX . $app);
+        if (!is_string($rawState)) {
+            return null;
+        }
+        $state = HasCredentialsState::tryFrom($rawState);
+        if ($state === null) {
+            return null;
+        }
+
+        $rawAt = $this->session->getScoped(self::SCOPE, self::STATE_AT_PREFIX . $app);
+        $since = is_int($rawAt)
+            ? (new DateTimeImmutable())->setTimestamp($rawAt)
+            : null;
+
+        $rawReason = $this->session->getScoped(self::SCOPE, self::STATE_REASON_PREFIX . $app);
+        $reason = is_string($rawReason)
+            ? InvalidationReason::tryFrom($rawReason)
+            : null;
+
+        $rawDetail = $this->session->getScoped(self::SCOPE, self::STATE_DETAIL_PREFIX . $app);
+        $detail = is_string($rawDetail) ? $rawDetail : null;
+
+        return new CredentialStateMetadata(
+            state: $state,
+            since: $since,
+            reason: $reason,
+            detail: $detail,
+        );
+    }
+
+    /**
+     * Read the current credentials with explanatory state context.
+     *
+     * Designed for `match` over the returned `state`: callers that need
+     * the credentials get them when the state is
+     * {@see HasCredentialsState::Present}, and otherwise have the
+     * reason context they need to render the right reauth UX.
+     *
+     * Falls back to the legacy {@see get()} resolver to materialise
+     * credentials so the dedup-against-base-app rule keeps working.
+     * Returns a CredentialResult with `credentials = null` when the
+     * resolver returns false.
+     */
+    public function getOrExplain(string $app): CredentialResult
+    {
+        $value = $this->get($app);
+        $state = $this->getState($app);
+
+        if ($state === HasCredentialsState::Present) {
+            // The legacy resolver may still return false (no base app,
+            // or stale slot). Fall through to NeverHad in that case.
+            if (is_array($value)) {
+                return new CredentialResult(
+                    state: HasCredentialsState::Present,
+                    credentials: $value,
+                );
+            }
+            return new CredentialResult(state: HasCredentialsState::NeverHad);
+        }
+
+        $metadata = $this->getStateMetadata($app);
+        return new CredentialResult(
+            state: $state,
+            reason: $metadata?->reason,
+            detail: $metadata?->detail,
+        );
+    }
+
+    /**
+     * Write the per-app state slots.
+     */
+    private function writeState(
+        string $app,
+        HasCredentialsState $state,
+        ?InvalidationReason $reason = null,
+        ?string $detail = null,
+    ): void {
+        $this->session->setScoped(self::SCOPE, self::STATE_PREFIX . $app, $state->value);
+        $this->session->setScoped(self::SCOPE, self::STATE_AT_PREFIX . $app, time());
+
+        if ($reason !== null) {
+            $this->session->setScoped(self::SCOPE, self::STATE_REASON_PREFIX . $app, $reason->value);
+        } else {
+            $this->session->removeScoped(self::SCOPE, self::STATE_REASON_PREFIX . $app);
+        }
+
+        if ($detail !== null && $detail !== '') {
+            $this->session->setScoped(self::SCOPE, self::STATE_DETAIL_PREFIX . $app, $detail);
+        } else {
+            $this->session->removeScoped(self::SCOPE, self::STATE_DETAIL_PREFIX . $app);
+        }
     }
 }

--- a/src/Auth/CredentialResult.php
+++ b/src/Auth/CredentialResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+/**
+ * Outcome of {@see AuthCredentialStore::getOrExplain()}.
+ *
+ * Pairs the credential array (when {@see state} is
+ * {@see HasCredentialsState::Present}) with the state and metadata
+ * needed to render an explanatory UI when credentials are absent.
+ *
+ * Designed for `match` over `state`:
+ *
+ * ```php
+ * $result = $credStore->getOrExplain('imp');
+ * match ($result->state) {
+ *     HasCredentialsState::Present     => $imap->connect($user, $result->credentials),
+ *     HasCredentialsState::NeverHad    => $this->redirectToAppLogin('imp', 'remember-me'),
+ *     HasCredentialsState::Invalidated => $this->redirectToAppLogin('imp', $result->reason?->value ?? 'invalidated'),
+ * };
+ * ```
+ *
+ * `credentials` is non-null iff `state === Present`. The pair is enforced
+ * at construction.
+ */
+final class CredentialResult
+{
+    /**
+     * @param HasCredentialsState           $state       Current state.
+     * @param array<string,mixed>|null      $credentials The credentials
+     *                                                   array; non-null
+     *                                                   iff state is
+     *                                                   Present.
+     * @param InvalidationReason|null       $reason      Reason for
+     *                                                   invalidation;
+     *                                                   meaningful only
+     *                                                   when state is
+     *                                                   Invalidated.
+     * @param string|null                   $detail      Optional free-text
+     *                                                   detail for log
+     *                                                   trawling.
+     */
+    public function __construct(
+        public readonly HasCredentialsState $state,
+        public readonly ?array $credentials = null,
+        public readonly ?InvalidationReason $reason = null,
+        public readonly ?string $detail = null,
+    ) {}
+}

--- a/src/Auth/CredentialStateMetadata.php
+++ b/src/Auth/CredentialStateMetadata.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+use DateTimeImmutable;
+
+/**
+ * Per-app credential state plus the metadata of its last transition.
+ *
+ * Returned by {@see AuthCredentialStore::getStateMetadata()}. The
+ * timestamp is the moment the state was last set; the reason is
+ * meaningful only when state is {@see HasCredentialsState::Invalidated}.
+ */
+final class CredentialStateMetadata
+{
+    public function __construct(
+        public readonly HasCredentialsState $state,
+        public readonly ?DateTimeImmutable $since = null,
+        public readonly ?InvalidationReason $reason = null,
+        public readonly ?string $detail = null,
+    ) {}
+}

--- a/src/Auth/HasCredentialsState.php
+++ b/src/Auth/HasCredentialsState.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+/**
+ * Per-app credential availability state on a {@see HordeSession}.
+ *
+ * Distinguishes three meaningfully different reasons why a session may
+ * not have credentials for a given app:
+ *
+ * - {@see Present}: the session holds cleartext credentials for this app.
+ *   Apps that need to reach a backend (IMAP, LDAP, Samba) can do so.
+ * - {@see NeverHad}: this session was resumed from a remember-me token
+ *   or a similar low-trust channel that did not carry credentials. The
+ *   user is identified, but per-app authentication has to be redone.
+ * - {@see Invalidated}: the session previously held credentials, but
+ *   they have been wiped (rejected by the backend, password changed,
+ *   admin force, scheduled idle wipe). Indicates a state change worth
+ *   surfacing to the user with diagnostic context (see
+ *   {@see InvalidationReason}).
+ *
+ * Conflating "never had" with "had and lost them" loses diagnostic
+ * information. UX, audit logs, and reauth flows differ between the two.
+ */
+enum HasCredentialsState: string
+{
+    case Present = 'present';
+    case NeverHad = 'never-had';
+    case Invalidated = 'invalidated';
+}

--- a/src/Auth/InvalidationReason.php
+++ b/src/Auth/InvalidationReason.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Auth;
+
+/**
+ * Why an app's credentials transitioned from
+ * {@see HasCredentialsState::Present} to
+ * {@see HasCredentialsState::Invalidated}.
+ *
+ * Modern, type-safe equivalent of the disjointed
+ * `Horde_Auth::REASON_*` class constants. Used by
+ * {@see AuthCredentialStore::markInvalidated()} and read by
+ * authentication-aware UI to present an appropriate prompt:
+ *
+ * - {@see BackendRejected}: the backend (IMAP, LDAP, …) rejected the
+ *   stored credential at connection / bind time. Most common case;
+ *   user typed the wrong password, or it changed elsewhere.
+ * - {@see PasswordChanged}: the user changed their password through
+ *   `passwd/` or an equivalent flow. All apps holding credentials get
+ *   marked invalidated together.
+ * - {@see IdleWipe}: a scheduled hardening loop wiped credentials
+ *   after an idle threshold. Optional behaviour configured per
+ *   deployment.
+ * - {@see AdminForced}: an administrator action invalidated the
+ *   credentials.
+ * - {@see Unknown}: catch-all for cases that don't fit the above.
+ *   Discouraged; prefer the specific reasons.
+ */
+enum InvalidationReason: string
+{
+    case BackendRejected = 'backend-rejected';
+    case PasswordChanged = 'password-changed';
+    case IdleWipe = 'idle-wipe';
+    case AdminForced = 'admin-forced';
+    case Unknown = 'unknown';
+}

--- a/src/Middleware/HordeSessionMiddleware.php
+++ b/src/Middleware/HordeSessionMiddleware.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Middleware;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionConfig;
+use Horde\Http\SameSite;
+use Horde\Http\Server\Cookies;
+use Horde\Http\StrictCookie;
+use Horde\SessionHandler\Exception\SessionException;
+use Horde\SessionHandler\Session;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionId;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Modern PSR-15 cookie-bearing session middleware.
+ *
+ * Reads the session id from the configured session cookie, loads the
+ * matching {@see HordeSession} via {@see SessionHandler::load()}, and
+ * sets it as the request attribute {@see ATTRIBUTE_SESSION}. Mints a
+ * fresh session via {@see SessionHandler::create()} when no cookie is
+ * present or the cookie's row has been pruned.
+ *
+ * On the way out:
+ *
+ * - If the session was {@see HordeSession::markDestroyed()}: deletes
+ *   the row via {@see SessionHandler::destroySession()} and emits a
+ *   clearing `Set-Cookie` header.
+ * - If the session was {@see HordeSession::scheduleRegeneration()}:
+ *   rotates the id via {@see SessionHandler::regenerate()}, persists
+ *   the new row, and emits a `Set-Cookie` carrying the new id.
+ * - Otherwise: persists the row if dirty, and emits `Set-Cookie` only
+ *   when the request did not arrive with the same id.
+ *
+ * Composition with {@see JwtSessionLoader}: when JwtSessionLoader has
+ * already set {@see ATTRIBUTE_SESSION} on the request (because the
+ * `horde_jwt_refresh` cookie resolved a session), this middleware skips
+ * loading and only handles persistence on the way out.
+ *
+ * Operates entirely against {@see SessionHandler} primitives. Does NOT
+ * call PHP's session module, the legacy {@see \Horde_Session} shim, or
+ * {@see \Horde\Core\Session\SessionLifecycle}'s synchronous executors.
+ * The legacy stack continues to use the shim and the lifecycle directly.
+ */
+final class HordeSessionMiddleware implements MiddlewareInterface
+{
+    /** Request attribute carrying the active {@see HordeSession}. */
+    public const ATTRIBUTE_SESSION = JwtSessionLoader::ATTRIBUTE_SESSION;
+
+    /** Internal scope and key for the regenerate-at deadline. Matches HordeSession's wire format. */
+    private const REGENERATE_KEY = '_r';
+
+    public function __construct(
+        private readonly SessionHandler $handler,
+        private readonly SessionConfig $config,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {}
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        $existingSession = $request->getAttribute(self::ATTRIBUTE_SESSION);
+        $hadCookie = false;
+
+        if ($existingSession instanceof HordeSession) {
+            // A previous middleware (typically JwtSessionLoader) already
+            // resolved a session for this request. Use it.
+            $session = $existingSession;
+            $hadCookie = true;
+        } else {
+            [$session, $hadCookie] = $this->loadOrMint($request);
+            $request = $request->withAttribute(self::ATTRIBUTE_SESSION, $session);
+        }
+
+        $response = $handler->handle($request);
+
+        return $this->finalise($response, $session, $hadCookie);
+    }
+
+    /**
+     * Resolve the session for this request.
+     *
+     * Returns the session and whether the request arrived with a valid
+     * cookie that resolved to it. The boolean drives whether a fresh
+     * `Set-Cookie` is needed on the response.
+     *
+     * @return array{0: HordeSession, 1: bool}
+     */
+    private function loadOrMint(ServerRequestInterface $request): array
+    {
+        $cookies = $request->getCookieParams();
+        $cookieValue = $cookies[$this->config->cookieName] ?? null;
+
+        if (is_string($cookieValue) && $cookieValue !== '') {
+            $session = $this->safeLoad($cookieValue);
+            if ($session !== null) {
+                return [$session, true];
+            }
+        }
+
+        return [$this->mintFreshSession(), false];
+    }
+
+    private function safeLoad(string $cookieValue): ?HordeSession
+    {
+        try {
+            $sessionId = new SessionId($cookieValue);
+        } catch (InvalidArgumentException $e) {
+            $this->logger->debug('Session cookie value rejected as malformed id', [
+                'exception' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        try {
+            $loaded = $this->handler->load($sessionId);
+        } catch (SessionException $e) {
+            $this->logger->warning('Session backend load failed', [
+                'sid' => $cookieValue,
+                'exception' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        if ($loaded === null) {
+            return null;
+        }
+        if (!$loaded instanceof HordeSession) {
+            // SessionHandler factory configured against a non-HordeSession.
+            // Defensive check; should not happen in production.
+            $this->logger->warning('Loaded session is not a HordeSession', [
+                'class' => get_debug_type($loaded),
+            ]);
+            return null;
+        }
+        return $loaded;
+    }
+
+    private function mintFreshSession(): HordeSession
+    {
+        $created = $this->handler->create();
+        if (!$created instanceof HordeSession) {
+            // The configured factory is supposed to mint HordeSessions;
+            // if it doesn't, the rest of the modern stack will fail
+            // anyway. Surface the misconfiguration clearly.
+            throw new \LogicException(sprintf(
+                'SessionHandler::create() returned %s, expected HordeSession.',
+                get_debug_type($created),
+            ));
+        }
+        return $created;
+    }
+
+    /**
+     * Persist + emit cookie on the way out.
+     */
+    private function finalise(
+        ResponseInterface $response,
+        HordeSession $session,
+        bool $hadCookie,
+    ): ResponseInterface {
+        if ($session->isDestroyed()) {
+            return $this->finaliseDestroyed($response, $session);
+        }
+
+        if ($session->shouldRegenerate()) {
+            return $this->finaliseRegenerated($response, $session);
+        }
+
+        return $this->finaliseSteady($response, $session, $hadCookie);
+    }
+
+    private function finaliseDestroyed(
+        ResponseInterface $response,
+        HordeSession $session,
+    ): ResponseInterface {
+        try {
+            $this->handler->destroySession($session->getId());
+        } catch (SessionException $e) {
+            // Backend write failed during destroy. The user's intent was
+            // logout; we cannot rebound silently. Log and still emit
+            // the clearing cookie so the client treats the session as
+            // gone.
+            $this->logger->warning('Session destroy failed', [
+                'sid' => (string) $session->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+        }
+
+        return Cookies::clear(
+            $response,
+            $this->config->cookieName,
+            $this->config->cookiePath,
+            $this->config->cookieDomain,
+        );
+    }
+
+    private function finaliseRegenerated(
+        ResponseInterface $response,
+        HordeSession $session,
+    ): ResponseInterface {
+        try {
+            $rotated = $this->handler->regenerate($session);
+        } catch (SessionException $e) {
+            // Failed to rotate. Best-effort: persist what we have under
+            // the original id so the user's request work isn't lost,
+            // and don't emit a Set-Cookie. Next request retries
+            // rotation if the marker is set again.
+            $this->logger->warning('Session regenerate failed; persisting under original id', [
+                'sid' => (string) $session->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+            return $this->finaliseSteady($response, $session, hadCookie: true);
+        }
+
+        // Refresh the regenerate-at deadline. Two reasons:
+        //   1. Per-request rotations should reset the deadline; otherwise
+        //      a controller calling scheduleRegeneration() repeatedly
+        //      would not extend the next forced-rotation window.
+        //   2. SessionHandler::regenerate() returns a clean (non-dirty)
+        //      session because it merely restores the old payload under
+        //      a new id. Writing the deadline marks it dirty so save()
+        //      actually persists the row at the new id; without this,
+        //      the rotated session has no backend representation
+        //      because the old row was deleted by regenerate().
+        $rotated->setScoped(
+            self::REGENERATE_KEY,
+            '',
+            time() + $this->config->regenerateInterval,
+        );
+
+        try {
+            $this->handler->save($rotated);
+        } catch (SessionException $e) {
+            $this->logger->warning('Session save after regenerate failed', [
+                'sid' => (string) $rotated->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+        }
+
+        return Cookies::with($response, $this->buildSessionCookie((string) $rotated->getId()));
+    }
+
+    private function finaliseSteady(
+        ResponseInterface $response,
+        HordeSession $session,
+        bool $hadCookie,
+    ): ResponseInterface {
+        $this->saveIfDirty($session);
+
+        if (!$hadCookie) {
+            // First request, or cookie was missing/invalid: emit the
+            // freshly-minted session id.
+            return Cookies::with($response, $this->buildSessionCookie((string) $session->getId()));
+        }
+
+        // Steady state: cookie already present and id unchanged. Skip
+        // the cookie emission.
+        return $response;
+    }
+
+    private function saveIfDirty(Session $session): void
+    {
+        if (!$session->isDirty()) {
+            return;
+        }
+        try {
+            $this->handler->save($session);
+        } catch (SessionException $e) {
+            $this->logger->warning('Session save failed', [
+                'sid' => (string) $session->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function buildSessionCookie(string $value): StrictCookie
+    {
+        return new StrictCookie(
+            cookieName: $this->config->cookieName,
+            cookieValue: $value,
+            cookieMaxAge: $this->config->lifetime > 0 ? $this->config->lifetime : null,
+            cookieDomain: $this->config->cookieDomain,
+            cookiePath: $this->config->cookiePath,
+            cookieSecure: $this->config->secure,
+            cookieHttpOnly: true,
+            cookieSameSite: SameSite::Lax,
+        );
+    }
+}

--- a/src/Middleware/JwtSessionLoader.php
+++ b/src/Middleware/JwtSessionLoader.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Middleware;
+
+use Horde\Core\Auth\Jwt\JwtService;
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\Exception\SessionException;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionId;
+use InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Modern PSR-15 JWT-to-HordeSession loader.
+ *
+ * Reads the `horde_jwt_refresh` cookie, verifies the JWT, and loads
+ * the matching {@see HordeSession} via {@see SessionHandler::load()}
+ * keyed by the refresh token's `jti` (which IS the session id, per
+ * the JWT-JTI architecture decision). The loaded session is set as
+ * a request attribute under {@see ATTRIBUTE_SESSION}.
+ *
+ * Differs from the legacy {@see JwtSession} middleware in two ways:
+ *
+ * - Uses {@see SessionHandler::load()} directly. Does NOT call
+ *   `session_id()` and does NOT depend on PHP's session module
+ *   running afterwards. Suited to modern PSR-15 routes that own
+ *   their session lifecycle through {@see \Horde\Core\Session\SessionLifecycle}
+ *   plus middleware, not through the legacy
+ *   `Horde_Session::setup()` flow.
+ * - Verifies the JWT before lookup. An unverified JTI must not be
+ *   used to load a session row even though forging a valid JWT is
+ *   computationally infeasible: verification catches expired
+ *   refresh tokens and rejected signatures cheaply.
+ *
+ * Never short-circuits. Routes that need to demand authentication
+ * compose this with {@see DemandAuthenticatedUser} or similar
+ * downstream middleware. Failure modes (no cookie, invalid cookie,
+ * verification failure, no matching session row) all leave the
+ * request attribute unset and let the inner handler run normally.
+ */
+class JwtSessionLoader implements MiddlewareInterface
+{
+    /** Request attribute carrying the loaded {@see HordeSession}. */
+    public const ATTRIBUTE_SESSION = 'session';
+
+    /** Cookie name for the JWT refresh token. */
+    public const COOKIE_NAME = 'horde_jwt_refresh';
+
+    public function __construct(
+        private readonly JwtService $jwtService,
+        private readonly SessionHandler $sessionHandler,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        $session = $this->resolveSession($request);
+        if ($session !== null) {
+            $request = $request->withAttribute(self::ATTRIBUTE_SESSION, $session);
+        }
+        return $handler->handle($request);
+    }
+
+    /**
+     * Resolve a {@see HordeSession} from the request's JWT refresh cookie.
+     *
+     * Returns null and logs the reason for any failure. The middleware
+     * never raises; the worst case is that the inner handler runs
+     * without a session attribute and downstream code treats the
+     * request as unauthenticated.
+     */
+    private function resolveSession(ServerRequestInterface $request): ?HordeSession
+    {
+        $cookies = $request->getCookieParams();
+        $jwt = $cookies[self::COOKIE_NAME] ?? null;
+        if (!is_string($jwt) || $jwt === '') {
+            return null;
+        }
+
+        try {
+            $verified = $this->jwtService->verifyRefreshToken($jwt);
+        } catch (InvalidArgumentException $e) {
+            // Expired, malformed, or signature-rejected. The session row
+            // (if it exists) is no longer reachable by this token. Treat
+            // as unauthenticated and let downstream code redirect to
+            // login.
+            $this->logger->debug('JWT refresh token verification failed', [
+                'exception' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        $jti = $verified->getClaim('jti');
+        if (!is_string($jti) || $jti === '') {
+            $this->logger->debug('JWT refresh token has no jti claim');
+            return null;
+        }
+
+        try {
+            $session = $this->sessionHandler->load(new SessionId($jti));
+        } catch (SessionException $e) {
+            // Backend storage error. Same outcome as a missing row:
+            // unauthenticated.
+            $this->logger->warning('JWT session lookup failed', [
+                'jti' => $jti,
+                'exception' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        if ($session === null) {
+            // Token is valid (signature OK, not expired) but the session
+            // row is gone. Logout destroyed it; or it was pruned by GC.
+            // Token is effectively dead.
+            $this->logger->info('JWT session row not found', ['jti' => $jti]);
+            return null;
+        }
+
+        if (!$session instanceof HordeSession) {
+            // SessionHandler is configured with a non-HordeSession
+            // factory. Defensive check; should not happen in production.
+            $this->logger->warning('JWT session row is not a HordeSession', [
+                'jti' => $jti,
+                'class' => get_debug_type($session),
+            ]);
+            return null;
+        }
+
+        return $session;
+    }
+}

--- a/src/Session/SessionConfig.php
+++ b/src/Session/SessionConfig.php
@@ -73,6 +73,14 @@ final class SessionConfig
      *                                        value. Null leaves the PHP
      *                                        default in place. From
      *                                        `$conf['session']['cache_limiter']`.
+     * @param string      $serverName         Hostname the application is
+     *                                        served under. Used by the
+     *                                        cookie-domain guard in
+     *                                        {@see SessionLifecycle::setup()}
+     *                                        to refuse the broken
+     *                                        single-label-host plus
+     *                                        Domain-attribute combination.
+     *                                        From `$conf['server']['name']`.
      */
     public function __construct(
         public readonly string $cookieName,
@@ -82,5 +90,6 @@ final class SessionConfig
         public readonly int $lifetime,
         public readonly int $regenerateInterval,
         public readonly ?string $cacheLimiter,
+        public readonly string $serverName = '',
     ) {}
 }

--- a/src/Session/SessionConfig.php
+++ b/src/Session/SessionConfig.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Session;
+
+use Horde\Core\Session\SessionConfigFactory;
+use Horde\Injector\Attribute\Factory;
+
+/**
+ * Immutable typed view of session-related Horde configuration.
+ *
+ * Centralises the `$conf['session']` and `$conf['cookie']` keys that
+ * lifecycle and middleware code reads. Built by
+ * {@see SessionConfigFactory} from the same `ConfigLoader` state
+ * {@see SessionHandlerFactory} uses, so backend and front-end agree on
+ * one source.
+ *
+ * The class is a pure value object: no behaviour, no mutation. Callers
+ * read the readonly properties directly. A future middleware layer
+ * consumes this in place of repeated `$conf['session'][*]` /
+ * `$conf['cookie'][*]` lookups across the request lifecycle.
+ *
+ * Defaults match what the legacy `Horde_Session` shim and
+ * {@see SessionLifecycle} apply today when the corresponding config
+ * key is absent or empty.
+ */
+#[Factory(factory: SessionConfigFactory::class, method: 'create')]
+final class SessionConfig
+{
+    /** Default forced rotation interval in seconds (6 hours). */
+    public const DEFAULT_REGENERATE_INTERVAL = 21600;
+
+    /** Default cookie path (root). */
+    public const DEFAULT_COOKIE_PATH = '/';
+
+    /**
+     * @param string      $cookieName         Cookie name carrying the session id.
+     *                                        From `$conf['session']['name']`.
+     * @param string|null $cookieDomain       Cookie Domain attribute. Null
+     *                                        scopes the cookie to the exact
+     *                                        request host. From
+     *                                        `$conf['cookie']['domain']`.
+     * @param string      $cookiePath         Cookie Path attribute. From
+     *                                        `$conf['cookie']['path']`,
+     *                                        defaults to `/`.
+     * @param bool        $secure             Whether the Secure attribute
+     *                                        is set on the cookie. From
+     *                                        `$conf['use_ssl'] == 1`.
+     * @param int         $lifetime           Cookie / session lifetime in
+     *                                        seconds. 0 = browser session
+     *                                        (cookie expires when browser
+     *                                        closes). From
+     *                                        `$conf['session']['timeout']`.
+     * @param int         $regenerateInterval Forced session ID rotation
+     *                                        interval in seconds. From
+     *                                        `$conf['session']['regenerate_interval']`,
+     *                                        defaults to
+     *                                        {@see DEFAULT_REGENERATE_INTERVAL}.
+     * @param string|null $cacheLimiter       PHP `session_cache_limiter()`
+     *                                        value. Null leaves the PHP
+     *                                        default in place. From
+     *                                        `$conf['session']['cache_limiter']`.
+     */
+    public function __construct(
+        public readonly string $cookieName,
+        public readonly ?string $cookieDomain,
+        public readonly string $cookiePath,
+        public readonly bool $secure,
+        public readonly int $lifetime,
+        public readonly int $regenerateInterval,
+        public readonly ?string $cacheLimiter,
+    ) {}
+}

--- a/src/Session/SessionConfigFactory.php
+++ b/src/Session/SessionConfigFactory.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2026 The Horde Project
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+namespace Horde\Core\Session;
+
+use Horde\Core\Config\ConfigLoader;
+use Horde\Core\Config\State;
+use Horde\Injector\Injector;
+
+/**
+ * DI factory for {@see SessionConfig}.
+ *
+ * Reads `$conf['session']` and `$conf['cookie']` keys via
+ * {@see ConfigLoader}, applies the same defaults the legacy
+ * `Horde_Session` shim and {@see SessionLifecycle} use today, and
+ * produces an immutable typed view.
+ *
+ * Tests that need a different config shape can construct
+ * {@see SessionConfig} directly without going through this factory.
+ */
+class SessionConfigFactory
+{
+    /**
+     * Build the per-request {@see SessionConfig}.
+     */
+    public function create(Injector $injector): SessionConfig
+    {
+        $loader = $injector->getInstance(ConfigLoader::class);
+        $state = $loader->load('horde');
+
+        return $this->fromState($state);
+    }
+
+    /**
+     * Build a {@see SessionConfig} from a loaded {@see State}.
+     *
+     * Exposed separately so tests can hand-build a `State` and verify
+     * the field-by-field translation without an injector.
+     */
+    public function fromState(State $state): SessionConfig
+    {
+        $cookieName = (string) ($state->get('session.name', '') ?? '');
+        $cookieDomainRaw = (string) ($state->get('cookie.domain', '') ?? '');
+        $cookiePath = (string) ($state->get('cookie.path', '') ?? '');
+        if ($cookiePath === '') {
+            $cookiePath = SessionConfig::DEFAULT_COOKIE_PATH;
+        }
+        $secure = ((int) ($state->get('use_ssl', 0) ?? 0)) === 1;
+        $lifetime = (int) ($state->get('session.timeout', 0) ?? 0);
+
+        $regenerate = $state->get('session.regenerate_interval');
+        $regenerateInterval = is_int($regenerate) && $regenerate > 0
+            ? $regenerate
+            : SessionConfig::DEFAULT_REGENERATE_INTERVAL;
+
+        $limiter = $state->get('session.cache_limiter');
+        $cacheLimiter = (is_string($limiter) && $limiter !== '') ? $limiter : null;
+
+        return new SessionConfig(
+            cookieName: $cookieName,
+            cookieDomain: $cookieDomainRaw === '' ? null : $cookieDomainRaw,
+            cookiePath: $cookiePath,
+            secure: $secure,
+            lifetime: $lifetime,
+            regenerateInterval: $regenerateInterval,
+            cacheLimiter: $cacheLimiter,
+        );
+    }
+}

--- a/src/Session/SessionConfigFactory.php
+++ b/src/Session/SessionConfigFactory.php
@@ -69,6 +69,8 @@ class SessionConfigFactory
         $limiter = $state->get('session.cache_limiter');
         $cacheLimiter = (is_string($limiter) && $limiter !== '') ? $limiter : null;
 
+        $serverName = (string) ($state->get('server.name', '') ?? '');
+
         return new SessionConfig(
             cookieName: $cookieName,
             cookieDomain: $cookieDomainRaw === '' ? null : $cookieDomainRaw,
@@ -77,6 +79,7 @@ class SessionConfigFactory
             lifetime: $lifetime,
             regenerateInterval: $regenerateInterval,
             cacheLimiter: $cacheLimiter,
+            serverName: $serverName,
         );
     }
 }

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Horde\Core\Session;
 
-use Horde\Core\Config\State;
 use Horde\Injector\Attribute\Factory;
 use Horde\Injector\Injector;
 use Horde\SessionHandler\SessionHandler;
@@ -83,9 +82,6 @@ use Horde_Shutdown_Task;
 #[Factory(factory: SessionLifecycleFactory::class, method: 'create')]
 class SessionLifecycle implements Horde_Shutdown_Task
 {
-    /** Default deadline (in seconds) for periodic session ID rotation. */
-    private const DEFAULT_REGENERATE_INTERVAL = 21600; // 6 hours
-
     /** Marker for a string scoped value (matches HordeSession). */
     private const NOT_SERIALIZED = "\0";
 
@@ -121,16 +117,18 @@ class SessionLifecycle implements Horde_Shutdown_Task
      *                                        {@see destroy()} replace it.
      * @param SessionHandler        $handler  Modern save handler. Registered
      *                                        with PHP via setup().
-     * @param State                 $config   Loaded Horde config. setup()
-     *                                        reads cookie.*, server.name,
-     *                                        session.*, use_ssl from it.
+     * @param SessionConfig         $config   Typed view of session-related
+     *                                        Horde config keys. Built by
+     *                                        {@see SessionConfigFactory} from
+     *                                        the same `ConfigLoader` state
+     *                                        {@see SessionHandlerFactory} uses.
      * @param Horde_Secret_Cbc|null $secret   Optional. Re-keyed on clean(),
      *                                        cleared on destroy().
      */
     public function __construct(
         private readonly Injector $injector,
         private readonly SessionHandler $handler,
-        private readonly State $config,
+        private readonly SessionConfig $config,
         private readonly ?Horde_Secret_Cbc $secret = null,
     ) {}
 
@@ -159,8 +157,8 @@ class SessionLifecycle implements Horde_Shutdown_Task
     ): void {
         ini_set('url_rewriter.tags', 0);
 
-        $cookieDomain = (string) ($this->config->get('cookie.domain', '') ?? '');
-        $serverName = (string) ($this->config->get('server.name', '') ?? '');
+        $cookieDomain = $this->config->cookieDomain ?? '';
+        $serverName = $this->config->serverName;
         if ($cookieDomain !== '' && strpos($serverName, '.') === false) {
             throw new Horde_Exception(sprintf(
                 'Session cookies will not work because the server name "%s" '
@@ -179,23 +177,22 @@ class SessionLifecycle implements Horde_Shutdown_Task
             ));
         }
 
-        $timeout = (int) ($this->config->get('session.timeout', 0) ?? 0);
+        $timeout = $this->config->lifetime;
         if ($timeout > 0) {
             ini_set('session.gc_maxlifetime', (string) $timeout);
         }
 
         session_set_cookie_params(
             $timeout,
-            (string) ($this->config->get('cookie.path', '') ?? ''),
+            $this->config->cookiePath,
             $cookieDomain,
-            (int) ($this->config->get('use_ssl', 0) ?? 0) === 1,
+            $this->config->secure,
             true,
         );
         session_cache_limiter(
-            $cacheLimiter
-                ?? (string) ($this->config->get('session.cache_limiter', '') ?? ''),
+            $cacheLimiter ?? ($this->config->cacheLimiter ?? ''),
         );
-        session_name(urlencode((string) ($this->config->get('session.name', '') ?? '')));
+        session_name(urlencode($this->config->cookieName));
         if ($sessionId !== null && $sessionId !== '') {
             session_id($sessionId);
         }
@@ -425,15 +422,13 @@ class SessionLifecycle implements Horde_Shutdown_Task
     /**
      * The deadline interval (seconds) between forced session ID rotations.
      *
-     * Reads `session.regenerate_interval` from config if set, else falls
-     * back to the 6-hour default. Matches the legacy shim's default.
+     * Reads from {@see SessionConfig::$regenerateInterval}, which the
+     * factory builds from `session.regenerate_interval` with a 6-hour
+     * fallback (the legacy shim's default).
      */
     private function regenerateInterval(): int
     {
-        $configured = $this->config->get('session.regenerate_interval');
-        return is_int($configured) && $configured > 0
-            ? $configured
-            : self::DEFAULT_REGENERATE_INTERVAL;
+        return $this->config->regenerateInterval;
     }
 
     /**

--- a/src/Session/SessionLifecycleFactory.php
+++ b/src/Session/SessionLifecycleFactory.php
@@ -16,8 +16,6 @@ declare(strict_types=1);
 
 namespace Horde\Core\Session;
 
-use Horde\Core\Config\ConfigLoader;
-use Horde\Core\Config\State;
 use Horde\Injector\Injector;
 use Horde\SessionHandler\SessionHandler;
 use Horde_Secret_Cbc;
@@ -26,9 +24,10 @@ use Horde_Secret_Cbc;
  * DI factory for {@see SessionLifecycle}.
  *
  * Wires the modern {@see SessionHandler}, the {@see Injector} (used for
- * lazy {@see HordeSession} resolution), the loaded `horde` config
- * {@see State}, and the optional {@see Horde_Secret_Cbc} into a single
- * per-request lifecycle orchestrator.
+ * lazy {@see HordeSession} resolution), the typed
+ * {@see SessionConfig} built by {@see SessionConfigFactory}, and the
+ * optional {@see Horde_Secret_Cbc} into a single per-request lifecycle
+ * orchestrator.
  *
  * The legacy binding name `Horde_Secret_Cbc` is used deliberately. Asking
  * for the `Horde_Core_Secret_Cbc` class directly bypasses the binding and
@@ -40,15 +39,14 @@ class SessionLifecycleFactory
     /**
      * Build the request-scoped {@see SessionLifecycle}.
      *
-     * Resolves the `horde` config {@see State} through {@see ConfigLoader}
-     * rather than reading `$GLOBALS['conf']` directly. Tests that need a
-     * different config shape can construct {@see SessionLifecycle}
-     * directly with their own {@see State}.
+     * Resolves {@see SessionConfig} through the injector. Tests that
+     * need a different config shape can construct {@see SessionLifecycle}
+     * directly with their own {@see SessionConfig}.
      */
     public function create(Injector $injector): SessionLifecycle
     {
         $handler = $injector->getInstance(SessionHandler::class);
-        $config = $this->loadConfig($injector);
+        $config = $injector->getInstance(SessionConfig::class);
 
         $secret = null;
         try {
@@ -60,12 +58,5 @@ class SessionLifecycleFactory
         }
 
         return new SessionLifecycle($injector, $handler, $config, $secret);
-    }
-
-    private function loadConfig(Injector $injector): State
-    {
-        $loader = $injector->getInstance(ConfigLoader::class);
-
-        return $loader->load('horde');
     }
 }

--- a/test/Unit/Auth/AuthCredentialStoreTest.php
+++ b/test/Unit/Auth/AuthCredentialStoreTest.php
@@ -12,6 +12,10 @@ declare(strict_types=1);
 namespace Horde\Core\Test\Unit\Auth;
 
 use Horde\Core\Auth\AuthCredentialStore;
+use Horde\Core\Auth\CredentialResult;
+use Horde\Core\Auth\CredentialStateMetadata;
+use Horde\Core\Auth\HasCredentialsState;
+use Horde\Core\Auth\InvalidationReason;
 use Horde\Core\Session\HordeSession;
 use Horde\SessionHandler\SessionId;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -265,5 +269,195 @@ class AuthCredentialStoreTest extends TestCase
         $session->setScoped('horde', 'auth_app/horde', true);
 
         self::assertFalse($store->get('horde'));
+    }
+
+    // ---------------------------------------------------------------
+    // Per-app credential state (HasCredentialsState + InvalidationReason)
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function getStateDefaultsToNeverHadWhenNoSlot(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        // No state slot has been written; the implicit default is NeverHad.
+        self::assertSame(HasCredentialsState::NeverHad, $store->getState('imp'));
+    }
+
+    #[Test]
+    public function setMarksStateAsPresent(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('horde', ['password' => 'secret']);
+
+        self::assertSame(HasCredentialsState::Present, $store->getState('horde'));
+    }
+
+    #[Test]
+    public function setCredentialsAliasMarksStateAsPresent(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->setCredentials('horde', ['password' => 'secret']);
+
+        self::assertSame(HasCredentialsState::Present, $store->getState('horde'));
+        self::assertSame(['password' => 'secret'], $store->get('horde'));
+    }
+
+    #[Test]
+    public function markInvalidatedFlipsStateAndDropsCredentials(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'secret']);
+        $store->markInvalidated('imp', InvalidationReason::BackendRejected);
+
+        self::assertSame(HasCredentialsState::Invalidated, $store->getState('imp'));
+        // Credentials are no longer present in the slot.
+        self::assertFalse($session->hasScoped('horde', 'auth_app/imp'));
+    }
+
+    #[Test]
+    public function markInvalidatedRecordsReasonAndDetail(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'secret']);
+        $store->markInvalidated('imp', InvalidationReason::PasswordChanged, 'changed via passwd/');
+
+        $metadata = $store->getStateMetadata('imp');
+        self::assertNotNull($metadata);
+        self::assertSame(HasCredentialsState::Invalidated, $metadata->state);
+        self::assertSame(InvalidationReason::PasswordChanged, $metadata->reason);
+        self::assertSame('changed via passwd/', $metadata->detail);
+        self::assertNotNull($metadata->since);
+    }
+
+    #[Test]
+    public function markInvalidatedIsIdempotent(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'secret']);
+        $store->markInvalidated('imp', InvalidationReason::BackendRejected);
+        $store->markInvalidated('imp', InvalidationReason::AdminForced, 'admin clicked clear');
+
+        $metadata = $store->getStateMetadata('imp');
+        self::assertNotNull($metadata);
+        self::assertSame(InvalidationReason::AdminForced, $metadata->reason);
+        self::assertSame('admin clicked clear', $metadata->detail);
+    }
+
+    #[Test]
+    public function markNeverHadFlipsStateWithoutReason(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->markNeverHad('imp');
+
+        self::assertSame(HasCredentialsState::NeverHad, $store->getState('imp'));
+        $metadata = $store->getStateMetadata('imp');
+        self::assertNotNull($metadata);
+        self::assertNull($metadata->reason);
+        self::assertNull($metadata->detail);
+    }
+
+    #[Test]
+    public function clearRemovesStateSlots(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'secret']);
+        $store->markInvalidated('imp', InvalidationReason::BackendRejected, 'rejected');
+        $store->clear('imp');
+
+        // After clear, no metadata is recorded; getState falls back to
+        // the implicit NeverHad default.
+        self::assertSame(HasCredentialsState::NeverHad, $store->getState('imp'));
+        self::assertNull($store->getStateMetadata('imp'));
+    }
+
+    #[Test]
+    public function getStateMetadataReturnsNullWhenNoSlot(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        // No state has been recorded for this app; metadata is null even
+        // though getState() returns NeverHad as the safe default.
+        self::assertNull($store->getStateMetadata('imp'));
+        self::assertSame(HasCredentialsState::NeverHad, $store->getState('imp'));
+    }
+
+    #[Test]
+    public function getOrExplainReturnsCredentialsWhenPresent(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('horde', ['password' => 'secret']);
+        $result = $store->getOrExplain('horde');
+
+        self::assertInstanceOf(CredentialResult::class, $result);
+        self::assertSame(HasCredentialsState::Present, $result->state);
+        self::assertSame(['password' => 'secret'], $result->credentials);
+        self::assertNull($result->reason);
+    }
+
+    #[Test]
+    public function getOrExplainReturnsInvalidatedReasonWhenInvalidated(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'secret']);
+        $store->markInvalidated('imp', InvalidationReason::BackendRejected, 'imap rejected');
+
+        $result = $store->getOrExplain('imp');
+
+        self::assertSame(HasCredentialsState::Invalidated, $result->state);
+        self::assertNull($result->credentials);
+        self::assertSame(InvalidationReason::BackendRejected, $result->reason);
+        self::assertSame('imap rejected', $result->detail);
+    }
+
+    #[Test]
+    public function getOrExplainReturnsNeverHadByDefault(): void
+    {
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $result = $store->getOrExplain('kronolith');
+
+        self::assertSame(HasCredentialsState::NeverHad, $result->state);
+        self::assertNull($result->credentials);
+        self::assertNull($result->reason);
+    }
+
+    #[Test]
+    public function setRecoversFromInvalidatedState(): void
+    {
+        // After a backend rejects credentials and the user re-enters them,
+        // a fresh set() should clear the Invalidated state and reason.
+        $session = $this->sessionWithBaseApp('horde');
+        $store = new AuthCredentialStore($session);
+
+        $store->set('imp', ['password' => 'old']);
+        $store->markInvalidated('imp', InvalidationReason::BackendRejected, 'wrong password');
+        $store->set('imp', ['password' => 'new']);
+
+        self::assertSame(HasCredentialsState::Present, $store->getState('imp'));
+        $metadata = $store->getStateMetadata('imp');
+        self::assertNotNull($metadata);
+        self::assertNull($metadata->reason, 'reason must be cleared on re-set to Present');
     }
 }

--- a/test/Unit/Middleware/HordeSessionMiddlewareTest.php
+++ b/test/Unit/Middleware/HordeSessionMiddlewareTest.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+
+namespace Horde\Core\Test\Unit\Middleware;
+
+use Horde\Core\Middleware\HordeSessionMiddleware;
+use Horde\Core\Middleware\JwtSessionLoader;
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\HordeSessionFactory;
+use Horde\Core\Session\SessionConfig;
+use Horde\SessionHandler\Exception\SessionException;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionStorageBackend;
+use Horde\SessionHandler\Storage\BuiltinBackend;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(HordeSessionMiddleware::class)]
+class HordeSessionMiddlewareTest extends TestCase
+{
+    use SetUpTrait {
+        setUp as protected traitSetUp;
+    }
+
+    protected function setUp(): void
+    {
+        $this->traitSetUp();
+    }
+
+    private function config(string $cookieName = 'Horde'): SessionConfig
+    {
+        return new SessionConfig(
+            cookieName: $cookieName,
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+        );
+    }
+
+    private function realHandler(): SessionHandler
+    {
+        return new SessionHandler(
+            new BuiltinBackend(),
+            sessionFactory: new HordeSessionFactory(),
+        );
+    }
+
+    private function middleware(SessionHandler $handler, ?SessionConfig $config = null): HordeSessionMiddleware
+    {
+        return new HordeSessionMiddleware(
+            $handler,
+            $config ?? $this->config(),
+            new NullLogger(),
+        );
+    }
+
+    private function requestWithCookies(array $cookies)
+    {
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        return $request->withCookieParams($cookies);
+    }
+
+    /** Pull a Set-Cookie header value matching the cookie name. */
+    private function setCookieFor(string $name, $response): ?string
+    {
+        foreach ($response->getHeader('Set-Cookie') as $line) {
+            if (str_starts_with($line, $name . '=')) {
+                return $line;
+            }
+        }
+        return null;
+    }
+
+    // ---------------------------------------------------------------
+    // No cookie -> mint, set attribute, emit Set-Cookie
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testNoCookieMintsFreshSession(): void
+    {
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie, 'fresh session must emit Set-Cookie');
+        self::assertStringContainsString((string) $session->getId(), $setCookie);
+    }
+
+    // ---------------------------------------------------------------
+    // Valid cookie + valid row -> load, attribute, no Set-Cookie when steady
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testValidCookieLoadsExistingSession(): void
+    {
+        $handler = $this->realHandler();
+        // Pre-populate a session.
+        $existing = $handler->create();
+        $existing->setScoped('horde', 'auth/userId', 'alice');
+        $handler->save($existing);
+        $sid = (string) $existing->getId();
+
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => $sid]),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertSame('alice', $session->getScoped('horde', 'auth/userId'));
+        self::assertNull(
+            $this->setCookieFor('Horde', $response),
+            'steady-state load must not re-emit Set-Cookie',
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Valid cookie but no session row -> mint fresh, emit Set-Cookie
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testInvalidCookieMintsFreshSession(): void
+    {
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler)->process(
+            // session id format is permissive (a-zA-Z0-9,-) but the row
+            // doesn't exist.
+            $this->requestWithCookies(['Horde' => 'nonexistent-id-1234']),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertNotSame('nonexistent-id-1234', (string) $session->getId());
+
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie, 'cookie pointing at missing row must trigger fresh Set-Cookie');
+        self::assertStringContainsString((string) $session->getId(), $setCookie);
+    }
+
+    // ---------------------------------------------------------------
+    // Malformed cookie value -> mint fresh
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testMalformedCookieValueMintsFreshSession(): void
+    {
+        $handler = $this->realHandler();
+        // SessionId pattern rejects values with whitespace, etc.
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => 'has space']),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertNotNull($this->setCookieFor('Horde', $response));
+    }
+
+    // ---------------------------------------------------------------
+    // Dirty session -> persisted
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testDirtySessionIsPersistedOnTheWayOut(): void
+    {
+        $handler = $this->realHandler();
+        // Wire the inner handler to mutate the session.
+        $this->defaultPayloadHandler = $this->createStub(\Psr\Http\Server\RequestHandlerInterface::class);
+        $this->defaultPayloadHandler->method('handle')->willReturnCallback(function ($request) {
+            $this->recentlyHandledRequest = $request;
+            $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+            self::assertInstanceOf(HordeSession::class, $session);
+            $session->setScoped('horde', 'auth/userId', 'alice');
+            return $this->defaultPayloadResponse;
+        });
+
+        $this->middleware($handler)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        // Reload via a fresh handler to confirm persistence took.
+        $reloaded = $handler->load(
+            $this->recentlyHandledRequest
+                ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION)
+                ->getId(),
+        );
+        self::assertInstanceOf(HordeSession::class, $reloaded);
+        self::assertSame('alice', $reloaded->getScoped('horde', 'auth/userId'));
+    }
+
+    // ---------------------------------------------------------------
+    // markDestroyed -> destroy row, clearing Set-Cookie
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testMarkDestroyedDestroysRowAndClearsCookie(): void
+    {
+        $handler = $this->realHandler();
+        $existing = $handler->create();
+        $handler->save($existing);
+        $sid = (string) $existing->getId();
+
+        $this->defaultPayloadHandler = $this->createStub(\Psr\Http\Server\RequestHandlerInterface::class);
+        $this->defaultPayloadHandler->method('handle')->willReturnCallback(function ($request) {
+            $this->recentlyHandledRequest = $request;
+            $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+            $session->markDestroyed();
+            return $this->defaultPayloadResponse;
+        });
+
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => $sid]),
+            $this->defaultPayloadHandler,
+        );
+
+        // The row is gone.
+        self::assertNull($handler->load($existing->getId()));
+
+        // The Set-Cookie clears the cookie.
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringContainsString('Max-Age=0', $setCookie);
+    }
+
+    // ---------------------------------------------------------------
+    // scheduleRegeneration -> rotate, new id in Set-Cookie, payload preserved
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testScheduleRegenerationRotatesIdAndPersists(): void
+    {
+        $handler = $this->realHandler();
+        $existing = $handler->create();
+        $existing->setScoped('horde', 'auth/userId', 'alice');
+        $handler->save($existing);
+        $oldSid = (string) $existing->getId();
+
+        $this->defaultPayloadHandler = $this->createStub(\Psr\Http\Server\RequestHandlerInterface::class);
+        $this->defaultPayloadHandler->method('handle')->willReturnCallback(function ($request) {
+            $this->recentlyHandledRequest = $request;
+            $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+            $session->scheduleRegeneration();
+            return $this->defaultPayloadResponse;
+        });
+
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => $oldSid]),
+            $this->defaultPayloadHandler,
+        );
+
+        // Old row is gone.
+        self::assertNull($handler->load($existing->getId()));
+
+        // Set-Cookie carries a different id than the old one.
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringNotContainsString($oldSid, $setCookie);
+
+        // Payload preserved under whatever new id was minted: extract
+        // the new id from the Set-Cookie line and reload.
+        preg_match('/^Horde=([^;]+);/', $setCookie, $m);
+        self::assertNotEmpty($m[1] ?? '', 'Set-Cookie must contain the new id');
+        $newSid = $m[1];
+        $reloaded = $handler->load(new \Horde\SessionHandler\SessionId($newSid));
+        self::assertInstanceOf(HordeSession::class, $reloaded);
+        self::assertSame('alice', $reloaded->getScoped('horde', 'auth/userId'));
+    }
+
+    // ---------------------------------------------------------------
+    // JwtSessionLoader already populated the attribute
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testHonoursPreExistingSessionAttribute(): void
+    {
+        $handler = $this->realHandler();
+        $preLoaded = $handler->create();
+        $preLoaded->setScoped('horde', 'auth/userId', 'jwtuser');
+
+        // Simulate JwtSessionLoader having populated the attribute.
+        $request = $this->requestWithCookies([])
+            ->withAttribute(JwtSessionLoader::ATTRIBUTE_SESSION, $preLoaded);
+
+        $this->middleware($handler)->process($request, $this->defaultPayloadHandler);
+
+        $observed = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+
+        self::assertSame($preLoaded, $observed);
+    }
+
+    // ---------------------------------------------------------------
+    // Backend exception on load -> mint fresh, no exception escapes
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testLoadExceptionFallsBackToFreshSession(): void
+    {
+        // Stub backend that throws on load() but tolerates create()/save().
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())
+            ->method('load')
+            ->willThrowException(new SessionException('backend down'));
+        // create() doesn't go through the backend; save() does.
+        // We don't constrain save here because the fresh session has no
+        // dirty data and isDirty() will be false.
+
+        $handler = new SessionHandler(
+            $backend,
+            sessionFactory: new HordeSessionFactory(),
+        );
+
+        $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => 'will-fail']),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        self::assertInstanceOf(HordeSession::class, $session);
+    }
+
+    // ---------------------------------------------------------------
+    // Returned response is the inner handler's response
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testReturnsInnerHandlerResponse(): void
+    {
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        // The inner handler returned $this->defaultPayloadResponse with
+        // status 200. The middleware may have added Set-Cookie headers
+        // but the body/status is preserved.
+        self::assertSame(200, $response->getStatusCode());
+    }
+}

--- a/test/Unit/Middleware/JwtSessionLoaderTest.php
+++ b/test/Unit/Middleware/JwtSessionLoaderTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+
+namespace Horde\Core\Test\Unit\Middleware;
+
+use Horde\Core\Auth\Jwt\JwtService;
+use Horde\Core\Auth\Jwt\VerifiedJwt;
+use Horde\Core\Middleware\JwtSessionLoader;
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\HordeSessionFactory;
+use Horde\SessionHandler\Exception\SessionException;
+use Horde\SessionHandler\SerializedSessionPayload;
+use Horde\SessionHandler\SessionHandler;
+use Horde\SessionHandler\SessionId;
+use Horde\SessionHandler\SessionStorageBackend;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(JwtSessionLoader::class)]
+class JwtSessionLoaderTest extends TestCase
+{
+    use SetUpTrait {
+        setUp as protected traitSetUp;
+    }
+
+    private LoggerInterface $logger;
+
+    protected function setUp(): void
+    {
+        $this->traitSetUp();
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * Build the middleware with the given collaborators. Each test
+     * supplies fresh mocks/stubs tailored to what that test asserts.
+     */
+    private function middleware(
+        JwtService $jwt,
+        SessionStorageBackend $backend,
+    ): JwtSessionLoader {
+        $handler = new SessionHandler(
+            $backend,
+            sessionFactory: new HordeSessionFactory(),
+        );
+        return new JwtSessionLoader($jwt, $handler, $this->logger);
+    }
+
+    /** Build a request with the given cookies. */
+    private function requestWithCookies(array $cookies)
+    {
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        return $request->withCookieParams($cookies);
+    }
+
+    /** Stub VerifiedJwt with the given jti claim. */
+    private function verifiedJwtWithJti(string $jti): VerifiedJwt
+    {
+        $verified = $this->createStub(VerifiedJwt::class);
+        $verified->method('getClaim')->willReturnCallback(
+            static fn(string $name, mixed $default = null): mixed
+                => $name === 'jti' ? $jti : $default,
+        );
+        return $verified;
+    }
+
+    // ---------------------------------------------------------------
+    // No cookie -> pass through, no attribute set
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testNoCookieLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $response = $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertSame($this->defaultPayloadResponse, $response);
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testEmptyCookieLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createStub(SessionStorageBackend::class);
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => '']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Verification failure -> pass through, no attribute set
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testInvalidJwtLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())
+            ->method('verifyRefreshToken')
+            ->with('bad-token')
+            ->willThrowException(new InvalidArgumentException('expired'));
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'bad-token']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Missing jti claim -> pass through, no attribute set
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testJwtWithoutJtiClaimLeavesAttributeUnset(): void
+    {
+        $verified = $this->createStub(VerifiedJwt::class);
+        $verified->method('getClaim')->willReturn(null);
+
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())->method('verifyRefreshToken')->willReturn($verified);
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'token']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Session row missing -> pass through, no attribute set
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testNullSessionRowLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createStub(JwtService::class);
+        $jwt->method('verifyRefreshToken')
+            ->willReturn($this->verifiedJwtWithJti('jti-xyz'));
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())->method('load')->willReturn(null);
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'token']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Session backend error -> pass through, no attribute set
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testSessionLoadExceptionLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createStub(JwtService::class);
+        $jwt->method('verifyRefreshToken')
+            ->willReturn($this->verifiedJwtWithJti('jti-xyz'));
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())->method('load')
+            ->willThrowException(new SessionException('backend down'));
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'token']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Happy path -> session attribute is the loaded HordeSession
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testValidJwtAndSessionRowSetsAttribute(): void
+    {
+        $jti = 'jti-abc-123';
+        $serialised = new SerializedSessionPayload(
+            serialize(['horde' => ['auth/userId' => 'alice']])
+        );
+
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())
+            ->method('verifyRefreshToken')
+            ->with('token')
+            ->willReturn($this->verifiedJwtWithJti($jti));
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())->method('load')->willReturnCallback(
+            static fn(SessionId $id): ?SerializedSessionPayload
+                => (string) $id === $jti ? $serialised : null,
+        );
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'token']),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertSame('alice', $session->getAuthenticatedUser());
+    }
+
+    #[Test]
+    public function testNeverShortCircuitsTheRequest(): void
+    {
+        // Whatever happens, the inner handler must run. The middleware
+        // is a session-loader, not an auth gate.
+        $jwt = $this->createStub(JwtService::class);
+        $jwt->method('verifyRefreshToken')
+            ->willThrowException(new InvalidArgumentException('expired'));
+
+        $backend = $this->createStub(SessionStorageBackend::class);
+
+        $response = $this->middleware($jwt, $backend)->process(
+            $this->requestWithCookies([JwtSessionLoader::COOKIE_NAME => 'bad']),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertSame($this->defaultPayloadResponse, $response);
+        self::assertNotNull($this->recentlyHandledRequest);
+    }
+}

--- a/test/Unit/Session/SessionConfigFactoryTest.php
+++ b/test/Unit/Session/SessionConfigFactoryTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Session;
+
+use Horde\Core\Config\State;
+use Horde\Core\Session\SessionConfig;
+use Horde\Core\Session\SessionConfigFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SessionConfigFactory::class)]
+#[CoversClass(SessionConfig::class)]
+class SessionConfigFactoryTest extends TestCase
+{
+    private SessionConfigFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new SessionConfigFactory();
+    }
+
+    // ---------------------------------------------------------------
+    // Defaults applied when keys are absent
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testEmptyStateProducesDefaultedConfig(): void
+    {
+        $config = $this->factory->fromState(new State([]));
+
+        self::assertSame('', $config->cookieName);
+        self::assertNull($config->cookieDomain);
+        self::assertSame(SessionConfig::DEFAULT_COOKIE_PATH, $config->cookiePath);
+        self::assertFalse($config->secure);
+        self::assertSame(0, $config->lifetime);
+        self::assertSame(SessionConfig::DEFAULT_REGENERATE_INTERVAL, $config->regenerateInterval);
+        self::assertNull($config->cacheLimiter);
+    }
+
+    #[Test]
+    public function testEmptyCookieDomainBecomesNull(): void
+    {
+        // An empty string in $conf['cookie']['domain'] means "host-only";
+        // SessionConfig represents that as null so the cookie helpers can
+        // omit the Domain attribute rather than emit Domain= with an
+        // empty value.
+        $config = $this->factory->fromState(new State([
+            'cookie' => ['domain' => ''],
+        ]));
+        self::assertNull($config->cookieDomain);
+    }
+
+    #[Test]
+    public function testEmptyCookiePathFallsBackToRoot(): void
+    {
+        $config = $this->factory->fromState(new State([
+            'cookie' => ['path' => ''],
+        ]));
+        self::assertSame('/', $config->cookiePath);
+    }
+
+    #[Test]
+    public function testZeroRegenerateIntervalFallsBackToDefault(): void
+    {
+        // Zero or negative regenerate intervals are not meaningful;
+        // SessionLifecycle::regenerateInterval() applies the same fallback.
+        $config = $this->factory->fromState(new State([
+            'session' => ['regenerate_interval' => 0],
+        ]));
+        self::assertSame(SessionConfig::DEFAULT_REGENERATE_INTERVAL, $config->regenerateInterval);
+    }
+
+    #[Test]
+    public function testNonIntegerRegenerateIntervalFallsBackToDefault(): void
+    {
+        $config = $this->factory->fromState(new State([
+            'session' => ['regenerate_interval' => 'lots'],
+        ]));
+        self::assertSame(SessionConfig::DEFAULT_REGENERATE_INTERVAL, $config->regenerateInterval);
+    }
+
+    #[Test]
+    public function testEmptyCacheLimiterBecomesNull(): void
+    {
+        $config = $this->factory->fromState(new State([
+            'session' => ['cache_limiter' => ''],
+        ]));
+        self::assertNull($config->cacheLimiter);
+    }
+
+    // ---------------------------------------------------------------
+    // Field-by-field translation
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testAllFieldsRoundTrip(): void
+    {
+        $config = $this->factory->fromState(new State([
+            'session' => [
+                'name' => 'Horde',
+                'timeout' => 3600,
+                'cache_limiter' => 'nocache',
+                'regenerate_interval' => 7200,
+            ],
+            'cookie' => [
+                'domain' => 'example.com',
+                'path' => '/horde',
+            ],
+            'use_ssl' => 1,
+        ]));
+
+        self::assertSame('Horde', $config->cookieName);
+        self::assertSame('example.com', $config->cookieDomain);
+        self::assertSame('/horde', $config->cookiePath);
+        self::assertTrue($config->secure);
+        self::assertSame(3600, $config->lifetime);
+        self::assertSame(7200, $config->regenerateInterval);
+        self::assertSame('nocache', $config->cacheLimiter);
+    }
+
+    #[Test]
+    public function testUseSslZeroIsNotSecure(): void
+    {
+        $config = $this->factory->fromState(new State([
+            'use_ssl' => 0,
+        ]));
+        self::assertFalse($config->secure);
+    }
+
+    #[Test]
+    public function testUseSslTwoIsNotSecure(): void
+    {
+        // Legacy `use_ssl` permits values 0/1/2 where 2 means "auto-detect"
+        // not "always force SSL". Only 1 is a forced HTTPS configuration.
+        $config = $this->factory->fromState(new State([
+            'use_ssl' => 2,
+        ]));
+        self::assertFalse($config->secure);
+    }
+
+    // ---------------------------------------------------------------
+    // Immutability
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testConfigIsImmutableValueObject(): void
+    {
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+        );
+
+        // readonly properties enforce this at the engine level; the
+        // assertion is documentary.
+        self::assertSame('Horde', $config->cookieName);
+    }
+}

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -13,6 +13,7 @@ namespace Horde\Core\Test\Unit\Session;
 
 use Horde\Core\Config\State;
 use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionConfigFactory;
 use Horde\Core\Session\SessionLifecycle;
 use Horde\Injector\Injector;
 use Horde\Injector\TopLevel;
@@ -60,8 +61,9 @@ class SessionLifecycleTest extends TestCase
         $injector->setInstance(HordeSession::class, $session);
 
         $handler = new SessionHandler(new BuiltinBackend());
+        $config = (new SessionConfigFactory())->fromState(new State($conf));
 
-        return new SessionLifecycle($injector, $handler, new State($conf));
+        return new SessionLifecycle($injector, $handler, $config);
     }
 
     // ---------------------------------------------------------------
@@ -235,7 +237,8 @@ class SessionLifecycleTest extends TestCase
         $session ??= new HordeSession(new SessionId('process-flags-test'), []);
         $injector->setInstance(HordeSession::class, $session);
         $handler = new SessionHandler(new BuiltinBackend());
-        return new RecordingSessionLifecycle($injector, $handler, new State([]));
+        $config = (new SessionConfigFactory())->fromState(new State([]));
+        return new RecordingSessionLifecycle($injector, $handler, $config);
     }
 
     #[Test]


### PR DESCRIPTION
Necessary bits and pieces to handle sessions from the Horde Rampage middleware stack without relying on the legacy Horde_Registry god object, avoidable globals or implied session writing at request shutdown.

- **feat(session): add SessionConfig value object built by SessionConfigFactory**
- **feat(auth): add HasCredentialsState/InvalidationReason on AuthCredentialStore**
- **feat(middleware): add JwtSessionLoader for modern PSR-15 routes**
- **fixup! feat(session): add SessionConfig value object built by SessionConfigFactory**
- **refactor(session): SessionLifecycle consumes SessionConfig instead of State**
- **feat(middleware): add HordeSessionMiddleware for modern PSR-15 routes**
