### PR TITLE
fix(core): add CSRF token to HordePopup.popup at click time

### DIFF
--- a/js/hordecore.js
+++ b/js/hordecore.js
@@ -206,6 +206,17 @@ var HordeCore = {
         params.set('token', this.conf.TOKEN);
     },
 
+    // params: (Hash) URL parameters
+    // Append only the CSRF token for same-origin navigation (popups, GET
+    // views). Session identity is carried by cookies — do not add legacy
+    // SID query parameters to these URLs.
+    addCsrfToken: function(params)
+    {
+        if (this.conf.TOKEN) {
+            params.set('token', this.conf.TOKEN);
+        }
+    },
+
     sessionId: function(sid)
     {
         var conf = this.baseWindow().HordeCore.conf;

--- a/js/popup.js
+++ b/js/popup.js
@@ -49,6 +49,12 @@ var HordePopup = {
         if (opts.params) {
             params.update(opts.params);
         }
+
+        /* Add session ID and CSRF token at click time (not page render time). */
+        if (typeof HordeCore !== 'undefined' && HordeCore.addRequestParams) {
+            HordeCore.addRequestParams(params);
+        }
+
         params.set('uniq', uniq);
 
         win = window.open(

--- a/js/popup.js
+++ b/js/popup.js
@@ -50,9 +50,9 @@ var HordePopup = {
             params.update(opts.params);
         }
 
-        /* Add session ID and CSRF token at click time (not page render time). */
-        if (typeof HordeCore !== 'undefined' && HordeCore.addRequestParams) {
-            HordeCore.addRequestParams(params);
+        /* Fresh CSRF token at click time; session auth uses cookies, not SID. */
+        if (typeof HordeCore !== 'undefined' && HordeCore.addCsrfToken) {
+            HordeCore.addCsrfToken(params);
         }
 
         params.set('uniq', uniq);

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -53,6 +53,7 @@ use Horde\Core\Factory\OAuthScopeClaimsMappingFactory;
 use Horde\Core\Factory\OAuthIdTokenBuilderFactory;
 use Horde\Core\Factory\OAuthConsentMiddlewareFactory;
 use Horde\Core\Factory\OAuthFlowStoreFactory;
+use Horde\Core\Factory\TokenServiceFactory;
 use Horde\Core\Middleware\OAuthConsentMiddleware;
 use Horde\OAuth\Client\OAuthFlowStore;
 use Horde\Core\Factory\SecretManagerFactory;
@@ -607,12 +608,8 @@ class Horde_Registry implements Horde_Shutdown_Task
             /* Ensure the per-session CSRF secret exists before closing a
              * read-only session, so view/download scripts can validate
              * tokens generated on full page views. */
-            try {
-                $injector->getInstance(Horde\Core\Factory\TokenServiceFactory::class)
-                    ->createForSession($injector->getInstance(Horde\Core\Session\HordeSession::class));
-            } catch (Throwable $e) {
-                Horde::log($e, Horde_Log::WARN);
-            }
+            $injector->getInstance(TokenServiceFactory::class)
+                ->createForSession($injector->getInstance(HordeSession::class));
 
             if ($session_flags & self::SESSION_READONLY) {
                 /* Close the session immediately so no changes can be made but

--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -603,6 +603,17 @@ class Horde_Registry implements Horde_Shutdown_Task
         } else {
             $GLOBALS['session'] = $session = new Horde_Session();
             $session->setup(true, $args['session_cache_limiter'] ?? null);
+
+            /* Ensure the per-session CSRF secret exists before closing a
+             * read-only session, so view/download scripts can validate
+             * tokens generated on full page views. */
+            try {
+                $injector->getInstance(Horde\Core\Factory\TokenServiceFactory::class)
+                    ->createForSession($injector->getInstance(Horde\Core\Session\HordeSession::class));
+            } catch (Throwable $e) {
+                Horde::log($e, Horde_Log::WARN);
+            }
+
             if ($session_flags & self::SESSION_READONLY) {
                 /* Close the session immediately so no changes can be made but
                    values are still available. */

--- a/src/DefaultInjectorBindings.php
+++ b/src/DefaultInjectorBindings.php
@@ -84,6 +84,7 @@ use Horde\Core\Factory\SessionHandlerFactory;
 use Horde\Core\Factory\SimpleCacheFactory;
 use Horde\Core\Factory\TinymceFactory;
 use Horde\Core\Factory\TinymcePageBinderFactory;
+use Horde\Core\Factory\TokenServiceFactory;
 use Horde\Core\Factory\VersionServiceFactory;
 use Horde\Core\Middleware\AuthIsGlobalAdmin;
 use Horde\Core\Middleware\ErrorFilter;
@@ -252,7 +253,7 @@ class DefaultInjectorBindings implements InjectorBindings
             'Horde_Template' => 'Horde_Core_Factory_Template',
             'Horde_Timezone' => 'Horde_Core_Factory_Timezone',
             'Horde_Token' => 'Horde_Core_Factory_Token',
-            Token::class => Factory\TokenServiceFactory::class,
+            Token::class => TokenServiceFactory::class,
             'Horde_Variables' => 'Horde_Core_Factory_Variables',
             'Horde_View' => 'Horde_Core_Factory_View',
             'Horde_View_Base' => 'Horde_Core_Factory_View',

--- a/src/PageOutput/ViewModeConfigurator.php
+++ b/src/PageOutput/ViewModeConfigurator.php
@@ -20,6 +20,7 @@ use Horde\Core\Assets\JsDiscoverer;
 use Horde\Core\Service\PrefsService;
 use Horde\Core\Session\HordeSession;
 use Horde\Injector\Attribute\Factory;
+use Horde\Token\Token;
 use Horde_Registry;
 use Exception;
 
@@ -42,6 +43,7 @@ class ViewModeConfigurator
         private readonly PrefsService $prefs,
         private readonly HordeSession $session,
         private readonly JsDiscoverer $jsDiscoverer,
+        private readonly Token $tokenService,
     ) {}
 
     public function configure(AssetCollector $collector, ViewMode $mode): void
@@ -95,7 +97,7 @@ class ViewModeConfigurator
             'URI_AJAX' => $this->getServiceLinkUrl('ajax', $app),
             'URI_DLOAD' => $this->getServiceLinkUrl('download', $app),
             'URI_LOGOUT' => $this->getServiceLinkUrl('logout'),
-            'TOKEN' => $this->session->getScoped('horde', 'token') ?? '',
+            'TOKEN' => (string) $this->tokenService->generate(HordeSession::CSRF_SEED)->token,
             'growler_log' => true,
             'popup_height' => 610,
             'popup_width' => 820,

--- a/src/PageOutput/ViewModeConfiguratorFactory.php
+++ b/src/PageOutput/ViewModeConfiguratorFactory.php
@@ -21,6 +21,7 @@ use Horde\Core\Service\PrefsService;
 use Horde\Core\Session\HordeSession;
 use Horde_Injector;
 use Horde\Injector\Injector;
+use Horde\Token\Token;
 use Horde_Registry;
 
 /**
@@ -40,6 +41,7 @@ class ViewModeConfiguratorFactory
             $injector->getInstance(PrefsService::class),
             $injector->getInstance(HordeSession::class),
             $injector->getInstance(JsDiscoverer::class),
+            $injector->getInstance(Token::class),
         );
     }
 }

--- a/test/Unit/PageOutput/ViewModeConfiguratorDiscovererTest.php
+++ b/test/Unit/PageOutput/ViewModeConfiguratorDiscovererTest.php
@@ -10,6 +10,8 @@ use Horde\Core\PageOutput\ViewMode;
 use Horde\Core\PageOutput\ViewModeConfigurator;
 use Horde\Core\Service\PrefsService;
 use Horde\Core\Session\HordeSession;
+use Horde\Token\GeneratedToken;
+use Horde\Token\Token;
 use Horde\Url\Url;
 use Horde_Registry;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -44,6 +46,15 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
         };
     }
 
+    private function createTokenServiceMock(string $token = 'token123'): Token
+    {
+        $tokenService = $this->createMock(Token::class);
+        $tokenService->method('generate')
+            ->willReturn(new GeneratedToken($token, time()));
+
+        return $tokenService;
+    }
+
     #[Test]
     public function basicModeResolvesPrototypeAndHorde(): void
     {
@@ -64,7 +75,13 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
         $session->expects(self::once())->method('getAuthId')->willReturn(null);
         $session->expects(self::never())->method('getScoped');
 
-        $configurator = new ViewModeConfigurator($registry, $prefs, $session, $discoverer);
+        $configurator = new ViewModeConfigurator(
+            $registry,
+            $prefs,
+            $session,
+            $discoverer,
+            $this->createTokenServiceMock()
+        );
         $collector = new AssetCollector();
 
         $configurator->configure($collector, ViewMode::BASIC);
@@ -90,7 +107,13 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
         $session->expects(self::once())->method('getAuthId')->willReturn(null);
         $session->expects(self::never())->method('getScoped');
 
-        $configurator = new ViewModeConfigurator($registry, $prefs, $session, $discoverer);
+        $configurator = new ViewModeConfigurator(
+            $registry,
+            $prefs,
+            $session,
+            $discoverer,
+            $this->createTokenServiceMock()
+        );
         $collector = new AssetCollector();
 
         $configurator->configure($collector, ViewMode::BASIC);
@@ -124,12 +147,14 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
 
         $session = $this->createMock(HordeSession::class);
         $session->expects(self::exactly(2))->method('getAuthId')->willReturn(null);
-        $session->expects(self::once())
-            ->method('getScoped')
-            ->with('horde', 'token')
-            ->willReturn(null);
 
-        $configurator = new ViewModeConfigurator($registry, $prefs, $session, $discoverer);
+        $configurator = new ViewModeConfigurator(
+            $registry,
+            $prefs,
+            $session,
+            $discoverer,
+            $this->createTokenServiceMock()
+        );
         $collector = new AssetCollector();
 
         $configurator->configure($collector, ViewMode::DYNAMIC);
@@ -168,7 +193,13 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
         $session->expects(self::once())->method('getAuthId')->willReturn('testuser');
         $session->expects(self::never())->method('getScoped');
 
-        $configurator = new ViewModeConfigurator($registry, $prefs, $session, $discoverer);
+        $configurator = new ViewModeConfigurator(
+            $registry,
+            $prefs,
+            $session,
+            $discoverer,
+            $this->createTokenServiceMock()
+        );
         $collector = new AssetCollector();
 
         $configurator->configure($collector, ViewMode::BASIC);
@@ -207,7 +238,13 @@ class ViewModeConfiguratorDiscovererTest extends TestCase
         $session->expects(self::once())->method('getAuthId')->willReturn(null);
         $session->expects(self::never())->method('getScoped');
 
-        $configurator = new ViewModeConfigurator($registry, $prefs, $session, $discoverer);
+        $configurator = new ViewModeConfigurator(
+            $registry,
+            $prefs,
+            $session,
+            $discoverer,
+            $this->createTokenServiceMock()
+        );
         $collector = new AssetCollector();
         $configurator->configure($collector, ViewMode::BASIC);
 

--- a/test/Unit/PageOutput/ViewModeConfiguratorTest.php
+++ b/test/Unit/PageOutput/ViewModeConfiguratorTest.php
@@ -22,6 +22,8 @@ use Horde\Core\PageOutput\ViewMode;
 use Horde\Core\PageOutput\ViewModeConfigurator;
 use Horde\Core\Service\PrefsService;
 use Horde\Core\Session\HordeSession;
+use Horde\Token\GeneratedToken;
+use Horde\Token\Token;
 use Horde\Url\Url;
 use Horde_Registry;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -54,6 +56,16 @@ class ViewModeConfiguratorTest extends TestCase
         return $jsDiscoverer;
     }
 
+    private function createTokenServiceMock(string $token = 'token123'): MockObject
+    {
+        $tokenService = $this->createMock(Token::class);
+        $tokenService->expects($this->any())
+            ->method('generate')
+            ->willReturn(new GeneratedToken($token, time()));
+
+        return $tokenService;
+    }
+
     public function testBasicModeAddsPrototypeAndHorde(): void
     {
         $registry = $this->createMock(Horde_Registry::class);
@@ -72,6 +84,7 @@ class ViewModeConfiguratorTest extends TestCase
             $prefs,
             $session,
             $jsDiscoverer,
+            $this->createTokenServiceMock(),
         );
         $collector = new AssetCollector();
 
@@ -101,6 +114,7 @@ class ViewModeConfiguratorTest extends TestCase
             $prefs,
             $session,
             $this->createJsDiscovererMock(),
+            $this->createTokenServiceMock(),
         );
         $collector = new AssetCollector();
 
@@ -128,6 +142,7 @@ class ViewModeConfiguratorTest extends TestCase
             $prefs,
             $session,
             $this->createJsDiscovererMock(),
+            $this->createTokenServiceMock(),
         );
         $collector = new AssetCollector();
 
@@ -147,10 +162,6 @@ class ViewModeConfiguratorTest extends TestCase
         $session = $this->createMock(HordeSession::class);
         // getAuthId fires for BASIC's accesskey check AND for DYNAMIC's uid lookup.
         $session->expects($this->exactly(2))->method('getAuthId')->willReturn('testuser');
-        $session->expects($this->once())
-            ->method('getScoped')
-            ->with('horde', 'token')
-            ->willReturn('token123');
 
         $prefs = $this->createMock(PrefsService::class);
         $prefs->expects($this->once())
@@ -163,6 +174,7 @@ class ViewModeConfiguratorTest extends TestCase
             $prefs,
             $session,
             $this->createJsDiscovererMock(),
+            $this->createTokenServiceMock(),
         );
         $collector = new AssetCollector();
 
@@ -185,10 +197,6 @@ class ViewModeConfiguratorTest extends TestCase
 
         $session = $this->createMock(HordeSession::class);
         $session->expects($this->exactly(2))->method('getAuthId')->willReturn('testuser');
-        $session->expects($this->once())
-            ->method('getScoped')
-            ->with('horde', 'token')
-            ->willReturn('mytoken');
 
         $prefs = $this->createMock(PrefsService::class);
         $prefs->expects($this->once())
@@ -201,6 +209,7 @@ class ViewModeConfiguratorTest extends TestCase
             $prefs,
             $session,
             $this->createJsDiscovererMock(),
+            $this->createTokenServiceMock('mytoken'),
         );
         $collector = new AssetCollector();
 


### PR DESCRIPTION
## Summary
- Add only the CSRF `token` to every `HordePopup.popup()` URL at click time via new `HordeCore.addCsrfToken()` (no legacy `SID` query parameter).
- Ensure `token_secret_key` exists before read-only sessions are closed, so download/view scripts can validate HMAC tokens.
- Fix `ViewModeConfigurator` to expose a modern HMAC `HordeCore.conf.TOKEN` instead of the legacy empty session slot.
- Register `TokenServiceFactory` explicitly in `DefaultInjectorBindings` and use `use` imports in `Registry` to avoid doubled namespace resolution.

## Motivation
After Horde 6 switched to HMAC CSRF tokens, IMP links that open MIME parts in a popup (e.g. “View HTML data in new window”) failed with “Invalid token!” and showed the portal instead of the message. `Horde::popupJs()` uses `HordePopup.popup()`, which never appended a `token` parameter, unlike `HordeCore.popupWindow()`.

Session identity must stay in cookies/headers, not URL query parameters (review feedback).

## Changes
- `js/hordecore.js`: add `HordeCore.addCsrfToken()` (token only).
- `js/popup.js`: call `HordeCore.addCsrfToken()` before `window.open()`.
- `lib/Horde/Registry.php`: seed per-session CSRF secret before `SESSION_READONLY` close.
- `src/DefaultInjectorBindings.php`: explicit `Token::class => TokenServiceFactory::class` binding.
- `src/PageOutput/ViewModeConfigurator.php` (+ factory, tests): use `Horde\Token\Token` for `TOKEN`.

## Test plan
- [ ] Open an HTML message in IMP dynamic view; click “View HTML data in new window”; popup shows rendered HTML.
- [ ] No “Invalid token!” growler messages in the parent window.
- [ ] Other `Horde::popupJs()` popups (help, prefs import, etc.) still open and authenticate correctly.
- [ ] `vendor/bin/phpunit --bootstrap vendor/autoload.php -c vendor/horde/core/phpunit.xml.dist vendor/horde/core/test/Unit/PageOutput/ViewModeConfiguratorTest.php vendor/horde/core/test/Unit/PageOutput/ViewModeConfiguratorDiscovererTest.php vendor/horde/core/test/Unit/Factory/TokenServiceFactoryTest.php`