### PR TITLE
fix(core): improve MeetingResponse for EAS 16 LongId and recurring instance

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3165,7 +3165,9 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      *   - response:  The user's response to the request. One of the response
      *                code constants.
      *   - folderid:  The collection id that contains the meeting request.
-     *   -
+     *   - longid:    (EAS 16) mailbox:uid when responding from a search result.
+     *   - instanceid: (EAS 14.1+) Recurring instance UTC timestamp.
+     *   - sendresponse: (EAS 16) Optional iTip reply email body/flag.
      *
      * @return string  The UID of any created calendar entries, otherwise false.
      * @throws Horde_ActiveSync_Exception, Horde_Exception_NotFound
@@ -3173,6 +3175,18 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     public function meetingResponse(array $response)
     {
         global $injector;
+
+        if (!empty($response['longid']) && strpos($response['longid'], ':') !== false) {
+            [$mailbox, $uid] = explode(':', $response['longid'], 2);
+            if ($mailbox !== '' && $uid !== '') {
+                if (empty($response['folderid'])) {
+                    $response['folderid'] = $mailbox;
+                }
+                if (empty($response['requestid'])) {
+                    $response['requestid'] = $uid;
+                }
+            }
+        }
 
         if (empty($response['folderid']) || empty($response['requestid'])
             || empty($response['response'])) {


### PR DESCRIPTION
# Improve MeetingResponse handling for EAS 16 clients

**Package:** `horde/core`  
**Author:** Torben Dannhauer <torben@dannhauer.de>

## Summary

Enhances `Horde_Core_ActiveSync_Driver::meetingResponse()` for EAS 14.1+ / EAS 16 iOS clients: resolve `search:LongId`, honor `InstanceId` for recurring meetings, and fix iTip reply sender identity.

## Motivation

When an iOS user accepts or declines a meeting invitation:

1. **EAS 16 LongId** — clients may send `search:LongId` (`mailbox:uid`) instead of separate `FolderId` + `RequestId`. Horde rejected these requests as invalid.
2. **Recurring instances** — EAS 14.1+ sends `InstanceId` for single occurrences; Horde must set `RECURRENCE-ID` before importing the vEvent.
3. **iTip reply email** — when `SendResponse` is enabled, the code used `$vEvent->creator` to build the sender identity. `Horde_Icalendar_Vevent` has no `creator` property, causing PHP errors and failed organizer notifications.

## Changes

### `lib/Horde/Core/ActiveSync/Driver.php` — `meetingResponse()` only

- Resolve `longid` (`mailbox:uid`) into `folderid` / `requestid` before validation
- Apply `InstanceId` as `RECURRENCE-ID` on the parsed vEvent (EAS ≥ 14.1)
- Reuse `$ident` (authenticated ActiveSync user) for `Horde_Itip_Resource_Identity` instead of `$vEvent->creator`

## Files

| File | Methods / area |
|------|----------------|
| `lib/Horde/Core/ActiveSync/Driver.php` | `meetingResponse()` only |

## Cherry-pick warning

`Driver.php` may also contain **Find command** changes (`getFindResults()`, `resolveLongIdForUid()`). Those belong in a separate Find PR — include only the `meetingResponse()` hunks here.

## Dependencies

- `horde/activesync`: `MeetingResponse` request parser (stores `longid`, `instanceid`, `sendresponse`) — already upstream
- Recommended: `horde/kronolith` + `horde/activesync` invitation MIME PRs for full end-to-end RSVP

## Test plan

- [ ] Receive a Kronolith invitation on an EAS 16 iPhone account
- [ ] Accept from iOS **Calendar** app (pending invitation banner)
- [ ] Confirm ActiveSync log shows `MeetingResponse` with HTTP 200
- [ ] Confirm event appears in Kronolith with `PARTSTAT=ACCEPTED`
- [ ] With `SendResponse`, confirm organizer receives iTip REPLY without PHP errors
- [ ] For a recurring series invitation, accept one instance; verify `RECURRENCE-ID` is applied

## Commit message

```
fix(core): improve MeetingResponse for EAS 16 LongId and recurring instances

Resolve search:LongId into folder/request ids, apply InstanceId as
RECURRENCE-ID for recurring meetings, and use the authenticated user
identity when sending iTip reply mail from MeetingResponse.
```
