### PR TITLE
feat(session): clearScope helpers + deadline-elapsed rotation test

### DIFF
--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -725,11 +725,7 @@ class Horde_Registry implements Horde_Shutdown_Task
 
         $this->applications = $this->_apiList = $this->_cache['conf'] = $this->_cache['ob'] = $this->_interfaces = [];
 
-        foreach ($session->keysForApp('horde') as $key) {
-            if (str_starts_with($key, 'nls/') || str_starts_with($key, 'registry/')) {
-                $session->removeScoped('horde', $key);
-            }
-        }
+        $session->clearScopeWithPrefixes('horde', ['nls/', 'registry/']);
         $session->removeScoped('horde', self::REGISTRY_CACHE);
 
         $this->_loadApplications();
@@ -2255,14 +2251,7 @@ class Horde_Registry implements Horde_Shutdown_Task
             'auth_app_state_reason/',
             'auth_app_state_detail/',
         ];
-        foreach ($session->keysForApp('horde') as $key) {
-            foreach ($authPrefixes as $prefix) {
-                if (str_starts_with($key, $prefix)) {
-                    $session->removeScoped('horde', $key);
-                    continue 2;
-                }
-            }
-        }
+        $session->clearScopeWithPrefixes('horde', $authPrefixes);
 
         $this->_cache['auth'] = null;
         $this->_cache['existing'] = $this->_cache['isauth'] = [];
@@ -2306,9 +2295,7 @@ class Horde_Registry implements Horde_Shutdown_Task
         if ($this->isAuthenticated(['app' => $app, 'notransparent' => true])) {
             $this->callAppMethod($app, 'logout');
             // Wipe the app's entire session scope.
-            foreach ($session->keysForApp($app) as $key) {
-                $session->removeScoped($app, $key);
-            }
+            $session->clearScope($app);
             // Drop the credentials slots via the canonical store.
             $this->_credentialStore()->clear($app);
         }
@@ -3185,11 +3172,7 @@ class Horde_Registry implements Horde_Shutdown_Task
         }
 
         $session = $GLOBALS['injector']->getInstance(HordeSession::class);
-        foreach ($session->keysForApp('horde') as $key) {
-            if (str_starts_with($key, 'nls/')) {
-                $session->removeScoped('horde', $key);
-            }
-        }
+        $session->clearScopeWithPrefixes('horde', ['nls/']);
     }
 
     /**

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -246,6 +246,59 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
         return array_keys($this->data[$app]);
     }
 
+    /**
+     * Remove every key in the given application scope.
+     *
+     * Equivalent to iterating {@see keysForApp} and calling
+     * {@see removeScoped} for each key. Marks the session dirty when
+     * the scope had any keys. Cheaper to read at the call site than
+     * the explicit loop.
+     */
+    public function clearScope(string $app): void
+    {
+        if (!isset($this->data[$app]) || !is_array($this->data[$app])) {
+            return;
+        }
+        unset($this->data[$app]);
+        if (isset($this->data[self::ENCRYPTED_KEY][$app])) {
+            unset($this->data[self::ENCRYPTED_KEY][$app]);
+            if (empty($this->data[self::ENCRYPTED_KEY])) {
+                unset($this->data[self::ENCRYPTED_KEY]);
+            }
+        }
+        $this->dirty = true;
+    }
+
+    /**
+     * Remove every key in the given application scope whose name
+     * starts with any of the supplied prefixes.
+     *
+     * Centralises the filter-and-remove pattern used by Registry's
+     * auth-key sweeps, the locale reset, and the registry-cache
+     * teardown. Marks the session dirty when at least one key was
+     * removed.
+     *
+     * @param array<int, string> $prefixes Prefixes to match. Empty
+     *                                     array is a no-op.
+     */
+    public function clearScopeWithPrefixes(string $app, array $prefixes): void
+    {
+        if ($prefixes === []) {
+            return;
+        }
+        if (!isset($this->data[$app]) || !is_array($this->data[$app])) {
+            return;
+        }
+        foreach ($this->keysForApp($app) as $key) {
+            foreach ($prefixes as $prefix) {
+                if (str_starts_with($key, $prefix)) {
+                    $this->removeScoped($app, $key);
+                    continue 2;
+                }
+            }
+        }
+    }
+
     // ---------------------------------------------------------------
     // SessionMetaInterface
     // ---------------------------------------------------------------

