### PR TITLE
Feat/initial eas16.1 support

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3226,6 +3226,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      *   - longid:    (EAS 16) mailbox:uid when responding from a search result.
      *   - instanceid: (EAS 14.1+) Recurring instance UTC timestamp.
      *   - sendresponse: (EAS 16) Optional iTip reply email body/flag.
+     *   - proposedstarttime: (EAS 16.1) Optional proposed meeting start time.
+     *   - proposedendtime: (EAS 16.1) Optional proposed meeting end time.
      *
      * @return string  The UID of any created calendar entries, otherwise false.
      * @throws Horde_ActiveSync_Exception, Horde_Exception_NotFound
@@ -3289,6 +3291,68 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             }
         }
 
+        $proposedStart = null;
+        $proposedEnd = null;
+        if ($this->_version >= Horde_ActiveSync::VERSION_SIXTEENONE
+            && !empty($response['proposedstarttime'])) {
+            try {
+                $proposedStart = new Horde_Date($response['proposedstarttime'], 'UTC');
+            } catch (Horde_Date_Exception $e) {
+                $this->_logger->err(sprintf(
+                    'Invalid MeetingResponse ProposedStartTime %s: %s',
+                    $response['proposedstarttime'],
+                    $e->getMessage()
+                ));
+            }
+        }
+        if ($this->_version >= Horde_ActiveSync::VERSION_SIXTEENONE
+            && !empty($response['proposedendtime'])) {
+            try {
+                $proposedEnd = new Horde_Date($response['proposedendtime'], 'UTC');
+            } catch (Horde_Date_Exception $e) {
+                $this->_logger->err(sprintf(
+                    'Invalid MeetingResponse ProposedEndTime %s: %s',
+                    $response['proposedendtime'],
+                    $e->getMessage()
+                ));
+            }
+        }
+        if (!empty($proposedEnd) && empty($proposedStart)) {
+            $this->_logger->notice('MeetingResponse ProposedEndTime sent without ProposedStartTime; ignoring proposal.');
+            $proposedEnd = null;
+        }
+        if (!empty($proposedStart)) {
+            foreach (['DISALLOW-COUNTER', 'X-MICROSOFT-DISALLOW-COUNTER', 'X-MS-DISALLOW-COUNTER'] as $counterFlag) {
+                try {
+                    $flagValue = $vEvent->getAttribute($counterFlag);
+                } catch (Horde_Icalendar_Exception $e) {
+                    continue;
+                }
+                if (is_string($flagValue)
+                    && in_array(strtoupper(trim($flagValue)), ['1', 'TRUE', 'YES'], true)) {
+                    $this->_logger->notice(sprintf(
+                        'MeetingResponse proposal ignored because %s forbids new time proposals.',
+                        $counterFlag
+                    ));
+                    $proposedStart = null;
+                    $proposedEnd = null;
+                    break;
+                }
+            }
+        }
+        if (!empty($proposedStart) && empty($proposedEnd)) {
+            try {
+                $origStart = new Horde_Date($vEvent->getAttribute('DTSTART'));
+                $origEnd = new Horde_Date($vEvent->getAttribute('DTEND'));
+                $proposedEnd = clone $proposedStart;
+                $proposedEnd->timestamp = $proposedStart->timestamp
+                    + ($origEnd->timestamp - $origStart->timestamp);
+            } catch (Horde_Icalendar_Exception $e) {
+                $this->_logger->err('Unable to derive proposed end time from meeting request.');
+                $proposedEnd = null;
+            }
+        }
+
         // Update the vCal so the response will be reflected when imported.
         $ident = $injector->getInstance('Horde_Core_Factory_Identity')->create($this->_user);
         //$cn = $ident->getValue('fullname');
@@ -3316,8 +3380,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             throw new Horde_ActiveSync_Exception($e);
         }
 
