### PR TITLE
refactor/deglobal session handling

### DIFF
--- a/doc/SESSION_HANDLING.md
+++ b/doc/SESSION_HANDLING.md
@@ -1,0 +1,130 @@
+# Horde\Core Session Handling
+
+Building-block notes for the modern session-handling stack in horde/Core.
+Not exhaustive. Each section is one decision or contract worth capturing
+in source-controlled prose so it survives across refactors.
+
+## Components
+
+- `Horde\Core\Session\HordeSession`: request-scoped data layer. Two-level
+  scoped storage (`$data[$app][$name]`), plus a flat top level for
+  framework-internal markers (`_b` begin timestamp, `_r` regeneration
+  deadline). Carries lifecycle intent flags
+  (`scheduleRegeneration`, `markDestroyed`) that the engine acts on.
+- `Horde\Core\Session\SessionLifecycle`: engine. Wraps the modern
+  `Horde\SessionHandler\SessionHandler` plus the legacy PHP
+  session-module bootstrap (cookie params, ini tuning, save handler
+  registration, session_start). Synchronous executors:
+  `clean()`, `destroy()`, `regenerate()`. Engine method: `processFlags()`
+  reads HordeSession's intent markers and dispatches to the matching
+  executor. Always called explicitly.
+- `Horde\Core\Session\SessionConfig`: typed view of session-related
+  Horde config keys. Built from `ConfigLoader` state by
+  `SessionConfigFactory`. Immutable.
+- `Horde\Core\Middleware\HordeSessionMiddleware`: modern PSR-15
+  middleware. Loads session via `SessionHandler::load`, mints a fresh
+  one when no cookie or invalid cookie, sets a `session` request
+  attribute, persists on the way out, emits `Set-Cookie`.
+- `Horde\Core\Middleware\JwtSessionLoader`: modern PSR-15 middleware.
+  Reads JWT refresh cookie, verifies, looks up the session by JTI
+  (which IS the session id in the JWT-JTI architecture), sets the
+  same `session` request attribute. Composes with
+  `HordeSessionMiddleware` (the latter honours an already-set
+  attribute).
+- `Horde_Session` (lib/Horde/Session.php): legacy shim. Delegates
+  lifecycle work to `SessionLifecycle`. Carries its own relogin
+  guard and addFinal mirror task for legacy callers that read
+  `$_SESSION` directly.
+
+## Lifecycle markers
+
+`HordeSession` carries two private bool flags set by intent setters
+and read by the engine:
+
+- `markDestroyed()` / `isDestroyed()`: request the session be torn
+  down at end of request.
+- `scheduleRegeneration()` / `shouldRegenerate()`: request the
+  session id rotate.
+- `clearLifecycleFlags()`: `@internal`. Called by the engine after
+  acting on the markers.
+
+Markers are runtime-only. They are never persisted.
+
+`SessionLifecycle::processFlags(HordeSession)` is the canonical
+reader. Synchronous executors clear flags after acting so a
+downstream `processFlags()` call is a coherent no-op.
+
+## Cookie emission contract
+
+`HordeSessionMiddleware` emits `Set-Cookie` on three paths:
+
+- **Fresh mint:** request had no cookie or an invalid one. Emit
+  `Set-Cookie: <name>=<id>; ...` with the freshly minted id.
+- **Rotation:** controller called `scheduleRegeneration()`. Emit
+  the cookie with the new id. The old row is deleted by
+  `SessionHandler::regenerate`.
+- **Destruction:** controller called `markDestroyed()`. Emit a
+  clearing cookie (`Max-Age=0`, empty value).
+
+Steady-state requests (cookie present, id unchanged, no rotation,
+no destruction) do NOT re-emit the cookie.
+
+### `cookieDisabled` mode
+
+`SessionConfig::cookieDisabled` (default false). When true,
+`HordeSessionMiddleware` suppresses Set-Cookie on every path. The
+session row is still loaded and saved. Only the wire-level cookie
+transport is disabled. Used by pure API routes that identify
+clients via `Authorization: Bearer` tokens.
+
+`SessionConfigFactory` does not read this from configuration. Opt in
+by constructing `SessionConfig` directly as a route-specific
+override.
+
+## `Horde_Registry::clearAuth()`
+
+Wipes all auth-prefixed slots from the `horde` scope. Prefixes:
+
+- `auth/` (Registry::setAuth flat slots: userId, credentials,
+  timestamp, browser, remoteAddr, authId)
+- `auth_app/` (AuthCredentialStore credentials)
+- `auth_app_init/` (AuthCredentialStore init flag)
+- `auth_app_state/` (HasCredentialsState)
+- `auth_app_state_at/` (state transition timestamps)
+- `auth_app_state_reason/` (InvalidationReason)
+- `auth_app_state_detail/` (state detail message)
+
+Keep this list synchronised when new slot families are added to
+AuthCredentialStore.
+
+When `clearAuth($destroy=true)`, the method calls
+`SessionLifecycle::destroy()` directly (via injector) to tear down
+the backend row, then marks the rebuilt HordeSession destroyed so
+HordeSessionMiddleware emits `Set-Cookie: cleared` on response.
+
+The pre-Gap-14 implementation used `removeScoped('horde', 'auth')`
+which removed a literal key named `'auth'` (no slash). Every actual
+auth slot survived. The legacy stack masked the bug via
+`appInit`'s own auth-state checks. Modern PSR-15 routes that load
+the session via `SessionHandler::load` exposed it.
+
+## On-disk format
+
+The default session-data serializer is the pure-PHP
+`Horde\SessionHandler\PhpTextSessionSerializer` (or
+`PhpSessionSerializer` if PHP's `session.serialize_handler` is
+`php_serialize`). Both produce the exact byte sequence PHP's
+session module produces, so legacy and modern stacks share storage.
+
+Modern PSR-15 routes read and write session rows without ever
+calling `session_start()`. The legacy stack continues to go through
+the PHP session module via the `Horde_Session` shim.
+
+## See also
+
+- `horde-development/strategies/modern-session-migration/purely-modern-route-lifecycle-2026-06-10.md`
+  Master plan and gap status.
+- `horde-development/archive/completed-projects/session-unification-plan-2026-06-11.md`
+  Three-commit unification of `SessionLifecycle`, the shim, and the engine.
+- `horde-development/archive/completed-projects/session-whoami-demo-plan-2026-06-11.md`
+  Modern-stack end-to-end demo.

--- a/doc/SESSION_HANDLING.md
+++ b/doc/SESSION_HANDLING.md
@@ -146,7 +146,7 @@ to defeat session fixation), the controller calls
 middleware acts on the marker before emitting the response and the
 new id lands in the next `Set-Cookie`.
 
-## Truely Session-Less Routes
+## Truly Session-Less Routes
 
 The simplest example is the readiness probe in horde/base:
 

--- a/doc/SESSION_HANDLING.md
+++ b/doc/SESSION_HANDLING.md
@@ -1,22 +1,272 @@
 # Horde\Core Session Handling
 
-Building-block notes for the modern session-handling stack in horde/Core.
-Not exhaustive. Each section is one decision or contract worth capturing
-in source-controlled prose so it survives across refactors.
+> **Audience.** Application developers writing routes, controllers or
+> middleware against horde/Core. LLMs navigating Horde's two coexisting
+> session models. Framework contributors deciding where new behaviour
+> belongs.
+>
+> **Out of scope.** Detailed JWT generation/verification (see
+> `src/Auth/Jwt/`), credential storage (see `AuthCredentialStore`),
+> backend storage drivers (see horde/SessionHandler).
 
-## Components
+Session handling in horde/Core and applications based on it follows two
+different fundamental flows. Pick the right one for the route you are
+writing. Do not mix patterns within a single route.
 
