### PR TITLE
fix(registry): clearAuth removes literal 'auth' instead of auth/ keys

### DIFF
--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -2222,11 +2222,44 @@ class Horde_Registry implements Horde_Shutdown_Task
         $logout = new Horde_Registry_Logout();
         $logout->run();
 
-        // @suspicious shouldn't this be 'auth/'
-        $session->removeScoped('horde', 'auth');
+        /* Wipe every auth-related slot from the horde scope.
+         *
+         * Setup: Registry::setAuth() writes flat keys (auth/userId,
+         * auth/credentials, auth/timestamp, auth/browser, auth/remoteAddr,
+         * auth/authId). AuthCredentialStore::set() writes per-app slots
+         * under several prefixes (auth_app/, auth_app_init/,
+         * auth_app_state/, auth_app_state_at/, auth_app_state_reason/,
+         * auth_app_state_detail/).
+         *
+         * Pre-fix this method called removeScoped('horde', 'auth') which
+         * removes a key literally named 'auth' that does not exist;
+         * stored keys all have a slash. Result: every auth/ slot
+         * survived clearAuth and any session reader that trusted the
+         * row (modern PSR-15 routes via SessionHandler::load()) would
+         * report the user as still authenticated after logout. The
+         * legacy stack masked this because it re-runs appInit() with
+         * its own auth-state checks on every request.
+         *
+         * The sweep below removes every key whose name starts with one
+         * of the auth prefixes. The list of prefixes is the union of
+         * what Registry::setAuth() and AuthCredentialStore use; keep
+         * synchronised when new slot families are added.
+         */
+        $authPrefixes = [
+            'auth/',
+            'auth_app/',
+            'auth_app_init/',
+            'auth_app_state/',
+            'auth_app_state_at/',
+            'auth_app_state_reason/',
+            'auth_app_state_detail/',
+        ];
         foreach ($session->keysForApp('horde') as $key) {
-            if (str_starts_with($key, 'auth_app/')) {
-                $session->removeScoped('horde', $key);
+            foreach ($authPrefixes as $prefix) {
+                if (str_starts_with($key, $prefix)) {
+                    $session->removeScoped('horde', $key);
+                    continue 2;
+                }
             }
         }
 


### PR DESCRIPTION
Horde_Registry::clearAuth called $session->removeScoped('horde', 'auth')
which removes a key literally named 'auth'. Stored auth state lives
under keys with a slash: auth/userId, auth/credentials, auth/timestamp,
auth/browser, auth/remoteAddr, auth/authId. Plus AuthCredentialStore
writes auth_app/, auth_app_init/, auth_app_state/, auth_app_state_at/,
auth_app_state_reason/, and auth_app_state_detail/ slots. None of those
matched. clearAuth left every authentication key in place.

The bug was tagged in the source with a // @suspicious shouldn't this
be 'auth/' comment by Jan in 2016 (commit f5592e92). Never fixed.

The legacy stack masked it because every legacy request goes through
Horde_Registry::appInit which performs its own relogin guard and
auth-state checks. Modern PSR-15 routes that load the session via
SessionHandler::load trust the row directly and reported the user as
still authenticated after logout.

Sweep every key in the horde scope whose name starts with one of the
auth prefixes. Document the prefix list inline so additions to
AuthCredentialStore flag the need to keep clearAuth synchronised.

Verified end-to-end: login then logout then GET /api/v1/session/whoami
now returns 401 unauthorized. Pre-fix returned 200 with the user id.
Legacy stack login-portal-logout-relogin flow continues to work.

Reported in horde-development/strategies/modern-session-migration/
purely-modern-route-lifecycle-2026-06-10.md as Gap 14.