-        if (!empty($response['sendresponse'])) {
-            if ($response['sendresponse'] !== true) {
+        if (!empty($response['sendresponse']) || !empty($proposedStart)) {
+            if (!empty($response['sendresponse']) && $response['sendresponse'] !== true) {
                 $comment = $response['sendresponse']->data;
                 if ($response['sendresponse']->type == Horde_ActiveSync::BODYPREF_TYPE_HTML) {
                     $comment = Horde_Text_Filter::filter(
@@ -3359,16 +3423,32 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     $type = new Horde_Itip_Response_Type_Tentative($resource, $comment);
                     break;
             }
-            try {
-                // Send the reply.
-                Horde_Itip::factory($vEvent, $resource)->sendMultiPartResponse(
-                    $type,
-                    new Horde_Core_Itip_Response_Options_Horde('UTF-8', []),
-                    $injector->getInstance('Horde_Mail')
-                );
-                $this->_logger->meta('Reply sent.');
-            } catch (Horde_Itip_Exception $e) {
-                $this->_logger->err(sprintf('Error sending reply: %s.', $e->getMessage()), 'horde.error');
+            $itip = Horde_Itip::factory($vEvent, $resource);
+            $itipOptions = new Horde_Core_Itip_Response_Options_Horde('UTF-8', []);
+            $mail = $injector->getInstance('Horde_Mail');
+
+            if (!empty($response['sendresponse'])) {
+                try {
+                    $itip->sendMultiPartResponse($type, $itipOptions, $mail);
+                    $this->_logger->meta('Reply sent.');
+                } catch (Horde_Itip_Exception $e) {
+                    $this->_logger->err(sprintf('Error sending reply: %s.', $e->getMessage()), 'horde.error');
+                }
+            }
+
+            if (!empty($proposedStart)) {
+                try {
+                    $itip->sendCounterMultiPartResponse(
+                        $type,
+                        $itipOptions,
+                        $mail,
+                        $proposedStart,
+                        $proposedEnd
+                    );
+                    $this->_logger->meta('Counter proposal sent.');
+                } catch (Horde_Itip_Exception $e) {
+                    $this->_logger->err(sprintf('Error sending counter proposal: %s.', $e->getMessage()), 'horde.error');
+                }
             }
         }
 

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3531,6 +3531,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                 Horde_ActiveSync::VERSION_FOURTEEN,
                 Horde_ActiveSync::VERSION_FOURTEENONE,
                 Horde_ActiveSync::VERSION_SIXTEEN,
+                Horde_ActiveSync::VERSION_SIXTEENONE,
             ]
         );
 

--- a/test/Unit/ActiveSync/DriverVersionCallbackTest.php
+++ b/test/Unit/ActiveSync/DriverVersionCallbackTest.php
@@ -154,6 +154,38 @@ class DriverVersionCallbackTest extends TestCase
     }
 
     /**
+     * Per-user horde:activesync:version 16.1 must raise MS-ASProtocolVersions
+     * above global 16.0 for this request.
+     */
+    public function testVersionCallbackAppliesSixteenOnePermission(): void
+    {
+        if (!class_exists('Horde_ActiveSync_State_Sql')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $server = $this->createActiveSyncServer(
+            [
+                'PHP_AUTH_USER' => 'alice',
+                'PHP_AUTH_PW' => 'secret',
+            ],
+            [],
+            Horde_ActiveSync::VERSION_SIXTEEN
+        );
+        $this->assertSupportedVersionsUpTo($server, Horde_ActiveSync::VERSION_SIXTEEN);
+
+        $driver = $this->createDriver();
+        $this->setupGlobals(
+            permsVersion: Horde_ActiveSync::VERSION_SIXTEENONE,
+            expectedUsername: 'alice',
+            globalVersion: Horde_ActiveSync::VERSION_SIXTEEN
+        );
+
+        $driver->versionCallback($server);
+
+        $this->assertSupportedVersionsUpTo($server, Horde_ActiveSync::VERSION_SIXTEENONE);
+    }
+
+    /**
      * Global admin ceiling is 16.0; per-user horde:activesync:version is
      * 14.1. versionCallback() must lower the advertised protocol versions for
      * this user below the global setting.
@@ -370,6 +402,7 @@ class DriverVersionCallbackTest extends TestCase
             Horde_ActiveSync::VERSION_FOURTEEN,
             Horde_ActiveSync::VERSION_FOURTEENONE,
             Horde_ActiveSync::VERSION_SIXTEEN,
+            Horde_ActiveSync::VERSION_SIXTEENONE,
         ];
 
         $index = array_search($maxVersion, $supported, true);


### PR DESCRIPTION
# feat(core): add EAS 16.1 meeting proposal handling in MeetingResponse

## Summary

Extends `Horde_Core_ActiveSync_Driver::meetingResponse()` to handle EAS **16.1** `ProposedStartTime` / `ProposedEndTime`: send RFC5546 **`METHOD=COUNTER`** to the organizer (via `horde/itip`), respect disallow-counter iCal flags, and keep the existing `METHOD=REPLY` path when `SendResponse` is set.

## Motivation

`horde/activesync` parses 16.1 proposal fields from `MeetingResponse` WBXML; this PR is the application-layer bridge that turns them into standards-compliant iTip COUNTER messages and enforces organizer policy.

> **Note:** Verify `lib/Horde/Core/ActiveSync/Driver.php` in your branch contains these changes before opening the PR. If your working tree only has activesync/kronolith/itip/imp/horde updates, re-apply the `meetingResponse()` patch from your feature branch.

## Changes

### `meetingResponse()` (EAS ≥16.1)

1. Parse `proposedstarttime` / `proposedendtime` from the request array (UTC `Horde_Date`).
2. Validate: ignore `ProposedEndTime` without start; derive end from original meeting duration when end omitted.
3. If iCal event has `DISALLOW-COUNTER`, `X-MICROSOFT-DISALLOW-COUNTER`, or `X-MS-DISALLOW-COUNTER` set to a true-like value, clear proposal (no COUNTER sent).
4. When `sendresponse` and/or proposal present:
   - Send normal **REPLY** via `sendMultiPartResponse()` when `sendresponse` is set.
   - Send separate **COUNTER** via `sendCounterMultiPartResponse()` when proposed start is present.

### Docblock

- Document `proposedstarttime` / `proposedendtime` request keys.

## Files changed

```
lib/Horde/Core/ActiveSync/Driver.php
```

(No new tests in core for this slice; behaviour is covered by `horde/itip` integration tests and manual EAS testing. Optional follow-up: unit test with mocked `Horde_Itip`.)

## Dependencies

- **activesync** — `VERSION_SIXTEENONE`, `MeetingResponse` parsing passes proposed times into driver.
- **itip** — `Horde_Itip::sendCounterMultiPartResponse()`.

Merge **after** activesync and itip, **before** or in parallel with imp (IMP does not call core meetingResponse directly).

## Test plan

- [ ] `php -l lib/Horde/Core/ActiveSync/Driver.php`
- [ ] Existing `vendor/bin/phpunit test/Unit/ActiveSync/` suite passes (no regression in version callback / draft sync).
- [ ] Manual — 16.1 device, meeting invite:
  - [ ] Accept with “propose new time” → organizer receives COUNTER with correct times.
  - [ ] Event with disallow-counter → no COUNTER; normal accept/decline still works.
  - [ ] `SendResponse` + proposal → both REPLY and COUNTER when applicable.
- [ ] Manual — 16.0 device unchanged (no proposed time fields).

## Suggested commit message

```
feat(core): add EAS 16.1 meeting proposal handling in MeetingResponse

Parse proposed start/end on 16.1+, send RFC5546 COUNTER via Horde_Itip,
and respect disallow-counter flags on the source invitation.
```

## Implementation reference

Key logic added after instance-id handling and before calendar import:

- Proposed time parsing and duration derivation.
- Disallow-counter guard on `$vEvent`.
- Split iTip send: `sendMultiPartResponse` (reply) + `sendCounterMultiPartResponse` (counter).
