### PR TITLE
feat(core): pass ActiveSync sync config to driver

### DIFF
--- a/lib/Horde/Core/Factory/ActiveSyncBackend.php
+++ b/lib/Horde/Core/Factory/ActiveSyncBackend.php
@@ -46,6 +46,7 @@ class Horde_Core_Factory_ActiveSyncBackend extends Horde_Core_Factory_Injector
                 ? new Horde_ActiveSync_Imap_Adapter($adapter_params)
                 : null,
             'ping' => $conf['activesync']['ping'],
+            'sync' => $conf['activesync']['sync'] ?? [],
             'state' => $injector->get('Horde_ActiveSyncState'),
             'auth' => $this->_getAuth(),
             'cache' => $injector->get('Horde_Cache')];


### PR DESCRIPTION
## Summary
- Pass `$conf['activesync']['sync']` from Horde config to the ActiveSync backend driver factory.

## Motivation
Companion to horde/ActiveSync adaptive Sync response time budgeting (horde/ActiveSync#45). The activesync package reads `maxresponsetime` via `Horde_ActiveSync_Driver_Base::getSyncConfig()`.

## Changes
- `Horde_Core_Factory_ActiveSyncBackend`: add `'sync' => $conf['activesync']['sync'] ?? []` to driver params.

## Dependencies
- horde/base: adds `activesync.sync.maxresponsetime` config key.

## Test plan
- [ ] With horde/base + horde/ActiveSync PRs deployed, set `$conf['activesync']['sync']['maxresponsetime'] = 25` and verify Sync truncates under load
