### PR TITLE
fix(activesync): parse MIME draft bodies and replace drafts on Change

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -2258,9 +2258,15 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                             );
                             $draft->setDraftMessage($message);
 
-                            // Do we need an existing Draft message?
-                            if ($id && !empty($message->airsyncbaseattachments)) {
-                                $draft->getExistingDraftMessage($draft_folder, $id);
+                            if ($id) {
+                                try {
+                                    $draft->getExistingDraftMessage(
+                                        $draft_folder,
+                                        $id
+                                    );
+                                } catch (Horde_ActiveSync_Exception $e) {
+                                    // Stale UID from client; treat as new.
+                                }
                             }
 
                             // Append the message and return results.

--- a/lib/Horde/Core/ActiveSync/Mail/Draft.php
+++ b/lib/Horde/Core/ActiveSync/Mail/Draft.php
@@ -122,7 +122,7 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
         foreach ($base as $part) {
             if ($part->isAttachment()
                 && !empty($atc_map[$part->getName()])) {
-                $atc_hash['add'][$atc_map[$part->getName()]] = $folderid . ':' . $stat['id'] . ':' . $part->getMimeId();
+                $atc_hash['add'][$atc_map[$part->getName()]] = $folderid . ':' . $new_uid . ':' . $part->getMimeId();
             }
         }
 
@@ -165,6 +165,23 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
         if ($draft->importance) {
             $this->_headers->addHeader('importance', $draft->importance);
         }
+
+        $bodyType = !empty($draft->airsyncbasebody)
+            ? $draft->airsyncbasebody->type
+            : null;
+        if ($bodyType == Horde_ActiveSync::BODYPREF_TYPE_MIME) {
+            $this->_importMimeDraftBody($draft);
+        } else {
+            // Get the text part and create a mime object for it.
+            $this->_textPart = new Horde_Mime_Part();
+            $this->_textPart->setContents($draft->airsyncbasebody->data);
+            $this->_textPart->setType(
+                $bodyType == Horde_ActiveSync::BODYPREF_TYPE_HTML
+                    ? 'text/html'
+                    : 'text/plain'
+            );
+        }
+
         if ($from = $this->_getIdentityFromAddress()) {
             $this->_headers->removeHeader('From');
             $this->_headers->addHeader('From', $from);
@@ -176,17 +193,41 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
         $this->_headers->addHeaderOb(Horde_Mime_Headers_ContentId::create());
         $this->_headers->addHeader('X-IMP-Draft', 'Yes');
 
-        // Get the text part and create a mime object for it.
-        $this->_textPart = new Horde_Mime_Part();
-        $this->_textPart->setContents($draft->airsyncbasebody->data);
-        $this->_textPart->setType(
-            $draft->airsyncbasebody->type == Horde_ActiveSync::BODYPREF_TYPE_HTML
-                ? 'text/html'
-                : 'text/plain'
-        );
-
         // Attachments.
         $this->_handleAttachments();
+    }
+
+    /**
+     * Parse a Type-4 (MIME) draft body from the client.
+     *
+     * iOS sends a full RFC822 message in the body; POOMMAIL header fields are
+     * often omitted. Extract envelope headers and preserve the MIME structure
+     * for round-trip sync (see EasMessageBuilder/Mime export path).
+     *
+     * @param Horde_ActiveSync_Message_Mail $draft
+     */
+    protected function _importMimeDraftBody(Horde_ActiveSync_Message_Mail $draft)
+    {
+        $data = $draft->airsyncbasebody->data;
+        if (is_resource($data)) {
+            $data = stream_get_contents($data);
+        }
+        if ($data === '' || $data === false) {
+            $this->_textPart = new Horde_Mime_Part();
+            return;
+        }
+
+        $rfc822 = new Horde_ActiveSync_Rfc822($data, false);
+        $mimeHeaders = $rfc822->getHeaders();
+
+        foreach (['To', 'Cc', 'Bcc', 'Subject'] as $name) {
+            if (!$this->_headers->getValue($name)
+                && ($val = $mimeHeaders->getValue($name))) {
+                $this->_headers->addHeader($name, $val);
+            }
+        }
+
+        $this->_textPart = $rfc822->getMimeObject();
     }
 
     protected function _handleAttachments()


### PR DESCRIPTION
# Fix ActiveSync draft sync: MIME import and Change replacement

## Summary

- Parse AirSyncBase **Type 4 (MIME)** draft bodies from clients instead of storing the raw RFC822 string as `text/plain`.
- Always replace an existing draft on **Sync Change** when a server UID is supplied, not only when attachments are present.
- Fix attachment hash generation in `Draft::append()` to use the new IMAP UID.

## Problem

### MIME drafts (iOS, EAS 16.0)

iOS Mail syncs draft updates with `AirSyncBase:Type` **4 (MIME)**. The body contains a full RFC822 message (headers, `multipart/alternative`, etc.). POOMMAIL fields such as `Subject` and `To` are often omitted in this mode.

`Horde_Core_ActiveSync_Mail_Draft::setDraftMessage()` stored the entire MIME blob as a single `text/plain` part and only read envelope fields from POOMMAIL. In IMP/webmail, drafts showed empty Subject/To and raw MIME in the body.

The export path (`Horde_ActiveSync_Imap_EasMessageBuilder_Mime`) already builds Type-4 MIME correctly; import was asymmetric.

### Sync Change without attachments (Android / Outlook)

When a client updates an existing draft via **Sync Change** with `ServerEntryId`, IMAP cannot update in place — Horde appends a new message and deletes the old UID.

The driver only called `getExistingDraftMessage()` when **attachments** were present:

```php
if ($id && !empty($message->airsyncbaseattachments)) {
    $draft->getExistingDraftMessage($draft_folder, $id);
}
```

Draft body updates without attachment changes left the previous IMAP message in place, causing duplicates or stale content.

### Out of scope

iOS often uses **Sync Add** with a new `ClientEntryId` per autosave and cleans up via client-side **Remove**. That behaviour is client-driven and inconsistent; server-side Message-ID heuristics were considered and rejected as unreliable.

## Solution

**MIME import (`Draft.php`)**

- If body type is `BODYPREF_TYPE_MIME`, parse with `Horde_ActiveSync_Rfc822`.
- Fill missing `To`, `Cc`, `Bcc`, `Subject` from MIME headers (POOMMAIL wins when set).
- Set `$_textPart` from `getMimeObject()` to preserve multipart structure for round-trip sync.

**Change replacement (`Driver.php`)**

- On draft sync with `$id` set, always call `getExistingDraftMessage()` before append; ignore stale UIDs gracefully.

**Minor fix (`Draft.php`)**

- Use `$new_uid` in the post-append attachment hash loop (was referencing undefined `$stat['id']`).

## Files changed

- `vendor/horde/core/lib/Horde/Core/ActiveSync/Mail/Draft.php`
- `vendor/horde/core/lib/Horde/Core/ActiveSync/Driver.php`

## Test plan

- [ ] **iOS MIME draft:** Compose draft on iPhone (EAS 16.0), set Subject and To, wait for autosave. Verify IMP/webmail shows correct Subject, recipient, and body text (not raw MIME).
- [ ] **iOS rename:** Rename draft on iPhone; verify single draft in webmail when iOS sends matching Remove (known client behaviour, not guaranteed by this PR).
- [ ] **Android/Outlook Change:** If available, update an existing draft via Sync Change without attachment changes; verify old UID is replaced, not duplicated.
- [ ] **Plain/HTML drafts:** Confirm Type 1/2 draft sync still works (non-iOS or older clients).
- [ ] **Attachments:** Add/remove attachment on draft Change; verify attachment references and replacement still work.
