### PR TITLE
fix(core): validate portal layout CSRF with session checkToken

### DIFF
--- a/lib/Horde/Core/Block/Collection.php
+++ b/lib/Horde/Core/Block/Collection.php
@@ -87,11 +87,17 @@ class Horde_Core_Block_Collection implements Serializable, JsonSerializable
     /**
      * Return the layout manager for this collection.
      *
+     * @param Horde_Session|null $session  Session for CSRF token checks.
+     *
      * @return Horde_Core_Block_Layout_Manager  Layout manager object.
      */
-    public function getLayoutManager()
+    public function getLayoutManager(?Horde_Session $session = null)
     {
-        return new Horde_Core_Block_Layout_Manager($this);
+        if ($session === null && isset($GLOBALS['injector'])) {
+            $session = $GLOBALS['injector']->getInstance('Horde_Session');
+        }
+
+        return new Horde_Core_Block_Layout_Manager($this, $session);
     }
 
     /**

--- a/lib/Horde/Core/Block/Layout/Manager.php
+++ b/lib/Horde/Core/Block/Layout/Manager.php
@@ -1,8 +1,5 @@
 <?php
 
-use Horde\Core\Session\HordeSession;
-use Horde\Token\Exception\TokenException;
-use Horde\Token\Token;
 use Horde\Util\Util;
 
 /**
@@ -218,19 +215,8 @@ class Horde_Core_Block_Layout_Manager extends Horde_Core_Block_Layout implements
             case 'save':
                 // Save the changes made to a block and continue editing.
             case 'save-resume':
-                // Check form token.
-                $tokenService = $GLOBALS['injector']->getInstance(Token::class);
-                try {
-                    $valid = $tokenService->isValid(
-                        (string) Util::getFormData('token'),
-                        HordeSession::CSRF_SEED
-                    );
-                } catch (TokenException $e) {
-                    throw new Horde_Exception('Invalid token!');
-                }
-                if (!$valid) {
-                    throw new Horde_Exception('Invalid token!');
-                }
+                // Check form token (same path as Horde_Session::getToken()).
+                $GLOBALS['session']->checkToken((string) Util::getFormData('token'));
 
                 // Get requested block type.
                 [$newapp, $newtype] = explode(':', Util::getFormData('app'));

--- a/lib/Horde/Core/Block/Layout/Manager.php
+++ b/lib/Horde/Core/Block/Layout/Manager.php
@@ -80,13 +80,22 @@ class Horde_Core_Block_Layout_Manager extends Horde_Core_Block_Layout implements
     protected $_changedCol = null;
 
     /**
+     * Session instance for CSRF validation.
+     *
+     * @var Horde_Session|null
+     */
+    protected $_session;
+
+    /**
      * Constructor.
      *
      * @param Horde_Core_Block_Collection $collection  TODO
+     * @param Horde_Session|null $session  Session for CSRF token checks.
      */
-    public function __construct(Horde_Core_Block_Collection $collection)
+    public function __construct(Horde_Core_Block_Collection $collection, ?Horde_Session $session = null)
     {
         $this->_collection = $collection;
+        $this->_session = $session;
         $this->_editUrl = Horde::selfUrl();
         $this->_layout = $collection->getLayout();
 
@@ -216,7 +225,10 @@ class Horde_Core_Block_Layout_Manager extends Horde_Core_Block_Layout implements
                 // Save the changes made to a block and continue editing.
             case 'save-resume':
                 // Check form token (same path as Horde_Session::getToken()).
-                $GLOBALS['session']->checkToken((string) Util::getFormData('token'));
+                if ($this->_session === null) {
+                    throw new Horde_Exception('Invalid token!');
+                }
+                $this->_session->checkToken((string) Util::getFormData('token'));
 
                 // Get requested block type.
                 [$newapp, $newtype] = explode(':', Util::getFormData('app'));


### PR DESCRIPTION
## Summary
- Use `Horde_Session::checkToken()` for portal block layout save actions
- Align CSRF validation with the token generated by `getToken()` in the edit form
- Inject `Horde_Session` into the layout manager instead of reading globals or calling the Token service directly

## Motivation
Classic portal block layout saves could fail silently because the layout manager validated CSRF tokens through a different code path than the portal edit form uses to generate them.

## Changes
- `lib/Horde/Core/Block/Layout/Manager.php`: accept an optional `Horde_Session` and call `checkToken()` on save / save-resume; drop the direct `Horde\Token\Token` injector path that rejected valid submissions
- `lib/Horde/Core/Block/Collection.php`: pass a session into the layout manager, resolving it from the injector when callers do not supply one

## Test plan
- [ ] Open `/horde/services/portal/edit.php`, add or move a block, click Save
- [ ] Confirm the block appears on `/horde/services/portal/`
- [ ] Confirm invalid or missing tokens still show an error notification