### PR TITLE
feat(core): resolve ActiveSync task series master for instance updates

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -700,6 +700,24 @@ class Horde_Core_ActiveSync_Connector
     }
 
     /**
+     * Resolve a task UID to its recurring series master when appropriate.
+     *
+     * @param string $uid  The mapped server UID
+     * @param Horde_ActiveSync_Message_Task $message  The task object
+     *
+     * @return string
+     */
+    public function tasks_resolveSeriesMasterUid(
+        $uid,
+        Horde_ActiveSync_Message_Task $message
+    ) {
+        return $this->_registry->tasks->resolveActiveSyncSeriesMasterUid(
+            $uid,
+            $message
+        );
+    }
+
+    /**
      * Delete a task from the backend.
      *
      * @param string $id  The task's uid

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -388,6 +388,21 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     }
 
     /**
+     * Resolve a task UID to its recurring series master when appropriate.
+     *
+     * @param string $uid  The mapped server UID
+     * @param Horde_ActiveSync_Message_Task $message  The task object
+     *
+     * @return string
+     */
+    public function resolveTaskSeriesMasterUid(
+        $uid,
+        Horde_ActiveSync_Message_Task $message
+    ) {
+        return $this->_connector->tasks_resolveSeriesMasterUid($uid, $message);
+    }
+
+    /**
      * Setup sync parameters. The user provided here is the user the backend
      * will sync with. This allows you to authenticate as one user, and sync as
      * another, if the backend supports this (Horde does not).


### PR DESCRIPTION
## Summary
- Bridge the ActiveSync importer to Nag so that duplicate dead-occurrence task `Add`s for a recurring series are applied to the series master instead of creating duplicate tasks.

## Motivation
EAS clients (iOS Reminders, Outlook) complete a single occurrence of a recurring task by sending a dead-occurrence `Add` (often reusing a client id) plus a master `Modify`. Without a way to map such an `Add` back to the recurring master UID, the importer either ignored the change or created duplicate rows.

## Changes
- `Horde_Core_ActiveSync_Connector::tasks_resolveSeriesMasterUid()` — delegate to the tasks API resolver.
- `Horde_Core_ActiveSync_Driver::resolveTaskSeriesMasterUid()` — expose the resolver to the ActiveSync importer.

## Companion PRs
- horde/activesync: importer uses `resolveTaskSeriesMasterUid()` and adds master-change detection.
- horde/nag: implements `resolveActiveSyncSeriesMasterUid()` and the recurrence completion logic.

## Test plan
- [x] Existing core test suite unaffected (additive API only).
- [x] Manual device test (iOS 16.1) via the nag/activesync companion changes: complete instance, uncomplete instance, complete whole series, reopen final instance — no duplicate rows.