-- `Horde\Core\Session\HordeSession`: request-scoped data layer. Two-level
-  scoped storage (`$data[$app][$name]`), plus a flat top level for
-  framework-internal markers (`_b` begin timestamp, `_r` regeneration
-  deadline). Carries lifecycle intent flags
+## Implied Flow (legacy)
+
+The "implied" flow is the legacy flow used by most existing code. It
+applies both to classic entrypoint scripts (`horde/services/portal.php`,
+`imp/index.php`) and all routes-based flows using the `HordeCore`
+middleware or relying on the legacy `Horde_Registry`.
+
+In this flow, some part of the call chain invokes
+`Horde_Registry::appInit` which bootstraps the globals environment used
+by most legacy code and implicitly sets up a session, even for
+unauthenticated pages, for guests and for REST/RPC calls.
+
+Code which relies on the globals (including the global `$session`,
+`$registry`, `$injector`, `$conf`, `$prefs`, `$language`, `$notification`)
+will work. Code generally does not care about persisting the session.
+The `SessionHandler` is installed as a `Horde_Shutdown` task and
+persists automatically at request shutdown. This means in the Rampage
+Routes & Middleware stack, sessions are written after the full HTTP
+response has been emitted and all middlewares have executed.
+
+The implied flow is correct for any controller that:
+
+- Reads or writes preferences, identities, app credentials, or
+  notifications in the per-request manner Horde apps have always done.
+- Reaches into `$GLOBALS['injector']->getInstance('Horde_Prefs')` or
+  similar bindings that Registry sets up at auth time.
+- Renders a Horde view template, since `Horde_View` and
+  `Horde_PageOutput` consume the same globals.
+
+## Explicit Flow (modern)
+
+In the explicit flow session control does not happen behind the scenes.
+If no session is ever requested, none will be initiated.
+
+A route decides if it wants sessions at all by adding a middleware
+early in the stack which loads sessions from a JWT's `jti` property or
+a session-cookie header. The same middleware persists the session on
+the way out when the response bubbles up through the middleware stack.
+
+Alternatively a route can have no session-loading middleware and let
+the controller decide if and when it wants to establish, recover,
+modify, store, rotate or destroy a session.
+
+The implication of this explicit flow: there is no `$session` global
+and the other Horde globals do not exist either unless the route took
+care of setting them up. Many factories and objects designed for the
+rich legacy environment will not work.
+
+Explicit session handling (and the wider implication of only setting
+up what the route asks for) enables a much leaner design with fewer
+surprising side effects. Use it for:
+
+- Pure JSON APIs where the response shape is the contract and you do
+  not want template engines or notification handlers in the way.
+- Health checks, readiness probes and other endpoints where any
+  side-effect during the request is undesirable.
+- Token-authenticated endpoints where session cookies are noise.
+- Any new route where you want to keep dependencies explicit.
+
+## Globals-Free Middleware Stack for JWT+Session
+
+The canonical example is the `whoami` demo route in horde/base:
+
+```php
+// base/config/routes.php
+$mapper->buildRoute(uri: '/api/v1/session/whoami', name: 'SessionWhoami')
+    ->withController(Service\SessionWhoamiController::class)
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withMiddleware([
+        ErrorFilter::class,
+        JwtSessionLoader::class,
+        HordeSessionMiddleware::class,
+    ])
+    ->withMethods(['GET'])
+    ->add();
+```
+
+The stack is, top to bottom:
+
+1. `ErrorFilter` catches uncaught exceptions and converts them to JSON
+   error responses with appropriate status codes.
+2. `JwtSessionLoader` reads the `horde_jwt_refresh` cookie if present.
+   When the cookie carries a valid refresh token, the loader extracts
+   the `jti` claim, calls `SessionHandler::load($jti)` and sets the
+   resulting `HordeSession` as the `session` request attribute. When
+   the cookie is missing, malformed, expired or points at a non-
+   existent row, the loader is a no-op and the session attribute is
+   left unset.
+3. `HordeSessionMiddleware` checks whether the session attribute is
+   already set (by `JwtSessionLoader` or any earlier middleware). If
+   set, the existing session is honoured. If not, the middleware reads
+   the regular session cookie (`Horde` by default), loads the row, or
+   mints a fresh one. Either way, the request attribute carries a
+   `HordeSession` by the time the controller sees it.
+4. The controller reads the session attribute via
+   `$request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION)`
+   and uses the typed `HordeSession` API.
+5. On the way out, `HordeSessionMiddleware` persists the session row
+   (when dirty), processes any `markDestroyed()` /
+   `scheduleRegeneration()` intent flags, and emits the appropriate
+   `Set-Cookie` header.
+
+### Authentication versus identity
+
+Neither `JwtSessionLoader` nor `HordeSessionMiddleware` performs
+authentication. They load whatever session the request hands them.
+Whether the loaded session represents an authenticated user is a
+question for the controller, which inspects
+`$session->getAuthenticatedUser()` and decides what to do.
+
+Stacks that want to demand authentication add `DemandAuthenticatedUser`
+or a similar middleware after the session-loading layer. That
+middleware short-circuits with a 401 when `getAuthenticatedUser()`
+returns null. The whoami route is gentler: it returns 401 with a
+documented JSON body when anonymous and a populated body when
+authenticated, both as 200 OK from the controller perspective.
+
+### Who establishes the session row
+
+The first request always lands without a `JwtSessionLoader` match (no
+cookie yet) and `HordeSessionMiddleware` mints a fresh session via
+`SessionHandler::create()`. The fresh session is anonymous: no
+`auth/userId`, empty `auth_app_*` slots. A subsequent login call
+(through `LoginService`, the legacy `Horde_Registry::setAuth` or any
+other authenticator) writes the auth slots into the SAME session row.
+The cookie carries the same id across the auth transition.
+
+If you want the auth transition to also rotate the id (good practice
+to defeat session fixation), the controller calls
+`$session->scheduleRegeneration()` after writing the auth slots. The
+middleware acts on the marker before emitting the response and the
+new id lands in the next `Set-Cookie`.
+
+## Truely Session-Less Routes
+
+The simplest example is the readiness probe in horde/base:
+
+```php
+$mapper->buildRoute(uri: '/observability/readiness', name: 'Readiness')
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withMiddleware([Observability\Readiness::class])
+    ->add();
+```
+
+No controller. No session middleware. The readiness middleware itself
+returns a fixed `1` body and never touches session state. The route
+exists to answer the question "is the server up enough to serve
+HTTP" without paying for any session bookkeeping.
+
+A token-authenticated admin route is the next step up. It
+authenticates the caller via `Authorization: Bearer <admin-secret>`
+or a JWT access token, but does not need a session row:
+
+```php
+$mapper->buildRoute(uri: '/api/v1/admin/diagnostic', name: 'AdminApiDiagnostic')
+    ->withController(Admin\DiagnosticController::class)
+    ->withDefaults(['HordeAuthType' => 'NONE'])
+    ->withMiddleware([
+        ErrorFilter::class,
+        JwtAuthMiddleware::class, // verifies Authorization: Bearer <access-token>
+    ])
+    ->withMethods(['GET'])
+    ->add();
+```
+
+Note that this is `JwtAuthMiddleware`, not `JwtSessionLoader`. The two
+have similar names but very different jobs:
+
+- `JwtSessionLoader`: reads the `horde_jwt_refresh` *cookie*, looks up
+  a session row by JTI, hands a `HordeSession` to the rest of the
+  stack. It is for browser-style flows where the JWT and the session
+  are two transports into one store.
+- `JwtAuthMiddleware`: reads an `Authorization: Bearer` header,
+  verifies the access token, sets `verified_jwt` and `user_id`
+  request attributes. It does NOT load or mint a session. It is for
+  pure API consumers who never want a session row.
+
+If a route uses `JwtAuthMiddleware` only, no session is ever loaded or
+created. The controller cannot call `$request->getAttribute('session')`
+because nothing put it there.
+
+For routes that need both a session AND token-authenticated callers
+(rare, but possible: imagine a script that first authenticates via
+Bearer token, then needs a short-lived session row to coordinate with
+a websocket), stack `JwtAuthMiddleware` followed by
+`HordeSessionMiddleware` with `cookieDisabled: true` set on its
+`SessionConfig`. The session row exists. No cookie ever leaves the
+server.
+
+## HordeCore-Based Flow with Globals
+
+The default middleware stack used by most existing routes pulls in the
+full legacy environment:
+
+```php
+$mapper->buildRoute(uri: '/admin/', name: 'AdminDashboard')
+    ->withController(Admin\AdminDashboardController::class)
+    ->withDefaults(['HordeAuthType' => 'authenticate'])
+    ->withMiddleware([
+        HordeCore::class,
+        ErrorFilter::class,
+        AuthHordeSession::class,
+        DemandAuthenticatedUser::class,
+    ])
+    ->add();
+```
+
+Here `HordeCore` middleware calls
+`Horde_Registry::appInit('horde', ['authentication' => 'none'])` which:
+
+- Bootstraps `$GLOBALS['registry']`, `$GLOBALS['injector']`,
+  `$GLOBALS['conf']`, `$GLOBALS['prefs']`, `$GLOBALS['language']`,
+  `$GLOBALS['notification']`, and the per-app prefs binding.
+- Registers the legacy `Horde_Session` shim under
+  `$GLOBALS['session']`.
+- Opens the PHP session via the shim's `setup()`, which delegates to
+  `SessionLifecycle::setup()` for the actual save-handler registration
+  and `session_start()`.
+- Applies the `Horde_Session` shim's relogin guard for sessions whose
+  auth state changed mid-request.
+
+`AuthHordeSession` middleware then reads the auth slot from
+`$_SESSION` (mirrored from the modern session by the shim's `addFinal`
+task) and short-circuits to a redirect or 401 when the session has no
+authenticated user.
+
+`DemandAuthenticatedUser` is a final guard that fires if any earlier
+layer left an unauthenticated request through.
+
+Use this stack for:
+
+- Any controller that renders a Horde view template.
+- Any controller that needs `Horde_Prefs`, `Horde_Identity` or other
+  per-user resources resolved through the legacy bindings.
+- Any controller that delegates to legacy app methods via
+  `$registry->callAppMethod()`.
+
+The trade-off is that every globals consumer the stack pulls in becomes
+part of the route's effective dependency surface. Modern routes that
+want a minimal surface use the explicit flow above.
+
+## Individual Components
+
+- `Horde\Core\Session\HordeSession`: request-scoped data layer.
+  Two-level scoped storage (`$data[$app][$name]`), plus a flat top
+  level for framework-internal markers (`_b` begin timestamp, `_r`
+  regeneration deadline). Carries lifecycle intent flags
   (`scheduleRegeneration`, `markDestroyed`) that the engine acts on.
 - `Horde\Core\Session\SessionLifecycle`: engine. Wraps the modern
   `Horde\SessionHandler\SessionHandler` plus the legacy PHP
   session-module bootstrap (cookie params, ini tuning, save handler
-  registration, session_start). Synchronous executors:
-  `clean()`, `destroy()`, `regenerate()`. Engine method: `processFlags()`
-  reads HordeSession's intent markers and dispatches to the matching
+  registration, `session_start`). Synchronous executors: `clean()`,
+  `destroy()`, `regenerate()`. Engine method: `processFlags()` reads
+  HordeSession's intent markers and dispatches to the matching
   executor. Always called explicitly.
 - `Horde\Core\Session\SessionConfig`: typed view of session-related
   Horde config keys. Built from `ConfigLoader` state by
@@ -31,12 +281,16 @@ in source-controlled prose so it survives across refactors.
   same `session` request attribute. Composes with
   `HordeSessionMiddleware` (the latter honours an already-set
   attribute).
-- `Horde_Session` (lib/Horde/Session.php): legacy shim. Delegates
+- `Horde\Core\Middleware\JwtAuthMiddleware`: modern PSR-15 middleware.
+  Reads `Authorization: Bearer <access-token>`, verifies the access
+  token, sets `verified_jwt` and `user_id` request attributes. Does
+  NOT load a session.
+- `Horde_Session` (`lib/Horde/Session.php`): legacy shim. Delegates
   lifecycle work to `SessionLifecycle`. Carries its own relogin
-  guard and addFinal mirror task for legacy callers that read
+  guard and `addFinal` mirror task for legacy callers that read
   `$_SESSION` directly.
 
-## Lifecycle markers
+## Lifecycle Markers
 
 `HordeSession` carries two private bool flags set by intent setters
 and read by the engine:
@@ -54,32 +308,37 @@ Markers are runtime-only. They are never persisted.
 reader. Synchronous executors clear flags after acting so a
 downstream `processFlags()` call is a coherent no-op.
 
-## Cookie emission contract
+In modern routes, `HordeSessionMiddleware` reads the markers on
+response emit (NOT via `processFlags`, which couples to PHP's session
+module that the modern middleware avoids) and dispatches to
+`SessionHandler::regenerate` / `SessionHandler::destroySession`
+directly. Same outcome, different code path.
+
+## Cookie Emission Contract
 
 `HordeSessionMiddleware` emits `Set-Cookie` on three paths:
 
 - **Fresh mint:** request had no cookie or an invalid one. Emit
   `Set-Cookie: <name>=<id>; ...` with the freshly minted id.
-- **Rotation:** controller called `scheduleRegeneration()`. Emit
-  the cookie with the new id. The old row is deleted by
+- **Rotation:** controller called `scheduleRegeneration()`. Emit the
+  cookie with the new id. The old row is deleted by
   `SessionHandler::regenerate`.
 - **Destruction:** controller called `markDestroyed()`. Emit a
   clearing cookie (`Max-Age=0`, empty value).
 
-Steady-state requests (cookie present, id unchanged, no rotation,
-no destruction) do NOT re-emit the cookie.
+Steady-state requests (cookie present, id unchanged, no rotation, no
+destruction) do NOT re-emit the cookie.
 
 ### `cookieDisabled` mode
 
 `SessionConfig::cookieDisabled` (default false). When true,
 `HordeSessionMiddleware` suppresses Set-Cookie on every path. The
 session row is still loaded and saved. Only the wire-level cookie
-transport is disabled. Used by pure API routes that identify
-clients via `Authorization: Bearer` tokens.
+transport is disabled. Used by pure API routes that identify clients
+via `Authorization: Bearer` tokens.
 
 `SessionConfigFactory` does not read this from configuration. Opt in
-by constructing `SessionConfig` directly as a route-specific
-override.
+by constructing `SessionConfig` directly as a route-specific override.
 
 ## `Horde_Registry::clearAuth()`
 
@@ -95,36 +354,91 @@ Wipes all auth-prefixed slots from the `horde` scope. Prefixes:
 - `auth_app_state_detail/` (state detail message)
 
 Keep this list synchronised when new slot families are added to
-AuthCredentialStore.
+`AuthCredentialStore`.
 
 When `clearAuth($destroy=true)`, the method calls
