### PR TITLE
feat(activesync): EAS 16.0 draft sync and calendar initial-sync in co…

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -90,13 +90,14 @@ class Horde_Core_ActiveSync_Connector
      * @param integer $endstamp      The end of time period
      * @param string  $calendar      The calendar id. If null, uses multiplexed.
      *                               @since 2.12.0
+     * @param array   $options       Options passed to listUids().
      *
      * @return array
      */
-    public function calendar_listUids($startstamp, $endstamp, $calendar)
+    public function calendar_listUids($startstamp, $endstamp, $calendar, array $options = [])
     {
         try {
-            return $this->_registry->calendar->listUids($calendar, $startstamp, $endstamp);
+            return $this->_registry->calendar->listUids($calendar, $startstamp, $endstamp, $options);
         } catch (Exception $e) {
             return [];
         }
@@ -132,32 +133,9 @@ class Horde_Core_ActiveSync_Connector
      * @param string $calendar                               The calendar id.
      *                                                       @since 2.12.0
      *
-     * @return string  The event's UID.
+     * @return array  uid and atchash keys.
      */
     public function calendar_import(
-        Horde_ActiveSync_Message_Appointment $content,
-        $calendar = null
-    ) {
-        return $this->_registry->calendar->import(
-            $content,
-            'activesync',
-            $calendar
-        );
-    }
-
-    /**
-     * Version of calendar_import capable of returning an array of values.
-     * Needed for EAS 16 support in order to deal with the fact that
-     * attachment actions are handled within the Message object.
-     *
-     * @param Horde_ActiveSync_Message_Appointment $content  The event content
-     * @param string $calendar                               The calendar id.
-     *
-     * @return  array
-     * @since  2.27.0
-     * @todo  Remove for H6 and make calendar_import return this structure.
-     */
-    public function calendar_import16(
         Horde_ActiveSync_Message_Appointment $content,
         $calendar = null
     ) {
@@ -169,13 +147,23 @@ class Horde_Core_ActiveSync_Connector
         );
 
         if (!is_array($result)) {
-            $result = [
+            return [
                 'uid' => $result,
                 'atchash' => false,
             ];
         }
 
         return $result;
+    }
+
+    /**
+     * @deprecated Use calendar_import()
+     */
+    public function calendar_import16(
+        Horde_ActiveSync_Message_Appointment $content,
+        $calendar = null
+    ) {
+        return $this->calendar_import($content, $calendar);
     }
 
     /**

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -1137,7 +1137,14 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     $startstamp = (int) $cutoffdate;
                     $endstamp = time() + 32140800; //60 * 60 * 24 * 31 * 12 == one year
                     try {
-                        $changes['add'] = $this->_connector->calendar_listUids($startstamp, $endstamp, $server_id);
+                        $changes['add'] = $this->_connector->calendar_listUids(
+                            $startstamp,
+                            $endstamp,
+                            $server_id,
+                            [
+                                'hide_exceptions' => $this->_version < Horde_ActiveSync::VERSION_SIXTEEN,
+                            ]
+                        );
                     } catch (Horde_Exception_AuthenticationFailure $e) {
                         $this->_endBuffer();
                         throw $e;
@@ -1416,12 +1423,21 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             ];
         }
 
-        // For CLASS_EMAIL, all changes are a change in flags, categories or
-        // softdelete. @todo: draft edits?
+        // For CLASS_EMAIL, flag/category changes are exported separately.
+        // Draft folder content changes use CHANGE_TYPE_DRAFT for EAS 16.0+.
         if ($folder->collectionClass() == Horde_ActiveSync::CLASS_EMAIL) {
             $flags = $folder->flags();
             $categories = $folder->categories();
+            $isDrafts = $this->_version >= Horde_ActiveSync::VERSION_SIXTEEN
+                && $folder->serverid() == $this->getSpecialFolderNameByType(self::SPECIAL_DRAFTS);
             foreach ($changes['modify'] as $uid) {
+                if ($isDrafts) {
+                    $results[] = [
+                        'id' => $uid,
+                        'type' => Horde_ActiveSync::CHANGE_TYPE_DRAFT,
+                    ];
+                    continue;
+                }
                 if (!isset($flags[$uid])) {
                     continue;
                 }
@@ -2127,8 +2143,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             case Horde_ActiveSync::CLASS_CALENDAR:
                 if (!$id) {
                     try {
-                        // @todo, remove 'import16' hack for H6
-                        $results  = $this->_connector->calendar_import16($message, $server_id);
+                        $results = $this->_connector->calendar_import($message, $server_id);
                     } catch (Horde_Exception $e) {
                         $this->_logger->err($e->getMessage());
                         $this->_endBuffer();
@@ -2240,13 +2255,56 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     if ($this->_version >= Horde_ActiveSync::VERSION_SIXTEEN
                         && $folderid == $this->getSpecialFolderNameByType(self::SPECIAL_DRAFTS)) {
 
-                        // @todo Does this only happen on drafts?
+                        // POOMMAIL2:Send on a Drafts-folder Sync Add/Modify
+                        // sends via SMTP and removes the draft (not SendMail).
                         if ($message->send) {
-                            $this->_logger->err('NOT YET SUPPORTED.');
-                            return $stat;
+                            $draft_folder = $this->getSpecialFolderNameByType(
+                                self::SPECIAL_DRAFTS
+                            );
+                            $draft = new Horde_Core_ActiveSync_Mail_Draft(
+                                $this->_imap,
+                                $this->_user,
+                                $this->_version
+                            );
+                            $draft->setDraftMessage($message);
+                            if ($id) {
+                                try {
+                                    $draft->getExistingDraftMessage(
+                                        $draft_folder,
+                                        $id
+                                    );
+                                } catch (Horde_ActiveSync_Exception $e) {
+                                    // Stale UID from client; treat as new.
+                                }
+                            }
+
+                            try {
+                                $this->sendMail(
+                                    $draft->toRfc822Stream(),
+                                    false,
+                                    false,
+                                    false,
+                                    true
+                                );
+                            } catch (Horde_ActiveSync_Exception $e) {
+                                $this->_logger->err($e->getMessage());
+                                $this->_endBuffer();
+                                return false;
+                            }
+
+                            if ($id) {
+                                $this->deleteMessage($draft_folder, [$id]);
+                            }
+
+                            $this->_endBuffer();
+                            return [
+                                'id' => $id ?: 0,
+                                'mod' => 0,
+                                'flags' => [],
+                            ];
                         }
 
-                        // Are we addding/changing a draft email?
+                        // Adding or changing a draft email.
                         if ($message->airsyncbasebody) {
                             $draft_folder = $this->getSpecialFolderNameByType(
                                 self::SPECIAL_DRAFTS

--- a/lib/Horde/Core/ActiveSync/Mail/Draft.php
+++ b/lib/Horde/Core/ActiveSync/Mail/Draft.php
@@ -74,9 +74,59 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
      */
     public function append($folderid)
     {
-        // Init
-        $atc_map = [];
+        [$base, $atc_map] = $this->_buildDraftMime();
+        $stream = $base->toString([
+            'stream' => true,
+            'headers' => $this->_headers->toString(),
+        ]);
+
+        $new_uid = $this->_imap->appendMessage(
+            $folderid,
+            $stream,
+            ['\draft', '\seen']
+        );
+
         $atc_hash = [];
+        foreach ($base as $part) {
+            if ($part->isAttachment()
+                && !empty($atc_map[$part->getName()])) {
+                $atc_hash['add'][$atc_map[$part->getName()]] = $folderid . ':' . $new_uid . ':' . $part->getMimeId();
+            }
+        }
+
+        // If we pulled down an existing Draft, delete it now since the
+        // new one will replace it.
+        if (!empty($this->_imapMessage)) {
+            $this->_imap->deleteMessages([$this->_draftUid], $folderid);
+        }
+
+        return [
+            'uid' => $new_uid,
+            'atchash' => $atc_hash,
+        ];
+    }
+
+    /**
+     * Build the RFC822 representation of the current draft.
+     *
+     * @return resource  Stream containing the full RFC822 message.
+     */
+    public function toRfc822Stream()
+    {
+        [$base] = $this->_buildDraftMime();
+
+        return $base->toString([
+            'stream' => true,
+            'headers' => $this->_headers->toString(),
+        ]);
+    }
+
+    /**
+     * @return array{0: Horde_Mime_Part, 1: array<string, string>}
+     */
+    protected function _buildDraftMime()
+    {
+        $atc_map = [];
 
         // Create the wrapper part.
         $base = new Horde_Mime_Part();
@@ -108,34 +158,7 @@ class Horde_Core_ActiveSync_Mail_Draft extends Horde_Core_ActiveSync_Mail
             $atc_map[$atc->displayname] = $atc->clientid;
         }
 
-        $stream = $base->toString([
-            'stream' => true,
-            'headers' => $this->_headers->toString(),
-        ]);
-
-        $new_uid = $this->_imap->appendMessage(
-            $folderid,
-            $stream,
-            ['\draft', '\seen']
-        );
-
-        foreach ($base as $part) {
-            if ($part->isAttachment()
-                && !empty($atc_map[$part->getName()])) {
-                $atc_hash['add'][$atc_map[$part->getName()]] = $folderid . ':' . $new_uid . ':' . $part->getMimeId();
-            }
-        }
-
-        // If we pulled down an existing Draft, delete it now since the
-        // new one will replace it.
-        if (!empty($this->_imapMessage)) {
-            $this->_imap->deleteMessages([$this->_draftUid], $folderid);
-        }
-
-        return [
-            'uid' => $new_uid,
-            'atchash' => $atc_hash,
-        ];
+        return [$base, $atc_map];
     }
 
     /**

--- a/test/Unit/ActiveSync/DraftSyncTest.php
+++ b/test/Unit/ActiveSync/DraftSyncTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author   Torben Dannhauer
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Core\Test\Unit\ActiveSync;
+
+use Horde\Core\Test\Support\MockSkipConstructorTrait;
+use Horde_ActiveSync;
+use Horde_ActiveSync_Imap_Adapter;
+use Horde_ActiveSync_Imap_Message;
+use Horde_ActiveSync_Message_Mail;
+use Horde_Core_ActiveSync_Mail_Draft;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for EAS 16.0 draft sync helpers in Horde_Core_ActiveSync_Mail_Draft.
+ *
+ * @author   Torben Dannhauer
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ * @subpackage UnitTests
+ */
+#[CoversClass(Horde_Core_ActiveSync_Mail_Draft::class)]
+class DraftSyncTest extends TestCase
+{
+    use MockSkipConstructorTrait;
+
+    public function testToRfc822StreamIncludesPlainTextDraftBody(): void
+    {
+        if (!class_exists('Horde_ActiveSync_Message_Mail')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $draft = $this->createDraftWithoutIdentity();
+        $draft->setDraftMessage($this->createClientDraftMessage(
+            'PHASE-A-ONLY',
+            'EAS16-DRAFT-EDIT'
+        ));
+
+        $stream = $draft->toRfc822Stream();
+        $this->assertIsResource($stream);
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertStringContainsString('PHASE-A-ONLY', $contents);
+        $this->assertStringContainsString('EAS16-DRAFT-EDIT', $contents);
+        $this->assertStringContainsString('test@dannhauer.de', $contents);
+    }
+
+    public function testAppendReplacesExistingDraftByDeletingOldUid(): void
+    {
+        if (!class_exists('Horde_ActiveSync_Message_Mail')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $folder = 'INBOX/Drafts';
+        $oldUid = 55317;
+        $newUid = 55318;
+
+        $imapMessage = $this->getMockSkipConstructor(
+            Horde_ActiveSync_Imap_Message::class,
+            ['getStructure']
+        );
+        $imapMessage->method('getStructure')->willReturn([]);
+
+        $imap = $this->getMockSkipConstructor(
+            Horde_ActiveSync_Imap_Adapter::class,
+            ['getImapMessage', 'appendMessage', 'deleteMessages']
+        );
+        $imap->expects($this->once())
+            ->method('getImapMessage')
+            ->with($folder, $oldUid)
+            ->willReturn([$oldUid => $imapMessage]);
+        $imap->expects($this->once())
+            ->method('appendMessage')
+            ->with(
+                $folder,
+                $this->isType('resource'),
+                ['\draft', '\seen']
+            )
+            ->willReturn($newUid);
+        $imap->expects($this->once())
+            ->method('deleteMessages')
+            ->with([$oldUid], $folder);
+
+        $draft = $this->createDraftWithoutIdentity($imap);
+        $draft->getExistingDraftMessage($folder, $oldUid);
+        $draft->setDraftMessage($this->createClientDraftMessage(
+            'PHASE-A-ONLY PHASE-B-EDITED',
+            'EAS16-DRAFT-EDIT'
+        ));
+
+        $result = $draft->append($folder);
+
+        $this->assertSame($newUid, $result['uid']);
+    }
+
+    public function testImportMimeDraftBodyUsesEnvelopeFromRfc822(): void
+    {
+        if (!class_exists('Horde_ActiveSync_Message_Mail')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $mime = implode("\r\n", [
+            'From: Sender <sender@example.com>',
+            'To: test@dannhauer.de',
+            'Subject: EAS16-DRAFT-EDIT',
+            'MIME-Version: 1.0',
+            'Content-Type: text/plain; charset=UTF-8',
+            '',
+            'PHASE-A-ONLY',
+        ]);
+
+        $message = new \Horde_ActiveSync_Message_Mail([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $body = new \Horde_ActiveSync_Message_AirSyncBaseBody([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $body->type = Horde_ActiveSync::BODYPREF_TYPE_MIME;
+        $body->data = $mime;
+        $message->airsyncbasebody = $body;
+
+        $draft = $this->createDraftWithoutIdentity();
+        $draft->setDraftMessage($message);
+
+        $stream = $draft->toRfc822Stream();
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+
+        $this->assertStringContainsString('PHASE-A-ONLY', $contents);
+        $this->assertStringContainsString('EAS16-DRAFT-EDIT', $contents);
+        $this->assertStringContainsString('test@dannhauer.de', $contents);
+    }
+
+    private function createDraftWithoutIdentity(
+        ?Horde_ActiveSync_Imap_Adapter $imap = null
+    ): Horde_Core_ActiveSync_Mail_Draft {
+        $imap ??= $this->getMockSkipConstructor(Horde_ActiveSync_Imap_Adapter::class);
+
+        return new class($imap, 'torben@dannhauer.info', Horde_ActiveSync::VERSION_SIXTEEN) extends Horde_Core_ActiveSync_Mail_Draft {
+            protected function _getIdentityFromAddress()
+            {
+                return null;
+            }
+
+            protected function _getReplyToAddress()
+            {
+                return null;
+            }
+        };
+    }
+
+    private function createClientDraftMessage(
+        string $body,
+        string $subject
+    ): Horde_ActiveSync_Message_Mail {
+        $message = new \Horde_ActiveSync_Message_Mail([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $message->to = 'test@dannhauer.de';
+        $message->subject = $subject;
+
+        $airsyncBody = new \Horde_ActiveSync_Message_AirSyncBaseBody([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $airsyncBody->type = Horde_ActiveSync::BODYPREF_TYPE_PLAIN;
+        $airsyncBody->data = $body;
+        $message->airsyncbasebody = $airsyncBody;
+
+        return $message;
+    }
+}


### PR DESCRIPTION
# Pull request: Core EAS 16.0 driver and draft sync

## Conventional commit message

```
feat(activesync): EAS 16.0 draft sync and calendar initial-sync in core driver

Report Drafts folder changes as CHANGE_TYPE_DRAFT, handle POOMMAIL2:Send and
draft Add/Modify via Mail/Draft, expose bound recurrence exceptions on initial
calendar sync at 16.0+, and unify calendar_import() return shape.
```

## PR title

`feat(activesync): EAS 16.0 draft sync and calendar initial-sync in core driver`

## Summary

- **Draft folder sync (EAS 16.0+):**
  - Export draft content changes as `CHANGE_TYPE_DRAFT` (not flag-only changes).
  - Handle inbound draft `<Add>` / `<Modify>` via `Horde_Core_ActiveSync_Mail_Draft` (append + replace-by-delete for edits).
  - Handle `POOMMAIL2:Send` on Drafts-folder Sync: build RFC822 via `toRfc822Stream()`, send via SMTP, delete source draft.
  - Set `IsDraft` on outbound mail messages from the Drafts collection at 16.0+.
- **Calendar initial sync (EAS 16.0+):**
  - Pass `hide_exceptions => false` to `calendar_listUids()` when protocol version ≥ 16.0 so bound recurrence exceptions appear as separate items on first sync (matches kronolith instance model).
- **Connector:**
  - `calendar_import()` always returns `['uid' => …, 'atchash' => …]`; deprecated `calendar_import16()` delegates to it.
- **Draft MIME bodies:**
  - `Horde_Core_ActiveSync_Mail_Draft` parses Type-4 (MIME) bodies from iOS when POOMMAIL headers are omitted.
- **Cleanup:** clarify draft-send comment in `Driver.php`; fix typo.

## Changed files

| File | Change |
|------|--------|
| `lib/Horde/Core/ActiveSync/Driver.php` | `CHANGE_TYPE_DRAFT`; draft send/edit path; `hide_exceptions` on initial calendar sync; `IsDraft` export |
| `lib/Horde/Core/ActiveSync/Connector.php` | Unified `calendar_import()`; deprecate `calendar_import16()` |
| `lib/Horde/Core/ActiveSync/Mail/Draft.php` | Type-4 MIME body import; `toRfc822Stream()` / append-replace edit model |
| `test/Unit/ActiveSync/DraftSyncTest.php` | Unit tests for RFC822 build, replace-on-edit, MIME envelope import |

## Related changes (other packages)

Deploy together with:

- **horde/kronolith** — ClientUid, Location, 16.0 instance export/import, `listUids(hide_exceptions)`
- **horde/activesync** — appointment 16.0 validation strip, recurrence protocol version, docs

## Test plan

- [ ] `php vendor/bin/phpunit --bootstrap core-tests-bootstrap.php vendor/horde/core/test/Unit/ActiveSync/DraftSyncTest.php` — all tests pass
- [ ] EAS 16.0 calendar on device: recurring series initial sync includes bound exceptions as separate items (with kronolith deployed)
- [ ] EAS 16.0 mail: `SendMail` sends message and saves to Sent (device test @ single account)
- [ ] EAS 16.0 mail: server-created draft syncs down to client with `IsDraft: 1` (device test)
- [ ] Draft edit upload from iOS not verified (client keeps edits local); server path covered by unit tests

## Device testing notes (2026-06-16)

| Area | Result |
|------|--------|
| Calendar ClientUid / Location / recurrence instances | Pass (iPhone, EAS 16.0) |
| `SendMail` | Pass |
| Draft download (IMP → iPhone) | Pass |
| Draft edit upload (iPhone → IMP) | Not observed — iOS Mail limitation, not server regression |