--- a/test/Unit/Middleware/HordeSessionMiddlewareTest.php
+++ b/test/Unit/Middleware/HordeSessionMiddlewareTest.php
@@ -312,6 +312,65 @@ class HordeSessionMiddlewareTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // Deadline-elapsed rotation: a controller that consults the
+    // regeneration deadline and schedules a rotation when it has
+    // passed. End-to-end against a real BuiltinBackend.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testDeadlineElapsedTriggersRotationAndRefreshesDeadline(): void
+    {
+        $handler = $this->realHandler();
+        $existing = $handler->create();
+        $existing->setScoped('horde', 'auth/userId', 'alice');
+        // Drive _r into the past so the deadline check fires.
+        $existing->setRegenerationDeadline(time() - 60);
+        $handler->save($existing);
+        $oldSid = (string) $existing->getId();
+
+        // Controller pattern: read the deadline marker, schedule a
+        // rotation if it has elapsed. The middleware acts on the
+        // marker on response emit.
+        $this->defaultPayloadHandler = $this->createStub(\Psr\Http\Server\RequestHandlerInterface::class);
+        $this->defaultPayloadHandler->method('handle')->willReturnCallback(function ($request) {
+            $this->recentlyHandledRequest = $request;
+            $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+            $deadline = $session->getRegenerationDeadline();
+            if ($deadline !== null && time() >= $deadline) {
+                $session->scheduleRegeneration();
+            }
+            return $this->defaultPayloadResponse;
+        });
+
+        $response = $this->middleware($handler)->process(
+            $this->requestWithCookies(['Horde' => $oldSid]),
+            $this->defaultPayloadHandler,
+        );
+
+        // Old row is gone.
+        self::assertNull($handler->load($existing->getId()));
+
+        // Set-Cookie carries a different id.
+        $setCookie = $this->setCookieFor('Horde', $response);
+        self::assertNotNull($setCookie);
+        self::assertStringNotContainsString($oldSid, $setCookie);
+
+        preg_match('/^Horde=([^;]+);/', $setCookie, $m);
+        $newSid = $m[1];
+        $reloaded = $handler->load(new \Horde\SessionHandler\SessionId($newSid));
+        self::assertInstanceOf(HordeSession::class, $reloaded);
+
+        // Payload preserved.
+        self::assertSame('alice', $reloaded->getScoped('horde', 'auth/userId'));
+
+        // Deadline refreshed: new row's _r is in the future, anchored
+        // at finaliseRegenerated's nextRegenerationDeadline call.
+        $newDeadline = $reloaded->getRegenerationDeadline();
+        self::assertNotNull($newDeadline);
+        self::assertGreaterThan(time(), $newDeadline);
+    }
+
+    // ---------------------------------------------------------------
     // JwtSessionLoader already populated the attribute
     // ---------------------------------------------------------------
 

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -696,4 +696,67 @@ class HordeSessionTest extends TestCase
         self::assertFalse($session->shouldRegenerate());
         self::assertFalse($session->isDestroyed());
     }
+
+    // ---------------------------------------------------------------
+    // clearScope() / clearScopeWithPrefixes()
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testClearScopeWipesEntireApp(): void
+    {
+        $session = $this->createSession();
+        $session->setScoped('imp', 'auth/userId', 'alice');
+        $session->setScoped('imp', 'mailbox', 'INBOX');
+        $session->setScoped('horde', 'auth/userId', 'alice');
+
+        $session->clearScope('imp');
+
+        self::assertSame([], $session->keysForApp('imp'));
+        // horde scope must remain untouched.
+        self::assertSame(['auth/userId'], $session->keysForApp('horde'));
+        self::assertTrue($session->isDirty());
+    }
+
+    #[Test]
+    public function testClearScopeIsNoOpWhenScopeAbsent(): void
+    {
+        $session = $this->createSession();
+        $session->clearScope('never-touched');
+        self::assertFalse($session->isDirty());
+    }
+
+    #[Test]
+    public function testClearScopeWithPrefixesRemovesMatching(): void
+    {
+        $session = $this->createSession();
+        $session->setScoped('horde', 'auth/userId', 'alice');
+        $session->setScoped('horde', 'auth_app/imp', 'imp-creds');
+        $session->setScoped('horde', 'nls/curr_default', 'en_US');
+        $session->setScoped('horde', 'theme', 'default');
+
+        $session->clearScopeWithPrefixes('horde', ['auth/', 'auth_app/']);
+
+        $remaining = $session->keysForApp('horde');
+        sort($remaining);
+        self::assertSame(['nls/curr_default', 'theme'], $remaining);
+    }
+
+    #[Test]
+    public function testClearScopeWithPrefixesEmptyArrayIsNoOp(): void
+    {
+        $session = $this->createSession();
+        $session->setScoped('horde', 'auth/userId', 'alice');
+
+        $session->clearScopeWithPrefixes('horde', []);
+
+        self::assertSame(['auth/userId'], $session->keysForApp('horde'));
+    }
+
+    #[Test]
+    public function testClearScopeWithPrefixesIsNoOpWhenScopeAbsent(): void
+    {
+        $session = $this->createSession();
+        $session->clearScopeWithPrefixes('never-touched', ['auth/']);
+        self::assertFalse($session->isDirty());
+    }
 }


### PR DESCRIPTION
Two open items from the session-handling backlog folded into one PR.

**#8: HordeSession::clearScope and clearScopeWithPrefixes**

Two new helpers on HordeSession replace the keysForApp + removeScoped loop pattern used in four places in Registry. clearScope wipes the entire app scope (plus matching encrypted-key entries). clearScopeWithPrefixes removes only keys whose names begin with one of the supplied prefixes.

Converted call sites:
- pushApp's nls/ + registry/ teardown
- clearAuth's seven auth* prefix sweep (PR Core#153 inline loop)
- clearAuthApp's full-scope wipe
- setLanguageEnvironment's nls/ reset

Five new unit tests on HordeSessionTest.

**#5: deadline-elapsed rotation end-to-end test**

Locks the contract for a controller that consults HordeSession::getRegenerationDeadline and schedules rotation when the deadline has elapsed. Real BuiltinBackend, real middleware. Asserts old row is gone, new row preserves payload and the new _r deadline is in the future.

**Smoke**

Login → whoami → logout → 401 round-trip on the live install: clean. 1419 tests pass; the 12 SessionHandlerFactoryTest errors that were present at branch creation cleared once the local composer.lock picked up SessionHandler#12 (separate workflow concern, not in this diff).