-`SessionLifecycle::destroy()` directly (via injector) to tear down
-the backend row, then marks the rebuilt HordeSession destroyed so
-HordeSessionMiddleware emits `Set-Cookie: cleared` on response.
+`SessionLifecycle::destroy()` directly (via injector) to tear down the
+backend row, then marks the rebuilt HordeSession destroyed so
+`HordeSessionMiddleware` emits `Set-Cookie: cleared` on response.
 
 The pre-Gap-14 implementation used `removeScoped('horde', 'auth')`
 which removed a literal key named `'auth'` (no slash). Every actual
-auth slot survived. The legacy stack masked the bug via
-`appInit`'s own auth-state checks. Modern PSR-15 routes that load
-the session via `SessionHandler::load` exposed it.
+auth slot survived. The legacy stack masked the bug via `appInit`'s
+own auth-state checks. Modern PSR-15 routes that load the session
+via `SessionHandler::load` exposed it.
 
-## On-disk format
+## On-Disk Format
 
 The default session-data serializer is the pure-PHP
 `Horde\SessionHandler\PhpTextSessionSerializer` (or
 `PhpSessionSerializer` if PHP's `session.serialize_handler` is
-`php_serialize`). Both produce the exact byte sequence PHP's
-session module produces, so legacy and modern stacks share storage.
+`php_serialize`). Both produce the exact byte sequence PHP's session
+module produces, so legacy and modern stacks share storage.
 
-Modern PSR-15 routes read and write session rows without ever
-calling `session_start()`. The legacy stack continues to go through
-the PHP session module via the `Horde_Session` shim.
+Modern PSR-15 routes read and write session rows without ever calling
+`session_start()`. The legacy stack continues to go through the PHP
+session module via the `Horde_Session` shim. A single backend row
+serves both flows.
 
-## See also
+## How to Pick a Flow
+
+| Question | Implied flow | Explicit flow |
+|----------|--------------|---------------|
+| Renders a Horde view template? | yes | no |
+| Reads `$registry->callAppMethod()`? | yes | no |
+| Uses `Horde_Prefs` directly? | yes | refactor: inject `PrefsService` |
+| Uses `Horde_Notification`? | yes | inject `Horde_Notification_Handler` |
+| Pure JSON API? | works but heavy | preferred |
+| Token-only authentication, no cookie? | wrong fit | preferred |
+| Health / readiness probe? | wrong fit | preferred |
+| New code? | only when the existing app demands it | default |
+
+Mixing rule: a route either pulls in `HordeCore` middleware or it does
+not. If it does, every controller behind it can assume the legacy
+globals exist. If it does not, the controller must take its
+collaborators via constructor injection through a `#[Factory]` and
+must read request-scoped state from PSR-7 attributes.
+
+## Common Pitfalls
+
+- **Reading `$_COOKIE` from a controller.** Use
+  `$request->getCookieParams()` from PSR-7 instead. The legacy stack
+  populates `$_COOKIE` via PHP's normal request handling, but the
+  modern stack accepts request injection from places PHP's
+  superglobals do not see.
+- **Calling `session_id()` or `session_name()` from controller code.**
+  Use `(string) $session->getId()` (where `$session` came from the
+  request attribute) and `$sessionConfig->cookieName` instead. The
+  legacy `session_*()` functions only return values when PHP's session
+  module is active, which is not the case in the explicit flow.
+- **Resolving `AuthCredentialStore` via DI from a modern controller.**
+  The DI binding hands you an `AuthCredentialStore` keyed to the
+  HordeSession that `HordeSessionFactory` produced at request start
+  (typically empty). You want one keyed to the session the middleware
+  loaded onto the request. Construct it locally:
+  `new AuthCredentialStore($request->getAttribute('session'))`.
+- **Mixing `JwtSessionLoader` with `JwtAuthMiddleware` and expecting
+  one to feed the other.** They read different sources (refresh
+  cookie vs `Authorization` header) and write different attributes
+  (`session` vs `verified_jwt` and `user_id`). Use one or the other
+  per route.
+- **Calling `$session->markDestroyed()` and expecting the cookie to
+  clear in legacy stacks.** `markDestroyed` only fires when
+  `HordeSessionMiddleware` is in the response chain. In legacy
+  flows, call `$registry->clearAuth(true)` instead, which performs
+  the synchronous destruction AND sets the marker for any modern
+  middleware that happens to also be present.
+
+## See Also
 
 - `horde-development/strategies/modern-session-migration/purely-modern-route-lifecycle-2026-06-10.md`
   Master plan and gap status.
 - `horde-development/archive/completed-projects/session-unification-plan-2026-06-11.md`
-  Three-commit unification of `SessionLifecycle`, the shim, and the engine.
+  Three-commit unification of `SessionLifecycle`, the shim and the
+  engine.
 - `horde-development/archive/completed-projects/session-whoami-demo-plan-2026-06-11.md`
-  Modern-stack end-to-end demo.
+  Modern-stack end-to-end demo. The whoami controller in horde/base
+  is the canonical worked example.
+- `src/Auth/Jwt/` for JWT generation and verification details.
+- `vendor/horde/sessionhandler/` for backend driver details
+  (Sql, Builtin, File, Hashtable, Stack).

--- a/doc/SESSION_HANDLING.md
+++ b/doc/SESSION_HANDLING.md
@@ -231,8 +231,6 @@ Here `HordeCore` middleware calls
 - Opens the PHP session via the shim's `setup()`, which delegates to
   `SessionLifecycle::setup()` for the actual save-handler registration
   and `session_start()`.
