### PR TITLE
refactor: shrink base factory class to accept "Injector" (of which Horde_Injector is a duck type)

### DIFF
--- a/lib/Horde/Core/Factory/Injector.php
+++ b/lib/Horde/Core/Factory/Injector.php
@@ -34,6 +34,6 @@ abstract class Horde_Core_Factory_Injector extends Horde_Core_Factory_Base
     /**
      * @throws Horde_Exception
      */
-    abstract public function create(Horde_Injector|Injector $injector);
+    abstract public function create(Injector $injector);
 
 }


### PR DESCRIPTION
Both "Injector" and "Horde_Injector|Injector" will be valid in child classes.
Single "Horde_Injector" will not work.