-- Applies the `Horde_Session` shim's relogin guard for sessions whose
-  auth state changed mid-request.
 
 `AuthHordeSession` middleware then reads the auth slot from
 `$_SESSION` (mirrored from the modern session by the shim's `addFinal`
@@ -286,9 +284,8 @@ want a minimal surface use the explicit flow above.
   token, sets `verified_jwt` and `user_id` request attributes. Does
   NOT load a session.
 - `Horde_Session` (`lib/Horde/Session.php`): legacy shim. Delegates
-  lifecycle work to `SessionLifecycle`. Carries its own relogin
-  guard and `addFinal` mirror task for legacy callers that read
-  `$_SESSION` directly.
+  lifecycle work to `SessionLifecycle`. Carries the `addFinal` mirror
+  task for legacy callers that read `$_SESSION` directly.
 
 ## Lifecycle Markers
 

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -60,6 +60,7 @@ use Horde\Core\Service\OAuthHttpClientService;
 use Horde\Core\Service\OAuthProviderConfigRepository;
 use Horde\Core\Service\OAuthTokenService;
 use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionLifecycle;
 use Horde\Token\Token;
 use Horde\Db\Adapter as DbAdapter;
 use Horde\Horde\Factory\OAuthHttpClientServiceFactory as BaseOAuthHttpClientServiceFactory;
@@ -2267,10 +2268,23 @@ class Horde_Registry implements Horde_Shutdown_Task
         $this->_cache['existing'] = $this->_cache['isauth'] = [];
 
         if ($destroy) {
-            // session_destroy() is a lifecycle operation that the shim
-            // wraps; HordeSession does not yet expose a lifecycle surface,
-            // so this stays on the shim until the shim itself is removed.
-            $GLOBALS['session']->destroy();
+            // Resolve the modern engine through the injector. The legacy
+            // shim's `$GLOBALS['session']->destroy()` wrapped exactly this
+            // call; reaching for SessionLifecycle directly removes the
+            // last shim hop inside Registry::clearAuth.
+            $lifecycle = $GLOBALS['injector']->getInstance(SessionLifecycle::class);
+            $lifecycle->destroy();
+
+            // Mark the modern HordeSession destroyed so
+            // HordeSessionMiddleware::finaliseDestroyed emits Set-Cookie:
+            // cleared on the response. SessionLifecycle::destroy() above
+            // wiped the data layer and rebuilt HordeSession over the
+            // empty payload, so the marker has to be set on the freshly
+            // rebuilt instance, not the one we resolved at the top of
+            // this method.
+            $GLOBALS['injector']
+                ->getInstance(HordeSession::class)
+                ->markDestroyed();
         }
     }
 

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -152,16 +152,6 @@ class Horde_Session implements Horde_Shutdown_Task
     protected $_data;
 
     /**
-     * Indicates that session data is read-only.
-     */
-    protected bool $_readonly = false;
-
-    /**
-     * On re-login, indicate whether we were previously authenticated.
-     */
-    protected ?bool $_relogin = null;
-
-    /**
      * Constructor.
      *
      * All dependencies are optional: when omitted they are resolved from the
@@ -232,13 +222,14 @@ class Horde_Session implements Horde_Shutdown_Task
     {
         switch ($name) {
             case 'begin':
-                if (!$this->_active && !$this->_relogin) {
+                if (!$this->_active) {
                     return 0;
                 }
-                $value = $this->modern->getScoped(self::BEGIN, '');
-                if ($value === null) {
-                    $value = $this->_data[self::BEGIN] ?? 0;
+                $begin = $this->modern->getSessionBegin();
+                if ($begin !== null) {
+                    return $begin->getTimestamp();
                 }
+                $value = $this->_data[self::BEGIN] ?? 0;
 
                 return is_int($value) ? $value : 0;
 
@@ -296,9 +287,8 @@ class Horde_Session implements Horde_Shutdown_Task
             // Delegate the PHP-session work (cookie params, ini tuning,
             // save handler, cookie-domain guard, optional session_start)
             // to the lifecycle. Pass start=false: the shim drives start()
-            // itself so its own bookkeeping (_active, _data, relogin
-            // guard) stays in lock-step with the rest of the shim's
-            // public surface.
+            // itself so its own bookkeeping (_active, _data) stays in
+            // lock-step with the rest of the shim's public surface.
             $lifecycle->setup(
                 start: false,
                 cacheLimiter: $cache_limiter,
@@ -392,21 +382,6 @@ class Horde_Session implements Horde_Shutdown_Task
         $this->_active = true;
         $this->_data = &$_SESSION;
         $this->_rebuildModern();
-
-        /* We have reopened a session. Check to make sure that authentication
-         * status has not changed in the meantime. The relogin guard is a
-         * legacy-stack concern; it lives here in the shim, NOT in
-         * SessionLifecycle. */
-        if (!$this->_readonly
-            && !is_null($this->_relogin)
-            && (($GLOBALS['registry']->getAuth() !== false) !== $this->_relogin)) {
-            Horde::log(
-                'Previous session attempted to be reopened after authentication'
-                . ' status change. All session modifications will be ignored.',
-                Horde_Log::DEBUG
-            );
-            $this->_readonly = true;
-        }
     }
 
     /**
@@ -532,10 +507,6 @@ class Horde_Session implements Horde_Shutdown_Task
     public function close()
     {
         $this->_active = false;
-        // The shim's relogin guard depends on this; record before we
-        // hand off to the lifecycle. Legacy concern, lives here.
-        $this->_relogin = isset($GLOBALS['registry'])
-            && ($GLOBALS['registry']->getAuth() !== false);
 
         $lifecycle = $this->_resolveLifecycle();
         if ($lifecycle !== null) {
@@ -691,10 +662,6 @@ class Horde_Session implements Horde_Shutdown_Task
      */
     public function set($app, $name, $value, $mask = 0)
     {
-        if ($this->_readonly) {
-            return;
-        }
-
         if ($mask & self::ENCRYPT) {
             $this->modern->setEncrypted($app, $name, $value);
             $this->sessionHandler->changed = true;
@@ -713,10 +680,6 @@ class Horde_Session implements Horde_Shutdown_Task
      */
     public function remove($app, $name = null)
     {
-        if ($this->_readonly) {
-            return;
-        }
-
         if (is_null($name)) {
             foreach ($this->modern->keysForApp($app) as $key) {
                 $this->modern->removeScoped($app, $key);

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -422,15 +422,15 @@ class Horde_Session implements Horde_Shutdown_Task
             $this->_data[self::BEGIN] = $curr_time;
             $this->_data[self::REGENERATE] = $curr_time
                 + $this->regenerate_interval;
-            // Begin slot is the canonical top-level int shape that
-            // HordeSession::getSessionBegin reads. The legacy
-            // setScoped(BEGIN, '', ...) call wrote the wrong shape
-            // ($data['_b'][''] instead of $data['_b']) and broke modern
-            // readers; setSessionBegin keeps both writers aligned.
+            // Begin and regenerate slots are top-level ints on the
+            // modern HordeSession (matching what getSessionBegin and
+            // getRegenerationDeadline read). The legacy setScoped(_,
+            // '', ...) calls wrote the wrong shape ($data['_b']['']
+            // and $data['_r'][''] instead of $data['_b'] / $data['_r'])
+            // and broke modern readers. The typed setters keep all
+            // writers aligned.
             $this->modern->setSessionBegin($curr_time);
-            $this->modern->setScoped(
-                self::REGENERATE,
-                '',
+            $this->modern->setRegenerationDeadline(
                 $curr_time + $this->regenerate_interval
             );
         }
@@ -445,12 +445,16 @@ class Horde_Session implements Horde_Shutdown_Task
     {
         $lifecycle = $this->_resolveLifecycle();
         if ($lifecycle !== null) {
-            // Lifecycle does mirror + session_regenerate_id(true) + writes
-            // the new _r deadline via HordeSession::setScoped() + clears
-            // lifecycle markers.
+            // Lifecycle does mirror + session_regenerate_id(true) +
+            // writes the new _r deadline via
+            // HordeSession::setRegenerationDeadline + clears lifecycle
+            // markers.
             $lifecycle->regenerate();
             $this->_data = &$_SESSION;
-            $this->_data[self::REGENERATE] = $this->modern->getScoped(self::REGENERATE, '');
+            $deadline = $this->modern->getRegenerationDeadline();
+            if ($deadline !== null) {
+                $this->_data[self::REGENERATE] = $deadline;
+            }
             return;
         }
 
@@ -460,7 +464,7 @@ class Horde_Session implements Horde_Shutdown_Task
         session_regenerate_id(true);
         $regenAt = time() + $this->regenerate_interval;
         $this->_data[self::REGENERATE] = $regenAt;
-        $this->modern->setScoped(self::REGENERATE, '', $regenAt);
+        $this->modern->setRegenerationDeadline($regenAt);
     }
 
     /**

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -417,12 +417,17 @@ class Horde_Session implements Horde_Shutdown_Task
         $curr_time = time();
 
         /* Create internal data arrays. */
-        if ($this->modern->getScoped(self::BEGIN, '') === null
+        if ($this->modern->getSessionBegin() === null
             && !isset($this->_data[self::BEGIN])) {
             $this->_data[self::BEGIN] = $curr_time;
             $this->_data[self::REGENERATE] = $curr_time
                 + $this->regenerate_interval;
-            $this->modern->setScoped(self::BEGIN, '', $curr_time);
+            // Begin slot is the canonical top-level int shape that
+            // HordeSession::getSessionBegin reads. The legacy
+            // setScoped(BEGIN, '', ...) call wrote the wrong shape
+            // ($data['_b'][''] instead of $data['_b']) and broke modern
+            // readers; setSessionBegin keeps both writers aligned.
+            $this->modern->setSessionBegin($curr_time);
             $this->modern->setScoped(
                 self::REGENERATE,
                 '',

--- a/src/Middleware/HordeSessionMiddleware.php
+++ b/src/Middleware/HordeSessionMiddleware.php
@@ -249,7 +249,7 @@ final class HordeSessionMiddleware implements MiddlewareInterface
         //      the rotated session has no backend representation
         //      because the old row was deleted by regenerate().
         $rotated->setRegenerationDeadline(
-            time() + $this->config->regenerateInterval,
+            $this->config->nextRegenerationDeadline(),
         );
 
         try {

--- a/src/Middleware/HordeSessionMiddleware.php
+++ b/src/Middleware/HordeSessionMiddleware.php
@@ -67,9 +67,6 @@ final class HordeSessionMiddleware implements MiddlewareInterface
     /** Request attribute carrying the active {@see HordeSession}. */
     public const ATTRIBUTE_SESSION = JwtSessionLoader::ATTRIBUTE_SESSION;
 
-    /** Internal scope and key for the regenerate-at deadline. Matches HordeSession's wire format. */
-    private const REGENERATE_KEY = '_r';
-
     public function __construct(
         private readonly SessionHandler $handler,
         private readonly SessionConfig $config,
@@ -251,9 +248,7 @@ final class HordeSessionMiddleware implements MiddlewareInterface
         //      actually persists the row at the new id; without this,
         //      the rotated session has no backend representation
         //      because the old row was deleted by regenerate().
-        $rotated->setScoped(
-            self::REGENERATE_KEY,
-            '',
+        $rotated->setRegenerationDeadline(
             time() + $this->config->regenerateInterval,
         );
 

--- a/src/Middleware/HordeSessionMiddleware.php
+++ b/src/Middleware/HordeSessionMiddleware.php
@@ -208,6 +208,13 @@ final class HordeSessionMiddleware implements MiddlewareInterface
             ]);
         }
 
+        if ($this->config->cookieDisabled) {
+            // Cookieless mode: client identifies via Authorization header.
+            // The backend row was destroyed above; nothing to clear on
+            // the wire.
+            return $response;
+        }
+
         return Cookies::clear(
             $response,
             $this->config->cookieName,
@@ -259,6 +266,13 @@ final class HordeSessionMiddleware implements MiddlewareInterface
             ]);
         }
 
+        if ($this->config->cookieDisabled) {
+            // Cookieless mode: rotated id lives only on the backend row.
+            // The client carries no cookie to update; the next request
+            // continues to identify via Authorization header.
+            return $response;
+        }
+
         return Cookies::with($response, $this->buildSessionCookie((string) $rotated->getId()));
     }
 
@@ -268,6 +282,12 @@ final class HordeSessionMiddleware implements MiddlewareInterface
         bool $hadCookie,
     ): ResponseInterface {
         $this->saveIfDirty($session);
+
+        if ($this->config->cookieDisabled) {
+            // Cookieless mode: never emit Set-Cookie regardless of
+            // whether the request arrived with one.
+            return $response;
+        }
 
         if (!$hadCookie) {
             // First request, or cookie was missing/invalid: emit the

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -300,6 +300,24 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
         return (new DateTimeImmutable())->setTimestamp($value);
     }
 
+    /**
+     * Record the session-begin timestamp.
+     *
+     * Writes the {@see BEGIN_KEY} slot at the top level as a bare int.
+     * Pairs with {@see getSessionBegin}, which reads the same shape.
+     * Use this in preference to {@see set()} so the begin slot's wire
+     * format stays internal to this class.
+     *
+     * Idempotent and dirty-marking. The legacy `Horde_Session` shim
+     * and {@see SessionLifecycle::initialiseTimestamps} both call this
+     * to converge on a single shape across all writers.
+     */
+    public function setSessionBegin(int $timestamp): void
+    {
+        $this->data[self::BEGIN_KEY] = $timestamp;
+        $this->dirty = true;
+    }
+
     public function getAuthenticatedApps(): array
     {
         $appData = $this->data['horde'] ?? [];

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -308,9 +308,11 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
      * Use this in preference to {@see set()} so the begin slot's wire
      * format stays internal to this class.
      *
-     * Idempotent and dirty-marking. The legacy `Horde_Session` shim
-     * and {@see SessionLifecycle::initialiseTimestamps} both call this
-     * to converge on a single shape across all writers.
+     * Marks the session dirty. Overwrites unconditionally. Callers
+     * that want to set the begin only once per session check
+     * {@see getSessionBegin} first; see
+     * {@see SessionLifecycle::initialiseTimestamps()} for the
+     * canonical guard.
      */
     public function setSessionBegin(int $timestamp): void
     {

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -318,6 +318,35 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
         $this->dirty = true;
     }
 
+    /**
+     * Read the session-id regeneration deadline as a Unix timestamp,
+     * or null when no deadline has been recorded.
+     *
+     * Pairs with {@see setRegenerationDeadline}. The slot is a top-level
+     * int. Pre-fix code wrote the deadline via
+     * `setScoped(REGENERATE_KEY, '', $ts)` which produced
+     * `$data['_r']['']` and was internally consistent (same writer used
+     * the same getScoped reader) but inconsistent with `_b`. Both keys
+     * now use the same top-level int shape.
+     */
+    public function getRegenerationDeadline(): ?int
+    {
+        $value = $this->data[self::REGENERATE_KEY] ?? null;
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * Record the session-id regeneration deadline.
+     *
+     * Writes the {@see REGENERATE_KEY} slot at the top level as a bare
+     * int. Pairs with {@see getRegenerationDeadline}.
+     */
+    public function setRegenerationDeadline(int $timestamp): void
+    {
+        $this->data[self::REGENERATE_KEY] = $timestamp;
+        $this->dirty = true;
+    }
+
     public function getAuthenticatedApps(): array
     {
         $appData = $this->data['horde'] ?? [];

--- a/src/Session/HordeSessionFactory.php
+++ b/src/Session/HordeSessionFactory.php
@@ -39,7 +39,7 @@ class HordeSessionFactory extends DefaultSessionFactory
     public function createNew(SessionId $id): Session
     {
         $session = new HordeSession($id, [], $this->encryptor, $this->decryptor);
-        $session->set('_b', time());
+        $session->setSessionBegin(time());
 
         return $session;
     }

--- a/src/Session/SessionConfig.php
+++ b/src/Session/SessionConfig.php
@@ -81,6 +81,21 @@ final class SessionConfig
      *                                        single-label-host plus
      *                                        Domain-attribute combination.
      *                                        From `$conf['server']['name']`.
+     * @param bool        $cookieDisabled     When true,
+     *                                        {@see HordeSessionMiddleware}
+     *                                        does NOT emit `Set-Cookie` on
+     *                                        any of its lifecycle paths
+     *                                        (steady-state, regenerated,
+     *                                        destroyed). Used by pure API
+     *                                        routes that identify clients
+     *                                        via `Authorization: Bearer`
+     *                                        tokens and do not want a
+     *                                        session cookie. The session
+     *                                        row is still loaded and saved
+     *                                        through {@see SessionHandler};
+     *                                        only the cookie transport
+     *                                        layer is suppressed. Default
+     *                                        false (cookie path active).
      */
     public function __construct(
         public readonly string $cookieName,
@@ -91,5 +106,6 @@ final class SessionConfig
         public readonly int $regenerateInterval,
         public readonly ?string $cacheLimiter,
         public readonly string $serverName = '',
+        public readonly bool $cookieDisabled = false,
     ) {}
 }

--- a/src/Session/SessionConfig.php
+++ b/src/Session/SessionConfig.php
@@ -108,4 +108,21 @@ final class SessionConfig
         public readonly string $serverName = '',
         public readonly bool $cookieDisabled = false,
     ) {}
+
+    /**
+     * Compute the next session-id regeneration deadline as a Unix
+     * timestamp.
+     *
+     * Centralises the `$now + $regenerateInterval` math so the
+     * lifecycle engine and the modern middleware do not drift on
+     * what "next deadline" means. Callers that already have a
+     * captured `$now` pass it in. Callers acting at the moment of
+     * call leave the argument null to read `time()` here.
+     *
+     * @param int|null $now Unix timestamp anchor. Null means now.
+     */
+    public function nextRegenerationDeadline(?int $now = null): int
+    {
+        return ($now ?? time()) + $this->regenerateInterval;
+    }
 }

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -85,12 +85,6 @@ class SessionLifecycle implements Horde_Shutdown_Task
     /** Marker for a string scoped value (matches HordeSession). */
     private const NOT_SERIALIZED = "\0";
 
-    /** $_SESSION top-level key holding the begin-timestamp. */
-    private const BEGIN_KEY = '_b';
-
-    /** $_SESSION top-level key holding the regenerate-at deadline. */
-    private const REGENERATE_KEY = '_r';
-
     /**
      * Whether PHP's session machinery is currently open for read/write.
      *
@@ -348,10 +342,10 @@ class SessionLifecycle implements Horde_Shutdown_Task
         $this->mirrorToSession();
         session_regenerate_id(true);
         $regenAt = time() + $this->regenerateInterval();
-        // The deadline is canonical on HordeSession via the scoped slot.
+        // The deadline is canonical on HordeSession at the top level.
         // The shim's addFinal() shutdown task mirrors HordeSession to
         // $_SESSION for legacy code that reads the superglobal directly.
-        $this->getSession()->setScoped(self::REGENERATE_KEY, '', $regenAt);
+        $this->getSession()->setRegenerationDeadline($regenAt);
 
         // Synchronous executor: clear pending intent so a downstream
         // processFlags() call sees a coherent no-op.
@@ -407,8 +401,8 @@ class SessionLifecycle implements Horde_Shutdown_Task
      */
     public function regenerationDue(): bool
     {
-        $regen = $this->getSession()->getScoped(self::REGENERATE_KEY, '');
-        return is_int($regen) && time() >= $regen;
+        $regen = $this->getSession()->getRegenerationDeadline();
+        return $regen !== null && time() >= $regen;
     }
 
     /**
@@ -505,7 +499,7 @@ class SessionLifecycle implements Horde_Shutdown_Task
         $regenAt = $now + $this->regenerateInterval();
 
         $session->setSessionBegin($now);
-        $session->setScoped(self::REGENERATE_KEY, '', $regenAt);
+        $session->setRegenerationDeadline($regenAt);
     }
 
     /**

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -486,21 +486,25 @@ class SessionLifecycle implements Horde_Shutdown_Task
     /**
      * Write the begin and regenerate-at timestamps on first session start.
      *
-     * No-op when either timestamp is already present, so re-running setup()
-     * or restoring a persisted session does not reset the begin time.
+     * No-op when the begin timestamp is already present, so re-running
+     * setup() or restoring a persisted session does not reset it. Reads
+     * via {@see HordeSession::getSessionBegin()} so the legacy
+     * scoped-with-empty-subkey shape (`$data['_b']['']`) is treated as
+     * absent and gets overwritten on the next setup; over time, all
+     * sessions converge on the canonical top-level int shape.
      */
     private function initialiseTimestamps(): void
     {
         $session = $this->getSession();
 
-        if ($session->getScoped(self::BEGIN_KEY, '') !== null) {
+        if ($session->getSessionBegin() !== null) {
             return;
         }
 
         $now = time();
         $regenAt = $now + $this->regenerateInterval();
 
-        $session->setScoped(self::BEGIN_KEY, '', $now);
+        $session->setSessionBegin($now);
         $session->setScoped(self::REGENERATE_KEY, '', $regenAt);
     }
 

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -109,6 +109,15 @@ class SessionLifecycle implements Horde_Shutdown_Task
     private bool $shutdownRegistered = false;
 
     /**
+     * Whether the one-time setup work (ini tuning, cookie params,
+     * cache_limiter, session_name, optional session_id forcing) has
+     * already been applied this request. Guards against repeated
+     * setup() calls overlapping the legacy shim and the modern
+     * middleware on the same request.
+     */
+    private bool $setupApplied = false;
+
+    /**
      * @param Injector              $injector Injector for resolving the
      *                                        current {@see HordeSession}
      *                                        on each call. The lifecycle
@@ -155,59 +164,63 @@ class SessionLifecycle implements Horde_Shutdown_Task
         ?string $cacheLimiter = null,
         ?string $sessionId = null,
     ): void {
-        ini_set('url_rewriter.tags', 0);
+        if (!$this->setupApplied) {
+            ini_set('url_rewriter.tags', 0);
 
-        $cookieDomain = $this->config->cookieDomain ?? '';
-        $serverName = $this->config->serverName;
-        if ($cookieDomain !== '' && strpos($serverName, '.') === false) {
-            throw new Horde_Exception(sprintf(
-                'Session cookies will not work because the server name "%s" '
-                . 'is a single-label hostname (no dot) but a cookie domain '
-                . '("%s") is configured. Browsers reject Domain= cookie '
-                . 'attributes on hostnames without a dot. This typically '
-                . 'affects http://localhost and other single-label hostnames. '
-                . 'Either: (1) use a fully qualified hostname like '
-                . 'http://horde.localhost or http://example.test, '
-                . '(2) clear $conf[\'cookie\'][\'domain\'] to let the browser '
-                . 'scope the cookie to the exact hostname, or '
-                . '(3) enable URL-based sessions by clearing '
-                . '$conf[\'session\'][\'use_only_cookies\'] (not recommended).',
-                $serverName,
+            $cookieDomain = $this->config->cookieDomain ?? '';
+            $serverName = $this->config->serverName;
+            if ($cookieDomain !== '' && strpos($serverName, '.') === false) {
+                throw new Horde_Exception(sprintf(
+                    'Session cookies will not work because the server name "%s" '
+                    . 'is a single-label hostname (no dot) but a cookie domain '
+                    . '("%s") is configured. Browsers reject Domain= cookie '
+                    . 'attributes on hostnames without a dot. This typically '
+                    . 'affects http://localhost and other single-label hostnames. '
+                    . 'Either: (1) use a fully qualified hostname like '
+                    . 'http://horde.localhost or http://example.test, '
+                    . '(2) clear $conf[\'cookie\'][\'domain\'] to let the browser '
+                    . 'scope the cookie to the exact hostname, or '
+                    . '(3) enable URL-based sessions by clearing '
+                    . '$conf[\'session\'][\'use_only_cookies\'] (not recommended).',
+                    $serverName,
+                    $cookieDomain,
+                ));
+            }
+
+            $timeout = $this->config->lifetime;
+            if ($timeout > 0) {
+                ini_set('session.gc_maxlifetime', (string) $timeout);
+            }
+
+            session_set_cookie_params(
+                $timeout,
+                $this->config->cookiePath,
                 $cookieDomain,
-            ));
+                $this->config->secure,
+                true,
+            );
+            session_cache_limiter(
+                $cacheLimiter ?? ($this->config->cacheLimiter ?? ''),
+            );
+            session_name(urlencode($this->config->cookieName));
+            if ($sessionId !== null && $sessionId !== '') {
+                session_id($sessionId);
+            }
+
+            if (!$this->handlerRegistered) {
+                session_set_save_handler($this->handler, true);
+                $this->handlerRegistered = true;
+            }
+
+            if (!$this->shutdownRegistered) {
+                Horde_Shutdown::add($this);
+                $this->shutdownRegistered = true;
+            }
+
+            $this->setupApplied = true;
         }
 
-        $timeout = $this->config->lifetime;
-        if ($timeout > 0) {
-            ini_set('session.gc_maxlifetime', (string) $timeout);
-        }
-
-        session_set_cookie_params(
-            $timeout,
-            $this->config->cookiePath,
-            $cookieDomain,
-            $this->config->secure,
-            true,
-        );
-        session_cache_limiter(
-            $cacheLimiter ?? ($this->config->cacheLimiter ?? ''),
-        );
-        session_name(urlencode($this->config->cookieName));
-        if ($sessionId !== null && $sessionId !== '') {
-            session_id($sessionId);
-        }
-
-        if (!$this->handlerRegistered) {
-            session_set_save_handler($this->handler, true);
-            $this->handlerRegistered = true;
-        }
-
-        if (!$this->shutdownRegistered) {
-            Horde_Shutdown::add($this);
-            $this->shutdownRegistered = true;
-        }
-
-        if ($start) {
+        if ($start && !$this->active) {
             $this->start();
             $this->initialiseTimestamps();
         }
@@ -226,6 +239,14 @@ class SessionLifecycle implements Horde_Shutdown_Task
      */
     public function start(): void
     {
+        if ($this->active) {
+            // Idempotency: session_start() emits a notice if called
+            // twice. The legacy shim and the modern setup() can both
+            // drive start(); guard so the second call is a coherent
+            // no-op rather than a runtime warning.
+            return;
+        }
+
         // Limit session ID to 32 bytes. Session IDs are NOT cryptographically
         // secure hashes; they are just a way to generate random strings.
         ini_set('session.hash_function', '0');

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -422,15 +422,30 @@ class SessionLifecycle implements Horde_Shutdown_Task
      * session_write_close(). For requests that never call close(), this
      * shutdown hook carries the modern data across to the persisted
      * session.
+     *
+     * Honours {@see HordeSession::isDestroyed()}: when a controller
+     * has marked the session destroyed but no synchronous executor
+     * (clean / destroy / clearAuth) has acted on the marker yet, the
+     * mirror is skipped. This catches the usage error where a legacy
+     * controller calls markDestroyed() without going through
+     * processFlags or a synchronous executor. Re-mirroring the
+     * about-to-be-destroyed payload would leave the row in a worse
+     * state than skipping. The marker stays set and the operator's
+     * next request through the modern middleware actually destroys
+     * the row.
      */
     public function shutdown(): void
     {
-        if ($this->active) {
-            $this->mirrorToSession();
+        if (!$this->active) {
+            return;
         }
+        if ($this->getSession()->isDestroyed()) {
+            return;
+        }
+        $this->mirrorToSession();
     }
 
-        /**
+    /**
      * Resolve the current {@see HordeSession} from the injector.
      *
      * Lazily looked up on every call because {@see clean()} and

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -336,11 +336,12 @@ class SessionLifecycle implements Horde_Shutdown_Task
     {
         $this->mirrorToSession();
         session_regenerate_id(true);
-        $regenAt = time() + $this->regenerateInterval();
         // The deadline is canonical on HordeSession at the top level.
         // The shim's addFinal() shutdown task mirrors HordeSession to
         // $_SESSION for legacy code that reads the superglobal directly.
-        $this->getSession()->setRegenerationDeadline($regenAt);
+        $this->getSession()->setRegenerationDeadline(
+            $this->config->nextRegenerationDeadline(),
+        );
 
         // Synchronous executor: clear pending intent so a downstream
         // processFlags() call sees a coherent no-op.
@@ -429,19 +430,7 @@ class SessionLifecycle implements Horde_Shutdown_Task
         }
     }
 
-    /**
-     * The deadline interval (seconds) between forced session ID rotations.
-     *
-     * Reads from {@see SessionConfig::$regenerateInterval}, which the
-     * factory builds from `session.regenerate_interval` with a 6-hour
-     * fallback (the legacy shim's default).
-     */
-    private function regenerateInterval(): int
-    {
-        return $this->config->regenerateInterval;
-    }
-
-    /**
+        /**
      * Resolve the current {@see HordeSession} from the injector.
      *
      * Lazily looked up on every call because {@see clean()} and
@@ -491,10 +480,10 @@ class SessionLifecycle implements Horde_Shutdown_Task
         }
 
         $now = time();
-        $regenAt = $now + $this->regenerateInterval();
-
         $session->setSessionBegin($now);
-        $session->setRegenerationDeadline($regenAt);
+        $session->setRegenerationDeadline(
+            $this->config->nextRegenerationDeadline($now),
+        );
     }
 
     /**

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -35,10 +35,9 @@ use Horde_Shutdown_Task;
  * `$_SESSION`, and optional {@see SessionSecret} re-keying on `clean()` /
  * `destroy()`.
  *
- * Registry-agnostic. The legacy stack's relogin auth-changed guard lives
- * on the `Horde_Session` shim, not here. SessionLifecycle is the engine
- * both flows leverage; it does not reach upward into Registry or sideways
- * into the shim.
+ * Registry-agnostic. SessionLifecycle is the engine both legacy and
+ * modern flows leverage. It does not reach upward into Registry or
+ * sideways into the shim.
  *
  * Two flavours of lifecycle methods coexist:
  *
@@ -226,10 +225,6 @@ class SessionLifecycle implements Horde_Shutdown_Task
      * Calls {@see session_start()}, marks the lifecycle active, and rebuilds
      * the modern {@see HordeSession} instance from the now-populated
      * `$_SESSION` payload.
-     *
-     * The relogin auth-changed guard for the legacy stack lives on the
-     * `Horde_Session` shim, where it belongs. SessionLifecycle is
-     * Registry-agnostic.
      */
     public function start(): void
     {

--- a/test/Unit/Auth/Jwt/JwtServiceFactoryTest.php
+++ b/test/Unit/Auth/Jwt/JwtServiceFactoryTest.php
@@ -14,6 +14,10 @@ use InvalidArgumentException;
 /**
  * Unit Test: JwtServiceFactory
  *
+ * The factory reads its configuration from `$GLOBALS['conf']` and never
+ * touches the injector. Each test owns its injector stub locally so
+ * the contract is explicit per test rather than implied by setUp.
+ *
  * Copyright 2026 The Horde Project (http://www.horde.org/)
  *
  * @category Horde
@@ -23,31 +27,21 @@ use InvalidArgumentException;
 #[CoversClass(JwtServiceFactory::class)]
 class JwtServiceFactoryTest extends TestCase
 {
-    private Injector $injector;
     private array $originalConf;
     private array $originalServer;
     private string $testSecretFile;
 
     protected function setUp(): void
     {
-        // Save original globals
         $this->originalConf = $GLOBALS['conf'] ?? [];
         $this->originalServer = $_SERVER;
-
-        // Create mock injector
-        $this->injector = $this->createMock(Injector::class);
-
-        // Create a temporary secret file for tests
         $this->testSecretFile = sys_get_temp_dir() . '/jwt_test_secret_' . uniqid();
     }
 
     protected function tearDown(): void
     {
-        // Restore original globals
         $GLOBALS['conf'] = $this->originalConf;
         $_SERVER = $this->originalServer;
-
-        // Clean up test secret file
         if (file_exists($this->testSecretFile)) {
             unlink($this->testSecretFile);
         }
@@ -57,6 +51,17 @@ class JwtServiceFactoryTest extends TestCase
     {
         file_put_contents($this->testSecretFile, $content);
         chmod($this->testSecretFile, 0o600);
+    }
+
+    /**
+     * Build an injector stub. The factory under test reads
+     * `$GLOBALS['conf']` directly and never calls any injector
+     * method, so a stub is the truthful descriptor of the test
+     * contract.
+     */
+    private function injectorStub(): Injector
+    {
+        return $this->createStub(Injector::class);
     }
 
     public function testCreateReturnsNullWhenJwtNotEnabled(): void
@@ -70,7 +75,7 @@ class JwtServiceFactoryTest extends TestCase
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertNull($result);
     }
@@ -82,7 +87,7 @@ class JwtServiceFactoryTest extends TestCase
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertNull($result);
     }
@@ -104,7 +109,7 @@ class JwtServiceFactoryTest extends TestCase
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }
@@ -119,13 +124,12 @@ class JwtServiceFactoryTest extends TestCase
                 'jwt' => [
                     'enabled' => true,
                     'secret_file' => $this->testSecretFile,
-                    // issuer not specified
                 ],
             ],
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }
@@ -140,13 +144,12 @@ class JwtServiceFactoryTest extends TestCase
                 'jwt' => [
                     'enabled' => true,
                     'secret_file' => $this->testSecretFile,
-                    // issuer not specified
                 ],
             ],
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }
@@ -161,13 +164,12 @@ class JwtServiceFactoryTest extends TestCase
                     'enabled' => true,
                     'secret_file' => $this->testSecretFile,
                     'issuer' => 'test.com',
-                    // TTL values not specified
                 ],
             ],
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }
@@ -187,7 +189,7 @@ class JwtServiceFactoryTest extends TestCase
         $this->expectExceptionMessage('JWT is enabled but secret file does not exist');
 
         $factory = new JwtServiceFactory();
-        $factory->create($this->injector);
+        $factory->create($this->injectorStub());
     }
 
     public function testCreateThrowsWhenSecretEmpty(): void
@@ -207,7 +209,7 @@ class JwtServiceFactoryTest extends TestCase
         $this->expectExceptionMessage('JWT secret file is empty');
 
         $factory = new JwtServiceFactory();
-        $factory->create($this->injector);
+        $factory->create($this->injectorStub());
     }
 
     public function testCreateThrowsWhenSecretTooShort(): void
@@ -227,7 +229,7 @@ class JwtServiceFactoryTest extends TestCase
         $this->expectExceptionMessage('JWT secret must be at least 256 bits (32 bytes)');
 
         $factory = new JwtServiceFactory();
-        $factory->create($this->injector);
+        $factory->create($this->injectorStub());
     }
 
     public function testCreateThrowsWhenSecret31Bytes(): void
@@ -247,7 +249,7 @@ class JwtServiceFactoryTest extends TestCase
         $this->expectExceptionMessage('JWT secret must be at least 256 bits (32 bytes)');
 
         $factory = new JwtServiceFactory();
-        $factory->create($this->injector);
+        $factory->create($this->injectorStub());
     }
 
     public function testCreateSucceedsWithExactly32ByteSecret(): void
@@ -265,7 +267,7 @@ class JwtServiceFactoryTest extends TestCase
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }
@@ -285,7 +287,7 @@ class JwtServiceFactoryTest extends TestCase
         ];
 
         $factory = new JwtServiceFactory();
-        $result = $factory->create($this->injector);
+        $result = $factory->create($this->injectorStub());
 
         $this->assertInstanceOf(JwtService::class, $result);
     }

--- a/test/Unit/Middleware/HordeSessionMiddlewareTest.php
+++ b/test/Unit/Middleware/HordeSessionMiddlewareTest.php
@@ -467,6 +467,132 @@ class HordeSessionMiddlewareTest extends TestCase
             'cookieDisabled must suppress Set-Cookie emission on rotation',
         );
     }
+
+    // ---------------------------------------------------------------
+    // Cookie attribute wire-format coverage
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testSetCookieReflectsSessionConfigAttributes(): void
+    {
+        // Construct a SessionConfig with non-default values for every
+        // attribute the middleware emits. Run the mint path. Assert the
+        // resulting Set-Cookie carries each attribute exactly. Locks
+        // the wire-format contract documented in
+        // doc/SESSION_HANDLING.md.
+        $config = new SessionConfig(
+            cookieName: 'CustomSid',
+            cookieDomain: '.example.com',
+            cookiePath: '/horde',
+            secure: true,
+            lifetime: 7200,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+            serverName: 'horde.example.com',
+        );
+
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler, $config)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $setCookie = $this->setCookieFor('CustomSid', $response);
+        self::assertNotNull($setCookie, 'mint must emit Set-Cookie');
+
+        // Cookie value: the session id mint produced. Verify shape
+        // through the request attribute.
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        self::assertInstanceOf(HordeSession::class, $session);
+        $sid = (string) $session->getId();
+
+        self::assertStringContainsString("CustomSid={$sid}", $setCookie);
+        self::assertStringContainsString('Max-Age=7200', $setCookie);
+        self::assertStringContainsString('Path=/horde', $setCookie);
+        self::assertStringContainsString('Domain=.example.com', $setCookie);
+        self::assertStringContainsString('Secure', $setCookie);
+        self::assertStringContainsString('HttpOnly', $setCookie);
+        self::assertStringContainsString('SameSite=Lax', $setCookie);
+    }
+
+    #[Test]
+    public function testSetCookieOmitsMaxAgeWhenLifetimeIsZero(): void
+    {
+        // lifetime=0 means "browser session cookie": no Max-Age, no
+        // Expires. The cookie disappears when the browser closes.
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+        );
+
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler, $config)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringNotContainsString('Max-Age', $setCookie);
+        self::assertStringNotContainsString('Expires', $setCookie);
+    }
+
+    #[Test]
+    public function testSetCookieOmitsDomainWhenNull(): void
+    {
+        // cookieDomain: null tells the browser to scope the cookie to
+        // the exact request host. The Domain= attribute must be
+        // absent on the wire.
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+        );
+
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler, $config)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringNotContainsString('Domain=', $setCookie);
+    }
+
+    #[Test]
+    public function testSetCookieOmitsSecureWhenSecureIsFalse(): void
+    {
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+        );
+
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler, $config)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringNotContainsString('Secure', $setCookie);
+    }
 }
 
 /**

--- a/test/Unit/Middleware/HordeSessionMiddlewareTest.php
+++ b/test/Unit/Middleware/HordeSessionMiddlewareTest.php
@@ -54,6 +54,21 @@ class HordeSessionMiddlewareTest extends TestCase
         );
     }
 
+    private function configCookieDisabled(string $cookieName = 'Horde'): SessionConfig
+    {
+        return new SessionConfig(
+            cookieName: $cookieName,
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: SessionConfig::DEFAULT_REGENERATE_INTERVAL,
+            cacheLimiter: null,
+            serverName: '',
+            cookieDisabled: true,
+        );
+    }
+
     private function realHandler(): SessionHandler
     {
         return new SessionHandler(
@@ -367,5 +382,130 @@ class HordeSessionMiddlewareTest extends TestCase
         // status 200. The middleware may have added Set-Cookie headers
         // but the body/status is preserved.
         self::assertSame(200, $response->getStatusCode());
+    }
+
+    // ---------------------------------------------------------------
+    // cookieDisabled mode: no Set-Cookie on any path
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testCookieDisabledOmitsSetCookieOnFreshSession(): void
+    {
+        $handler = $this->realHandler();
+        $response = $this->middleware($handler, $this->configCookieDisabled())->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertNull(
+            $this->setCookieFor('Horde', $response),
+            'cookieDisabled must suppress Set-Cookie when minting a fresh session',
+        );
+    }
+
+    #[Test]
+    public function testCookieDisabledOmitsSetCookieOnDestroy(): void
+    {
+        $handler = $this->realHandler();
+        $cfg = $this->configCookieDisabled();
+
+        // First request mints a session.
+        $first = $this->middleware($handler, $cfg)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        self::assertInstanceOf(HordeSession::class, $session);
+        $sid = (string) $session->getId();
+
+        // Mark the session destroyed and re-run middleware to exercise
+        // the destroy path. A named test handler that calls
+        // markDestroyed on the session attribute satisfies the no-
+        // anonymous-classes-in-DI guidance and also keeps the test
+        // body readable.
+        $destroyHandler = new MarkDestroyedHandler($this->defaultPayloadResponse);
+
+        $secondRequest = $this->requestFactory
+            ->createServerRequest('GET', '/test')
+            ->withCookieParams(['Horde' => $sid]);
+        $second = $this->middleware($handler, $cfg)->process($secondRequest, $destroyHandler);
+
+        self::assertNull(
+            $this->setCookieFor('Horde', $second),
+            'cookieDisabled must suppress clearing-cookie emission on destroy',
+        );
+    }
+
+    #[Test]
+    public function testCookieDisabledOmitsSetCookieOnRegenerate(): void
+    {
+        $handler = $this->realHandler();
+        $cfg = $this->configCookieDisabled();
+
+        $first = $this->middleware($handler, $cfg)->process(
+            $this->requestWithCookies([]),
+            $this->defaultPayloadHandler,
+        );
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        $sid = (string) $session->getId();
+
+        $regenHandler = new ScheduleRegenerationHandler($this->defaultPayloadResponse);
+
+        $secondRequest = $this->requestFactory
+            ->createServerRequest('GET', '/test')
+            ->withCookieParams(['Horde' => $sid]);
+        $second = $this->middleware($handler, $cfg)->process($secondRequest, $regenHandler);
+
+        self::assertNull(
+            $this->setCookieFor('Horde', $second),
+            'cookieDisabled must suppress Set-Cookie emission on rotation',
+        );
+    }
+}
+
+/**
+ * Test handler that marks the loaded session destroyed and returns a
+ * fixed response. Named (not anonymous) so DI / autoloader rules are
+ * satisfied.
+ */
+final class MarkDestroyedHandler implements \Psr\Http\Server\RequestHandlerInterface
+{
+    public function __construct(
+        private readonly \Psr\Http\Message\ResponseInterface $response,
+    ) {}
+
+    public function handle(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+    {
+        $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        if ($session instanceof HordeSession) {
+            $session->markDestroyed();
+        }
+        return $this->response;
+    }
+}
+
+/**
+ * Test handler that schedules session-id regeneration and returns a
+ * fixed response.
+ */
+final class ScheduleRegenerationHandler implements \Psr\Http\Server\RequestHandlerInterface
+{
+    public function __construct(
+        private readonly \Psr\Http\Message\ResponseInterface $response,
+    ) {}
+
+    public function handle(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+    {
+        $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        if ($session instanceof HordeSession) {
+            $session->scheduleRegeneration();
+        }
+        return $this->response;
     }
 }

--- a/test/Unit/Middleware/JwtAuthMiddlewareTest.php
+++ b/test/Unit/Middleware/JwtAuthMiddlewareTest.php
@@ -17,6 +17,12 @@ use InvalidArgumentException;
 /**
  * Unit Test: JwtAuthMiddleware
  *
+ * Each test builds its own mocks and asserts concrete expects() counts
+ * per the testing convention. The shared setUp() pattern was retired
+ * because PHPUnit 13 raises notices on mocks with no expectations
+ * configured, and the test contract is clearer when each test owns
+ * its collaborators outright.
+ *
  * Copyright 2026 The Horde Project (http://www.horde.org/)
  *
  * @category Horde
@@ -26,62 +32,72 @@ use InvalidArgumentException;
 #[CoversClass(JwtAuthMiddleware::class)]
 class JwtAuthMiddlewareTest extends TestCase
 {
-    private JwtService $jwtService;
-    private ServerRequestInterface $request;
-    private RequestHandlerInterface $handler;
-    private ResponseInterface $response;
-
-    protected function setUp(): void
-    {
-        $this->jwtService = $this->createMock(JwtService::class);
-        $this->request = $this->createMock(ServerRequestInterface::class);
-        $this->handler = $this->createMock(RequestHandlerInterface::class);
-        $this->response = $this->createMock(ResponseInterface::class);
-    }
-
     public function testProcessWithNoAuthHeaderAndNotRequired(): void
     {
-        // No Authorization header
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('');
 
-        $this->handler->expects($this->once())
+        // Required: false. Empty header. Middleware must NOT consult
+        // jwtService and must hand the request to the inner handler.
+        $jwtService->expects($this->never())->method('extractTokenFromHeader');
+        $jwtService->expects($this->never())->method('verifyAccessToken');
+
+        $handler->expects($this->once())
             ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
+            ->with($request)
+            ->willReturn($response);
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: false);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService, required: false);
+        $result = $middleware->process($request, $handler);
 
-        $this->assertSame($this->response, $result);
+        $this->assertSame($response, $result);
     }
 
     public function testProcessWithNoAuthHeaderAndRequired(): void
     {
-        // No Authorization header
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('');
 
-        $this->jwtService->expects($this->never())
-            ->method('extractTokenFromHeader');
+        // Required: true. Empty header. Middleware must short-circuit
+        // before touching jwtService and must NOT call the inner handler.
+        $jwtService->expects($this->never())->method('extractTokenFromHeader');
+        $jwtService->expects($this->never())->method('verifyAccessToken');
+        $handler->expects($this->never())->method('handle');
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: true);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService, required: true);
+        $result = $middleware->process($request, $handler);
 
-        // Should return 401 Unauthorized
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertEquals(401, $result->getStatusCode());
     }
 
     public function testProcessWithValidJwtToken(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('Bearer valid-jwt-token');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->with('Bearer valid-jwt-token')
             ->willReturn('valid-jwt-token');
 
@@ -91,107 +107,109 @@ class JwtAuthMiddlewareTest extends TestCase
             'iss' => 'horde.example.com',
         ]);
 
-        $this->jwtService->method('verifyAccessToken')
+        $jwtService->expects($this->once())
+            ->method('verifyAccessToken')
             ->with('valid-jwt-token')
             ->willReturn($verifiedJwt);
 
-        // Mock withAttribute calls
-        $requestWithJwt = $this->createMock(ServerRequestInterface::class);
-        $requestWithUserId = $this->createMock(ServerRequestInterface::class);
-        $requestWithClaims = $this->createMock(ServerRequestInterface::class);
-        $requestWithAuthType = $this->createMock(ServerRequestInterface::class);
+        // Middleware threads four request attributes through chained
+        // withAttribute calls (jwt, jwt_user_id, jwt_claims, auth_type).
+        // We don't care about the exact intermediate request objects,
+        // only that the chain reaches the handler. Returning $request
+        // from each withAttribute() lets the chain collapse onto itself.
+        $request->expects($this->exactly(4))
+            ->method('withAttribute')
+            ->willReturn($request);
 
-        $this->request->method('withAttribute')
-            ->willReturnCallback(function ($key, $value) use (
-                $requestWithJwt,
-                $requestWithUserId,
-                $requestWithClaims,
-                $requestWithAuthType
-            ) {
-                if ($key === 'jwt') {
-                    return $requestWithJwt;
-                }
-                if ($key === 'jwt_user_id') {
-                    return $requestWithUserId;
-                }
-                if ($key === 'jwt_claims') {
-                    return $requestWithClaims;
-                }
-                if ($key === 'auth_type') {
-                    return $requestWithAuthType;
-                }
-                return $this->request;
-            });
-
-        $requestWithJwt->method('withAttribute')->willReturn($requestWithUserId);
-        $requestWithUserId->method('withAttribute')->willReturn($requestWithClaims);
-        $requestWithClaims->method('withAttribute')->willReturn($requestWithAuthType);
-
-        $this->handler->expects($this->once())
+        $handler->expects($this->once())
             ->method('handle')
-            ->willReturn($this->response);
+            ->willReturn($response);
 
-        $middleware = new JwtAuthMiddleware($this->jwtService);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService);
+        $result = $middleware->process($request, $handler);
 
-        $this->assertSame($this->response, $result);
+        $this->assertSame($response, $result);
     }
 
     public function testProcessWithInvalidJwtTokenAndNotRequired(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('Bearer invalid-token');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->with('Bearer invalid-token')
             ->willReturn('invalid-token');
 
-        $this->jwtService->method('verifyAccessToken')
+        $jwtService->expects($this->once())
+            ->method('verifyAccessToken')
             ->with('invalid-token')
             ->willThrowException(new InvalidArgumentException('Token expired'));
 
-        // Should fall back to session auth
-        $this->handler->expects($this->once())
+        // Required: false. Verification failure falls back to session auth.
+        $handler->expects($this->once())
             ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
+            ->with($request)
+            ->willReturn($response);
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: false);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService, required: false);
+        $result = $middleware->process($request, $handler);
 
-        $this->assertSame($this->response, $result);
+        $this->assertSame($response, $result);
     }
 
     public function testProcessWithInvalidJwtTokenAndRequired(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('Bearer invalid-token');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->with('Bearer invalid-token')
             ->willReturn('invalid-token');
 
-        $this->jwtService->method('verifyAccessToken')
+        $jwtService->expects($this->once())
+            ->method('verifyAccessToken')
             ->with('invalid-token')
             ->willThrowException(new InvalidArgumentException('Token expired'));
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: true);
-        $result = $middleware->process($this->request, $this->handler);
+        // Required: true. Verification failure short-circuits with 401.
+        $handler->expects($this->never())->method('handle');
 
-        // Should return 401 Unauthorized
+        $middleware = new JwtAuthMiddleware($jwtService, required: true);
+        $result = $middleware->process($request, $handler);
+
         $this->assertInstanceOf(ResponseInterface::class, $result);
         $this->assertEquals(401, $result->getStatusCode());
     }
 
     public function testProcessWithHordeClaims(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('Bearer token-with-horde-claims');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->willReturn('token-with-horde-claims');
 
         $verifiedJwt = new VerifiedJwt('token-with-horde-claims', [
@@ -202,61 +220,82 @@ class JwtAuthMiddlewareTest extends TestCase
             ],
         ]);
 
-        $this->jwtService->method('verifyAccessToken')
+        $jwtService->expects($this->once())
+            ->method('verifyAccessToken')
             ->willReturn($verifiedJwt);
 
-        // Mock withAttribute chain
-        $mockRequest = $this->createMock(ServerRequestInterface::class);
-        $mockRequest->method('withAttribute')->willReturn($mockRequest);
-        $this->request->method('withAttribute')->willReturn($mockRequest);
+        // Five withAttribute calls when horde claims are present:
+        // jwt, jwt_user_id, jwt_claims, auth_type, plus
+        // jwt_horde_claims for the embedded horde namespace.
+        $request->expects($this->exactly(5))
+            ->method('withAttribute')
+            ->willReturn($request);
 
-        $this->handler->expects($this->once())
+        $handler->expects($this->once())
             ->method('handle')
-            ->willReturn($this->response);
+            ->willReturn($response);
 
-        $middleware = new JwtAuthMiddleware($this->jwtService);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService);
+        $result = $middleware->process($request, $handler);
 
-        $this->assertSame($this->response, $result);
+        $this->assertSame($response, $result);
     }
 
     public function testProcessWithNullTokenFromHeader(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('InvalidHeader');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->with('InvalidHeader')
             ->willReturn(null);
 
-        // Should fall back to session auth
-        $this->handler->expects($this->once())
+        // Header was non-empty so extractTokenFromHeader was consulted,
+        // but it returned null. With required:false the middleware
+        // forwards to session auth.
+        $jwtService->expects($this->never())->method('verifyAccessToken');
+
+        $handler->expects($this->once())
             ->method('handle')
-            ->with($this->request)
-            ->willReturn($this->response);
+            ->with($request)
+            ->willReturn($response);
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: false);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService, required: false);
+        $result = $middleware->process($request, $handler);
 
-        $this->assertSame($this->response, $result);
+        $this->assertSame($response, $result);
     }
 
     public function testProcessRequiredModePreventsSessionFallback(): void
     {
-        $this->request->method('getHeaderLine')
+        $jwtService = $this->createMock(JwtService::class);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $request->expects($this->once())
+            ->method('getHeaderLine')
             ->with('Authorization')
             ->willReturn('InvalidHeader');
 
-        $this->jwtService->method('extractTokenFromHeader')
+        $jwtService->expects($this->once())
+            ->method('extractTokenFromHeader')
             ->willReturn(null);
 
-        // Handler should NOT be called
-        $this->handler->expects($this->never())
-            ->method('handle');
+        // Required: true. Null token short-circuits with 401; the inner
+        // handler must not be called.
+        $jwtService->expects($this->never())->method('verifyAccessToken');
+        $handler->expects($this->never())->method('handle');
 
-        $middleware = new JwtAuthMiddleware($this->jwtService, required: true);
-        $result = $middleware->process($this->request, $this->handler);
+        $middleware = new JwtAuthMiddleware($jwtService, required: true);
+        $result = $middleware->process($request, $handler);
 
         $this->assertEquals(401, $result->getStatusCode());
     }

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -248,6 +248,30 @@ class HordeSessionTest extends TestCase
     }
 
     #[Test]
+    public function testSetSessionBeginRoundTrips(): void
+    {
+        $session = $this->createSession([]);
+        $session->setSessionBegin(1700000123);
+        $ts = $session->getSessionBegin();
+        self::assertNotNull($ts);
+        self::assertSame(1700000123, $ts->getTimestamp());
+        self::assertTrue($session->isDirty(), 'setSessionBegin must mark session dirty');
+    }
+
+    #[Test]
+    public function testGetSessionBeginIgnoresLegacyArrayShape(): void
+    {
+        // The pre-fix legacy shim wrote the begin slot via
+        // setScoped(BEGIN, '', $ts) which produces $data['_b'][''] = $ts.
+        // getSessionBegin only honours the canonical top-level int shape;
+        // sessions in the legacy shape return null from this getter
+        // until they are rewritten by setSessionBegin during the next
+        // initialiseTimestamps pass.
+        $session = $this->createSession(['_b' => ['' => 1700000000]]);
+        self::assertNull($session->getSessionBegin());
+    }
+
+    #[Test]
     public function testGetAuthenticatedApps(): void
     {
         $session = $this->createSession([

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -272,6 +272,36 @@ class HordeSessionTest extends TestCase
     }
 
     #[Test]
+    public function testGetRegenerationDeadlineRoundTrips(): void
+    {
+        $session = $this->createSession([]);
+        self::assertNull($session->getRegenerationDeadline());
+
+        $session->setRegenerationDeadline(1700001234);
+        self::assertSame(1700001234, $session->getRegenerationDeadline());
+        self::assertTrue($session->isDirty());
+    }
+
+    #[Test]
+    public function testGetRegenerationDeadlineFromInitialPayload(): void
+    {
+        $session = $this->createSession(['_r' => 1700001234]);
+        self::assertSame(1700001234, $session->getRegenerationDeadline());
+    }
+
+    #[Test]
+    public function testGetRegenerationDeadlineIgnoresLegacyArrayShape(): void
+    {
+        // Pre-fix writers used setScoped(REGENERATE_KEY, '', $ts) which
+        // produced $data['_r']['']. The reader was internally consistent
+        // (also via getScoped) but the shape disagreed with how _b is
+        // stored. Sessions still on disk in the legacy shape return null
+        // from this getter until the next setRegenerationDeadline pass.
+        $session = $this->createSession(['_r' => ['' => 1700001234]]);
+        self::assertNull($session->getRegenerationDeadline());
+    }
+
+    #[Test]
     public function testGetAuthenticatedApps(): void
     {
         $session = $this->createSession([

--- a/test/Unit/Session/SessionConfigFactoryTest.php
+++ b/test/Unit/Session/SessionConfigFactoryTest.php
@@ -169,4 +169,41 @@ class SessionConfigFactoryTest extends TestCase
         // assertion is documentary.
         self::assertSame('Horde', $config->cookieName);
     }
+
+    #[Test]
+    public function testNextRegenerationDeadlineHonoursExplicitNow(): void
+    {
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: 3600,
+            cacheLimiter: null,
+        );
+
+        self::assertSame(1700003600, $config->nextRegenerationDeadline(1700000000));
+    }
+
+    #[Test]
+    public function testNextRegenerationDeadlineDefaultsToNow(): void
+    {
+        $config = new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: 0,
+            regenerateInterval: 3600,
+            cacheLimiter: null,
+        );
+
+        $before = time();
+        $deadline = $config->nextRegenerationDeadline();
+        $after = time();
+
+        self::assertGreaterThanOrEqual($before + 3600, $deadline);
+        self::assertLessThanOrEqual($after + 3600, $deadline);
+    }
 }

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -196,7 +196,7 @@ class SessionLifecycleTest extends TestCase
     public function testRegenerationDueIsFalseWhenDeadlineInFuture(): void
     {
         $session = new HordeSession(new SessionId('rd-test'), []);
-        $session->setScoped('_r', '', time() + 3600);
+        $session->setRegenerationDeadline(time() + 3600);
         self::assertFalse($this->build(session: $session)->regenerationDue());
     }
 
@@ -204,15 +204,20 @@ class SessionLifecycleTest extends TestCase
     public function testRegenerationDueIsTrueWhenDeadlineInPast(): void
     {
         $session = new HordeSession(new SessionId('rd-test'), []);
-        $session->setScoped('_r', '', time() - 1);
+        $session->setRegenerationDeadline(time() - 1);
         self::assertTrue($this->build(session: $session)->regenerationDue());
     }
 
     #[Test]
-    public function testRegenerationDueIgnoresNonIntegerDeadlines(): void
+    public function testRegenerationDueIgnoresLegacyScopedShape(): void
     {
+        // Pre-fix _r writers used setScoped(REGENERATE_KEY, '', $ts).
+        // Sessions still on disk in that shape return null from
+        // getRegenerationDeadline and false from regenerationDue. Both
+        // shapes converge on the next regenerate() / initialiseTimestamps
+        // pass once the typed setters land.
         $session = new HordeSession(new SessionId('rd-test'), []);
-        $session->setScoped('_r', '', 'not-a-timestamp');
+        $session->setScoped('_r', '', time() - 1);
         self::assertFalse($this->build(session: $session)->regenerationDue());
     }
 
@@ -227,7 +232,7 @@ class SessionLifecycleTest extends TestCase
 
         try {
             $session = new HordeSession(new SessionId('rd-test'), []);
-            // No setScoped; HordeSession has no idea about the deadline.
+            // No setRegenerationDeadline; HordeSession has no idea about the deadline.
             self::assertFalse($this->build(session: $session)->regenerationDue());
         } finally {
             if ($previous === null) {

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -136,6 +136,44 @@ class SessionLifecycleTest extends TestCase
         $lifecycle->setup(start: false);
     }
 
+    #[Test]
+    public function testSetupIsIdempotentOnRepeatedCall(): void
+    {
+        // Build with FQDN config so the first setup() succeeds.
+        $lifecycle = $this->build([
+            'session' => ['name' => 'Horde'],
+            'cookie' => ['domain' => '.example.com'],
+            'server' => ['name' => 'horde.example.com'],
+        ]);
+
+        // setup() registers a Horde_Shutdown task which reaches for
+        // $GLOBALS['injector']. Provide a minimal stub to satisfy that
+        // path; the shutdown task itself never fires under unit test.
+        $injector = new Injector(new TopLevel());
+        $injector->setInstance('Horde_Shutdown', new \Horde_Shutdown());
+        $previousInjector = $GLOBALS['injector'] ?? null;
+        $GLOBALS['injector'] = $injector;
+
+        try {
+            $lifecycle->setup(start: false);
+
+            // First call set the flag.
+            $r = new \ReflectionProperty(SessionLifecycle::class, 'setupApplied');
+            $r->setAccessible(true);
+            self::assertTrue($r->getValue($lifecycle));
+
+            // Second call must not throw and must not mutate state.
+            $lifecycle->setup(start: false);
+            self::assertTrue($r->getValue($lifecycle));
+        } finally {
+            if ($previousInjector === null) {
+                unset($GLOBALS['injector']);
+            } else {
+                $GLOBALS['injector'] = $previousInjector;
+            }
+        }
+    }
+
     // The happy paths through setup() (FQDN hostname, empty cookie domain)
     // touch session_set_cookie_params, session_set_save_handler and the
     // global Horde_Shutdown registry. They are covered in the integration

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -298,6 +298,45 @@ class SessionLifecycleTest extends TestCase
         }
     }
 
+    #[Test]
+    public function testShutdownSkipsMirrorWhenSessionMarkedDestroyed(): void
+    {
+        // Usage error scenario: a controller calls markDestroyed()
+        // without going through a synchronous executor, so the marker
+        // is still pending when the request-shutdown task fires. The
+        // shutdown task must NOT mirror the about-to-be-destroyed
+        // payload back into $_SESSION; otherwise the session row gets
+        // re-persisted with stale data the controller already
+        // declared dead.
+        $session = new HordeSession(new SessionId('destroyed-mirror'), []);
+        $session->setScoped('horde', 'auth/userId', 'alice');
+        $session->markDestroyed();
+
+        $lifecycle = $this->build(session: $session);
+
+        $r = new \ReflectionProperty($lifecycle, 'active');
+        $r->setAccessible(true);
+        $r->setValue($lifecycle, true);
+
+        $previous = $_SESSION ?? null;
+        $_SESSION = ['untouched' => 'sentinel'];
+
+        try {
+            $lifecycle->shutdown();
+            self::assertSame(
+                ['untouched' => 'sentinel'],
+                $_SESSION,
+                'shutdown must not mirror when isDestroyed() is set'
+            );
+        } finally {
+            if ($previous === null) {
+                unset($_SESSION);
+            } else {
+                $_SESSION = $previous;
+            }
+        }
+    }
+
     // ---------------------------------------------------------------
     // processFlags()
     //


### PR DESCRIPTION
- **refactor(registry): clearAuth resolves SessionLifecycle via injector**
- **feat(session): add cookieDisabled mode to SessionConfig**
- **feat(session): make SessionLifecycle::setup idempotent**
- **fix(session): converge _b begin-slot shape across all writers**
