### PR TITLE
fix(core): keep encrypted session slots readable across key drift (imp #66)

### DIFF
--- a/lib/Horde/Core/Alarm/Handler/Mail.php
+++ b/lib/Horde/Core/Alarm/Handler/Mail.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+
+use Horde\Injector\Injector;
+
+/**
+ * A Horde_Alarm handler that notifies of active alarms by e-mail, deferring
+ * the Horde_Mail_Transport resolution until the first notify() call.
+ *
+ * Replaces the eager-mail-resolution pattern of {@see Horde_Alarm_Handler_Mail},
+ * whose constructor validates `$params['mail'] instanceof Horde_Mail_Transport`
+ * and forces every alarm-aware request (including the portal's
+ * Horde_Notification_Handler_Decorator_Alarm path) to instantiate Horde_Mail.
+ * That eager resolution dereferences the encrypted IMAP credentials slot,
+ * which turns any latent decrypt failure (stale per-session key, evicted
+ * cookie, post-regenerate mismatch) into a request-killing
+ * Horde\Crypt\Blowfish\EncryptionException ("Invalid PKCS#7 padding byte").
+ *
+ * This subclass deliberately extends Horde_Alarm_Handler directly rather
+ * than Horde_Alarm_Handler_Mail: extending the latter would inherit the
+ * constructor we are trying to bypass. The body of notify() is otherwise
+ * a direct port of the parent's implementation, with the transport
+ * resolved through the injector on first invocation and cached for the
+ * rest of the request.
+ *
+ * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL
+ * @package  Core
+ */
+class Horde_Core_Alarm_Handler_Mail extends Horde_Alarm_Handler
+{
+    /**
+     * Injector used to lazily resolve the Horde_Mail_Transport.
+     *
+     * @var Injector
+     */
+    protected $_injector;
+
+    /**
+     * An identity factory.
+     *
+     * @var Horde_Core_Factory_Identity
+     */
+    protected $_identity;
+
+    /**
+     * Cached transport, resolved on first notify().
+     *
+     * @var ?Horde_Mail_Transport
+     */
+    protected $_mail = null;
+
+    /**
+     * Constructor.
+     *
+     * @param array $params  Required parameters:
+     *                       - injector: A Horde\Injector\Injector instance
+     *                         the handler uses to lazily resolve the
+     *                         'Horde_Mail' binding when notify() runs.
+     *                       - identity: An identity factory that implements
+     *                                   create().
+     *
+     * @throws Horde_Alarm_Exception
+     */
+    public function __construct(?array $params = null)
+    {
+        foreach (['injector', 'identity'] as $param) {
+            if (!isset($params[$param])) {
+                throw new Horde_Alarm_Exception('Parameter \'' . $param . '\' missing.');
+            }
+        }
+        if (!($params['injector'] instanceof Injector)) {
+            throw new Horde_Alarm_Exception('Parameter \'injector\' is not a Horde\\Injector\\Injector instance.');
+        }
+        if (!method_exists($params['identity'], 'create')) {
+            throw new Horde_Alarm_Exception('Parameter \'identity\' does not have a method create().');
+        }
+        $this->_injector = $params['injector'];
+        $this->_identity = $params['identity'];
+    }
+
+    /**
+     * Notifies about an alarm by e-mail.
+     *
+     * Lazily resolves Horde_Mail on first call; subsequent calls reuse
+     * the cached transport.
+     *
+     * @param array $alarm  An alarm hash.
+     *
+     * @throws Horde_Alarm_Exception
+     */
+    public function notify(array $alarm)
+    {
+        if (!empty($alarm['internal']['mail']['sent'])) {
+            return;
+        }
+
+        if (empty($alarm['params']['mail']['email'])) {
+            if (empty($alarm['user'])) {
+                return;
+            }
+            $email = $this->_identity
+                ->create($alarm['user'])
+                ->getDefaultFromAddress(true);
+        } else {
+            $email = $alarm['params']['mail']['email'];
+        }
+
+        if ($this->_mail === null) {
+            $this->_mail = $this->_injector->getInstance('Horde_Mail');
+        }
+
+        try {
+            $mail = new Horde_Mime_Mail([
+                'Subject' => $alarm['title'],
+                'To' => $email,
+                'From' => $email,
+                'Auto-Submitted' => 'auto-generated',
+                'X-Horde-Alarm' => $alarm['title']]);
+            if (isset($alarm['params']['mail']['mimepart'])) {
+                $mail->setBasePart($alarm['params']['mail']['mimepart']);
+            } elseif (empty($alarm['params']['mail']['body'])) {
+                $mail->setBody($alarm['text']);
+            } else {
+                $mail->setBody($alarm['params']['mail']['body']);
+            }
+
+            $mail->send($this->_mail);
+        } catch (Horde_Mime_Exception $e) {
+            throw new Horde_Alarm_Exception($e);
+        }
+
+        $alarm['internal']['mail']['sent'] = true;
+        $this->alarm->internal($alarm['id'], $alarm['user'], $alarm['internal']);
+    }
+
+    /**
+     * Resets the internal status of the handler, so that alarm notifications
+     * are sent again.
+     *
+     * @param array $alarm  An alarm hash.
+     */
+    public function reset(array $alarm)
+    {
+        $alarm['internal']['mail']['sent'] = false;
+        $this->alarm->internal($alarm['id'], $alarm['user'], $alarm['internal']);
+    }
+
+    /**
+     * Returns a human readable description of the handler.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return Horde_Alarm_Translation::t("Email");
+    }
+
+    /**
+     * Returns a hash of user-configurable parameters for the handler.
+     *
+     * @return array
+     */
+    public function getParameters()
+    {
+        return [
+            'email' => [
+                'type' => 'text',
+                'desc' => Horde_Alarm_Translation::t("Email address (optional)"),
+                'required' => false]];
+    }
+}

--- a/lib/Horde/Core/Factory/Alarm.php
+++ b/lib/Horde/Core/Factory/Alarm.php
@@ -96,9 +96,9 @@ class Horde_Core_Factory_Alarm extends Horde_Core_Factory_Base
 
         $this->_alarm->addHandler(
             'mail',
-            new Horde_Alarm_Handler_Mail([
+            new Horde_Core_Alarm_Handler_Mail([
+                'injector' => $this->_injector,
                 'identity' => $this->_injector->getInstance('Horde_Core_Factory_Identity'),
-                'mail' => $this->_injector->getInstance('Horde_Mail'),
             ])
         );
 

--- a/lib/Horde/Core/Secret/Cbc.php
+++ b/lib/Horde/Core/Secret/Cbc.php
@@ -13,6 +13,7 @@
  */
 
 use Horde\Core\Secret\SessionSecret;
+use Horde\Core\Session\HordeSession;
 use Horde\Crypt\Blowfish\Blowfish;
 
 /**
@@ -23,6 +24,14 @@ use Horde\Crypt\Blowfish\Blowfish;
  * needs to live in a separate class for now.
  *
  * Uses the additional parameter 'iv' - the IV used to seed the CBC cipher.
+ *
+ * The per-session key persists primarily inside the modern
+ * {@see HordeSession} payload (slot `_secret`/`key`) after
+ * {@see setSession()} wires the session in. The legacy
+ * `horde_secret_key` cookie remains as a backwards-compatible
+ * fallback so a rollback to a pre-fix Core release can still read
+ * pre-existing sessions, and so sessions written before the
+ * payload-slot existed migrate transparently on first read.
  *
  * @todo  Merge this class with Horde_Core_Secret.
  *
@@ -35,12 +44,27 @@ use Horde\Crypt\Blowfish\Blowfish;
  */
 class Horde_Core_Secret_Cbc extends Horde_Core_Secret implements SessionSecret
 {
+    /** Slot scope where the per-session key lives in HordeSession. */
+    private const KEY_SCOPE = '_secret';
+
+    /** Slot name where the per-session key lives in HordeSession. */
+    private const KEY_NAME = 'key';
+
     /**
      * Key used for current cached cipher object.
      *
      * @var string
      */
     protected $_cachedKey = '';
+
+    /**
+     * Modern session, wired by {@see setSession()}. Null before wiring
+     * (e.g. during DI bootstrap, before HordeSessionFactory has built
+     * the session) and during the legacy-only test path.
+     *
+     * @var ?HordeSession
+     */
+    protected ?HordeSession $_session = null;
 
     /**
      */
@@ -59,4 +83,90 @@ class Horde_Core_Secret_Cbc extends Horde_Core_Secret implements SessionSecret
 
         return $this->_cipherCache[self::HORDE_KEYNAME];
     }
+
+    /**
+     * Wire the modern session in. Called from
+     * {@see \Horde\Core\Session\HordeSessionFactory::create()} right after
+     * the session is built. Subsequent {@see getKey()} / {@see setKey()}
+     * calls read and write the per-session key in the session payload
+     * instead of relying exclusively on the cookie.
+     */
+    public function setSession(HordeSession $session): void
+    {
+        $this->_session = $session;
+    }
+
+    /**
+     * Return the per-session encryption key.
+     *
+     * Resolution order:
+     *   1. The session payload slot. Always wins when present — it is
+     *      the location new code writes, and the location existing
+     *      ciphertext is bound to once a session has gone through the
+     *      modern write path even once.
+     *   2. The legacy `horde_secret_key` cookie. Wins on first read of
+     *      a session that pre-dates the payload slot; the value is
+     *      copied INTO the session slot so subsequent reads land on
+     *      the payload path.
+     *   3. Falls through to {@see Horde_Core_Secret::getKey()} which
+     *      mints a fresh random key (and writes the cookie). The new
+     *      value is copied into the session slot too.
+     */
+    public function getKey($keyname = self::DEFAULT_KEY)
+    {
+        if ($this->_session !== null
+            && $this->_session->hasScoped(self::KEY_SCOPE, self::KEY_NAME)) {
+            $stored = $this->_session->getScoped(self::KEY_SCOPE, self::KEY_NAME);
+            if (is_string($stored) && $stored !== '') {
+                return $stored;
+            }
+        }
+
+        if (isset($_COOKIE[self::HORDE_KEYNAME . '_key'])) {
+            $cookie = (string) $_COOKIE[self::HORDE_KEYNAME . '_key'];
+            $this->_session?->setScoped(self::KEY_SCOPE, self::KEY_NAME, $cookie);
+            return $cookie;
+        }
+
+        // Neither slot nor cookie has a usable value. Mint a fresh
+        // random key via setKey() (which writes both the cookie and
+        // the session slot for us). parent::getKey() would not work
+        // here: it falls through to session_id() — empty in CLI and
+        // brittle even at runtime — when the session-name cookie is
+        // absent, defeating the migration intent. setKey() is the
+        // documented mint path.
+        return $this->setKey($keyname);
+    }
+
+    /**
+     * Set or rotate the per-session encryption key.
+     *
+     * Writes both the legacy cookie (via the parent) and the session
+     * payload slot. Invalidates the cached cipher so the next
+     * {@see _getCipherOb()} rebuilds it under the new key.
+     */
+    public function setKey($keyname = self::DEFAULT_KEY)
+    {
+        $key = parent::setKey($keyname);
+        if (is_string($key) && $key !== '' && $this->_session !== null) {
+            $this->_session->setScoped(self::KEY_SCOPE, self::KEY_NAME, $key);
+        }
+        // Force the cipher cache to rebuild against the new key on the
+        // next encrypt/decrypt.
+        $this->_cachedKey = '';
+        return $key;
+    }
+
+    /**
+     * Clear the per-session encryption key from both the cookie and the
+     * session payload.
+     */
+    public function clearKey($keyname = self::DEFAULT_KEY)
+    {
+        $result = parent::clearKey($keyname);
+        $this->_session?->removeScoped(self::KEY_SCOPE, self::KEY_NAME);
+        $this->_cachedKey = '';
+        return $result;
+    }
 }
+

--- a/src/Secret/SessionSecret.php
+++ b/src/Secret/SessionSecret.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
 
 namespace Horde\Core\Secret;
 
+use Horde\Core\Session\HordeSession;
+
 /**
  * Session-key cipher used by {@see \Horde\Core\Session\SessionLifecycle}
  * to re-key encrypted session payloads on `clean()` / `destroy()`.
@@ -60,4 +62,22 @@ interface SessionSecret
      *               (legacy returns bool).
      */
     public function clearKey($keyname = 'generic');
+
+    /**
+     * Wire the modern session into this secret service.
+     *
+     * After this call, the implementation MUST read and write the
+     * per-session key in the session payload (e.g. via
+     * {@see HordeSession::getScoped()} / {@see HordeSession::setScoped()}
+     * at a slot of its choosing) instead of relying exclusively on a
+     * parallel cookie. Implementations MAY keep the legacy cookie path
+     * as a backwards-compatible fallback and SHOULD migrate any value
+     * found in the cookie into the session payload on first read.
+     *
+     * Called by {@see \Horde\Core\Session\HordeSessionFactory::create()}
+     * right after the modern session is built; subsequent encrypted
+     * reads and writes therefore land on a session that already knows
+     * how to source its key without depending on the user's cookie jar.
+     */
+    public function setSession(HordeSession $session): void;
 }

--- a/src/Session/HordeSession.php
+++ b/src/Session/HordeSession.php
@@ -426,6 +426,21 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
     // EncryptedValuesInterface
     // ---------------------------------------------------------------
 
+    /**
+     * Read an encrypted slot.
+     *
+     * Returns `null` when the slot is absent, when the stored ciphertext
+     * cannot be decrypted under the current key (e.g. a stale key from
+     * before a session regenerate, or an upgrade boundary that dropped
+     * the per-session key cookie), or when a non-string sits at the slot
+     * (defensive). When the decrypt succeeds but the resulting bytes
+     * cannot be Horde_Pack-unpacked, the raw decrypted bytes are returned
+     * unchanged for legacy wire-format compatibility.
+     *
+     * Callers MUST be prepared to receive `null` even when
+     * {@see isEncrypted()} returned true, since the encryption-map flag
+     * and the underlying ciphertext can diverge across key changes.
+     */
     public function getEncrypted(string $app, string $name): mixed
     {
         $raw = $this->data[$app][$name] ?? null;
@@ -442,7 +457,15 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
             return $raw;
         }
 
-        $decrypted = ($this->decryptor)($raw);
+        try {
+            $decrypted = ($this->decryptor)($raw);
+        } catch (\Throwable) {
+            // Wrong key, corrupted ciphertext, or any other decrypt-side
+            // failure: fail closed. AuthCredentialStore::get() and similar
+            // consumers turn this into a "no credentials" signal so the
+            // request keeps going instead of crashing.
+            return null;
+        }
 
         try {
             return $this->pack->unpack($decrypted);
@@ -536,6 +559,89 @@ class HordeSession extends DefaultSession implements SessionMetaInterface, Encry
         foreach ($plainValues as [$app, $name, $serialized]) {
             $encrypted = ($this->encryptor)($serialized);
             $this->data[$app][$name] = $encrypted;
+            $this->dirty = true;
+        }
+    }
+
+    /**
+     * Re-encrypt all encrypted slots around an externally-driven key
+     * rotation.
+     *
+     * Used when the encryption closures themselves stay the same (they
+     * capture the secret service by reference and call getKey() lazily),
+     * but the key the closures fetch is about to change underneath them.
+     * The canonical caller is {@see SessionLifecycle::regenerate()}, which
+     * rotates the PHP session id (and optionally re-mints the per-session
+     * Blowfish key) between drain and refill.
+     *
+     * Sequence:
+     *   1. Walk the encryption map and decrypt each slot using the
+     *      current decryptor (still bound to the OLD key).
+     *   2. Slots that cannot be decrypted under the current key are
+     *      dropped from `$data` and from the encryption map. Carrying
+     *      ciphertext nobody can read is strictly worse than dropping
+     *      it; consumers (e.g. AuthCredentialStore::get) already
+     *      degrade gracefully to a "no credentials" state.
+     *   3. Invoke `$rotate`. The callback's job is to make the next
+     *      `getKey()` call (inside the still-captured encryptor) yield
+     *      the NEW key.
+     *   4. Re-encrypt each surviving plaintext using the current
+     *      encryptor (now bound to the NEW key) and write it back.
+     *
+     * If `$rotate` throws, plaintexts are discarded and the encrypted
+     * slots stay as-is under the old key; the exception propagates to
+     * the caller. The session is left in a coherent pre-rotation state.
+     *
+     * @param Closure $rotate fn(): void — runs between drain and refill.
+     */
+    public function reEncryptAll(Closure $rotate): void
+    {
+        $map = $this->data[self::ENCRYPTED_KEY] ?? [];
+        if (!is_array($map)) {
+            $map = [];
+        }
+
+        $plainValues = [];
+        foreach ($map as $app => $names) {
+            if (!is_array($names)) {
+                continue;
+            }
+            foreach (array_keys($names) as $name) {
+                $raw = $this->data[$app][$name] ?? null;
+                if (!is_string($raw) || $this->decryptor === null) {
+                    continue;
+                }
+                try {
+                    $plainValues[] = [$app, $name, ($this->decryptor)($raw)];
+                } catch (\Throwable) {
+                    // Slot is unrecoverable under the current key. Drop
+                    // it from $data and from the encryption map; mark
+                    // the session dirty so the now-shrunken payload
+                    // makes it to the backend.
+                    unset($this->data[$app][$name]);
+                    if (empty($this->data[$app])) {
+                        unset($this->data[$app]);
+                    }
+                    unset($this->data[self::ENCRYPTED_KEY][$app][$name]);
+                    if (empty($this->data[self::ENCRYPTED_KEY][$app])) {
+                        unset($this->data[self::ENCRYPTED_KEY][$app]);
+                    }
+                    if (empty($this->data[self::ENCRYPTED_KEY])) {
+                        unset($this->data[self::ENCRYPTED_KEY]);
+                    }
+                    $this->dirty = true;
+                }
+            }
+        }
+
+        $rotate();
+
+        if ($this->encryptor === null) {
+            return;
+        }
+
+        foreach ($plainValues as [$app, $name, $plain]) {
+            $this->data[$app][$name] = ($this->encryptor)($plain);
             $this->dirty = true;
         }
     }

--- a/src/Session/HordeSessionFactory.php
+++ b/src/Session/HordeSessionFactory.php
@@ -73,11 +73,23 @@ class HordeSessionFactory extends DefaultSessionFactory
         $decryptor = static fn(string $ciphertext): string
             => (string) $secret->read($secret->getKey(), $ciphertext);
 
-        return new HordeSession(
+        $session = new HordeSession(
             new SessionId(session_id() ?: 'none'),
             $_SESSION ?? [],
             $encryptor,
             $decryptor,
         );
+
+        // Wire the modern session into the secret service so subsequent
+        // getKey() / setKey() calls read and write the per-session key
+        // in the session payload instead of depending exclusively on
+        // the legacy horde_secret_key cookie. This is what makes the
+        // encrypted slots survive cookie eviction, RC5→RC7 upgrades,
+        // and session-id rotation done without re-encrypt (imp #66).
+        if (method_exists($secret, 'setSession')) {
+            $secret->setSession($session);
+        }
+
+        return $session;
     }
 }

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -337,18 +337,36 @@ class SessionLifecycle implements Horde_Shutdown_Task
      */
     public function regenerate(): void
     {
-        $this->mirrorToSession();
-        session_regenerate_id(true);
+        $session = $this->getSession();
+
+        // Drain encrypted slots under the OLD key, rotate the PHP
+        // session id (and re-mint the per-session Blowfish key), then
+        // re-encrypt the surviving plaintexts under the NEW key. The
+        // encryption closures themselves stay the same — they capture
+        // the secret service by reference and resolve getKey() lazily,
+        // so the second pass reads the fresh key automatically.
+        // Without this dance, the session id rotates while the
+        // ciphertext stays bound to the OLD key, and every encrypted
+        // slot becomes unreadable on the next read (imp #66).
+        $session->reEncryptAll(function (): void {
+            session_regenerate_id(true);
+            $this->secret?->setKey();
+        });
+
         // The deadline is canonical on HordeSession at the top level.
         // The shim's addFinal() shutdown task mirrors HordeSession to
         // $_SESSION for legacy code that reads the superglobal directly.
-        $this->getSession()->setRegenerationDeadline(
+        $session->setRegenerationDeadline(
             $this->config->nextRegenerationDeadline(),
         );
 
+        // Mirror AFTER re-encryption so the save handler picks up the
+        // freshly re-encrypted payload, not the old ciphertext.
+        $this->mirrorToSession();
+
         // Synchronous executor: clear pending intent so a downstream
         // processFlags() call sees a coherent no-op.
-        $this->getSession()->clearLifecycleFlags();
+        $session->clearLifecycleFlags();
     }
 
     /**

--- a/test/Unit/Alarm/CoreAlarmHandlerMailTest.php
+++ b/test/Unit/Alarm/CoreAlarmHandlerMailTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Alarm;
+
+use Horde\Injector\Injector;
+use Horde\Injector\TopLevel;
+use Horde_Alarm;
+use Horde_Alarm_Exception;
+use Horde_Alarm_Null;
+use Horde_Core_Alarm_Handler_Mail;
+use Horde_Mail_Transport_Mock;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that Horde_Core_Alarm_Handler_Mail defers Horde_Mail resolution
+ * to first notify(). The portal render path that triggered imp #66 ran
+ * the eager-resolution flavour during Horde_Notification handling and
+ * the credentials-slot decrypt that followed killed the request.
+ */
+#[CoversClass(Horde_Core_Alarm_Handler_Mail::class)]
+class CoreAlarmHandlerMailTest extends TestCase
+{
+    /**
+     * Build a real Injector pre-loaded with a counter so we can assert
+     * how many times Horde_Mail was resolved.
+     *
+     * @return array{0: Injector, 1: \stdClass} Injector + counter object
+     *                                          whose `count` property is
+     *                                          incremented on each
+     *                                          resolution.
+     */
+    private function injectorWithMailCounter(): array
+    {
+        $injector = new Injector(new TopLevel());
+        $counter = new \stdClass();
+        $counter->count = 0;
+        $transport = new Horde_Mail_Transport_Mock();
+        $injector->addBinder(
+            'Horde_Mail',
+            new class ($counter, $transport) implements \Horde\Injector\Binder {
+                public function __construct(
+                    private \stdClass $counter,
+                    private Horde_Mail_Transport_Mock $transport,
+                ) {}
+
+                public function create(\Horde\Injector\Injector $injector): mixed
+                {
+                    $this->counter->count++;
+
+                    return $this->transport;
+                }
+
+                public function equals(\Horde\Injector\Binder $otherBinder): bool
+                {
+                    return false;
+                }
+            },
+        );
+
+        return [$injector, $counter];
+    }
+
+    /**
+     * Identity factory that returns an identity whose
+     * getDefaultFromAddress() yields a fixed email.
+     */
+    private function identityFactory(string $email = 'user@example.org'): object
+    {
+        return new class ($email) {
+            public function __construct(private string $email) {}
+
+            public function create(string $user): object
+            {
+                return new class ($this->email) {
+                    public function __construct(private string $email) {}
+
+                    public function getDefaultFromAddress(bool $bare): string
+                    {
+                        return $this->email;
+                    }
+                };
+            }
+        };
+    }
+
+    /**
+     * Attach a null Horde_Alarm to a handler so notify() can call
+     * `$this->alarm->internal(...)` without exploding.
+     */
+    private function attachAlarm(Horde_Core_Alarm_Handler_Mail $handler): void
+    {
+        $handler->alarm = new Horde_Alarm_Null();
+    }
+
+    #[Test]
+    public function testConstructorDoesNotResolveMail(): void
+    {
+        [$injector, $counter] = $this->injectorWithMailCounter();
+
+        new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+            'identity' => $this->identityFactory(),
+        ]);
+
+        self::assertSame(0, $counter->count);
+    }
+
+    #[Test]
+    public function testNotifyResolvesMailOnFirstCallOnly(): void
+    {
+        [$injector, $counter] = $this->injectorWithMailCounter();
+
+        $handler = new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+            'identity' => $this->identityFactory(),
+        ]);
+        $this->attachAlarm($handler);
+
+        $alarm = [
+            'id' => 'a1',
+            'user' => 'u',
+            'title' => 'T',
+            'text' => 'body',
+            'params' => ['mail' => ['email' => 'to@example.org']],
+            'internal' => [],
+        ];
+        $handler->notify($alarm);
+        self::assertSame(1, $counter->count);
+
+        // Reset the sent-marker so the handler doesn't short-circuit.
+        $alarm['internal'] = [];
+        $handler->notify($alarm);
+        self::assertSame(1, $counter->count, 'transport cached on second notify');
+    }
+
+    #[Test]
+    public function testNotifySkipsWhenAlarmAlreadySent(): void
+    {
+        [$injector, $counter] = $this->injectorWithMailCounter();
+
+        $handler = new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+            'identity' => $this->identityFactory(),
+        ]);
+        $this->attachAlarm($handler);
+
+        $handler->notify([
+            'id' => 'a1',
+            'user' => 'u',
+            'title' => 'T',
+            'text' => 'body',
+            'params' => ['mail' => ['email' => 'to@example.org']],
+            'internal' => ['mail' => ['sent' => true]],
+        ]);
+
+        self::assertSame(0, $counter->count, 'no mail resolution for already-sent alarm');
+    }
+
+    #[Test]
+    public function testNotifyWithoutEmailOrUserIsNoOp(): void
+    {
+        [$injector, $counter] = $this->injectorWithMailCounter();
+
+        $handler = new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+            'identity' => $this->identityFactory(),
+        ]);
+        $this->attachAlarm($handler);
+
+        $handler->notify([
+            'id' => 'a1',
+            'user' => '',
+            'title' => 'T',
+            'text' => 'body',
+            'params' => [],
+            'internal' => [],
+        ]);
+
+        self::assertSame(0, $counter->count);
+    }
+
+    #[Test]
+    public function testConstructorRejectsMissingInjector(): void
+    {
+        $this->expectException(Horde_Alarm_Exception::class);
+        new Horde_Core_Alarm_Handler_Mail([
+            'identity' => $this->identityFactory(),
+        ]);
+    }
+
+    #[Test]
+    public function testConstructorRejectsMissingIdentity(): void
+    {
+        [$injector] = $this->injectorWithMailCounter();
+        $this->expectException(Horde_Alarm_Exception::class);
+        new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+        ]);
+    }
+
+    #[Test]
+    public function testConstructorRejectsNonInjector(): void
+    {
+        $this->expectException(Horde_Alarm_Exception::class);
+        new Horde_Core_Alarm_Handler_Mail([
+            'injector' => 'not-an-injector',
+            'identity' => $this->identityFactory(),
+        ]);
+    }
+
+    #[Test]
+    public function testConstructorRejectsIdentityWithoutCreate(): void
+    {
+        [$injector] = $this->injectorWithMailCounter();
+        $this->expectException(Horde_Alarm_Exception::class);
+        new Horde_Core_Alarm_Handler_Mail([
+            'injector' => $injector,
+            'identity' => new \stdClass(),
+        ]);
+    }
+}

--- a/test/Unit/Secret/CbcTest.php
+++ b/test/Unit/Secret/CbcTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Secret;
+
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\SessionId;
+use Horde_Core_Secret;
+use Horde_Core_Secret_Cbc;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pin the session-payload key persistence added to fix imp #66.
+ *
+ * The Blowfish key the per-session encrypted slots are bound to used to
+ * live exclusively in the `horde_secret_key` cookie (falling back to
+ * `session_id()` when the cookie was absent). Either path turned the key
+ * into a moving target across upgrades, cookie eviction, and session-id
+ * rotation. After this change the canonical home is the modern session
+ * payload at slot `_secret`/`key`; the cookie remains as a BC fallback
+ * and the value migrates into the payload on first read.
+ */
+#[CoversClass(Horde_Core_Secret_Cbc::class)]
+class CbcTest extends TestCase
+{
+    /** Cookie name the legacy fallback writes to. */
+    private const COOKIE_KEY = Horde_Core_Secret::HORDE_KEYNAME . '_key';
+
+    /** Cookie name `Horde_Secret::setKey` checks to decide whether a session is "active". */
+    private const SESSION_COOKIE = 'horde_secret';
+
+    protected function setUp(): void
+    {
+        // Both Horde_Secret::setKey and ::getKey read $_COOKIE directly.
+        // Wipe relevant entries between tests so cookie state from a
+        // previous case does not leak.
+        unset(
+            $_COOKIE[self::COOKIE_KEY],
+            $_COOKIE[self::SESSION_COOKIE],
+        );
+    }
+
+    private function buildCbc(?HordeSession $session = null): Horde_Core_Secret_Cbc
+    {
+        $cbc = new Horde_Core_Secret_Cbc([
+            'cookie_domain' => '',
+            'cookie_path' => '/',
+            'cookie_ssl' => false,
+            'iv' => str_repeat("\0", 8),
+            'session_name' => self::SESSION_COOKIE,
+        ]);
+        if ($session !== null) {
+            $cbc->setSession($session);
+        }
+        return $cbc;
+    }
+
+    private function buildSession(): HordeSession
+    {
+        return new HordeSession(new SessionId('cbc-test'), []);
+    }
+
+    #[Test]
+    public function testGetKeyReadsFromSessionWhenPresent(): void
+    {
+        $session = $this->buildSession();
+        $session->setScoped('_secret', 'key', 'in-session-key');
+        $cbc = $this->buildCbc($session);
+
+        self::assertSame('in-session-key', $cbc->getKey());
+    }
+
+    #[Test]
+    public function testGetKeyMigratesFromCookieWhenSessionSlotEmpty(): void
+    {
+        $_COOKIE[self::COOKIE_KEY] = 'cookie-key';
+        $session = $this->buildSession();
+        $cbc = $this->buildCbc($session);
+
+        self::assertSame('cookie-key', $cbc->getKey());
+        // The cookie value is now copied into the session payload so the
+        // next read no longer depends on the cookie surviving.
+        self::assertTrue($session->hasScoped('_secret', 'key'));
+        self::assertSame('cookie-key', $session->getScoped('_secret', 'key'));
+    }
+
+    #[Test]
+    public function testGetKeySessionWinsWhenBothPresent(): void
+    {
+        $_COOKIE[self::COOKIE_KEY] = 'cookie-key';
+        $session = $this->buildSession();
+        $session->setScoped('_secret', 'key', 'in-session-key');
+        $cbc = $this->buildCbc($session);
+
+        self::assertSame('in-session-key', $cbc->getKey());
+    }
+
+    #[Test]
+    public function testGetKeyMintsFreshWhenNeitherPresent(): void
+    {
+        // Simulate an active session-name cookie so Horde_Secret::setKey
+        // (called transitively from getKey when no key cookie is set)
+        // takes the cookie-writing branch instead of falling through to
+        // session_id().
+        $_COOKIE[self::SESSION_COOKIE] = 'sess';
+        $session = $this->buildSession();
+        $cbc = $this->buildCbc($session);
+
+        $key = $cbc->getKey();
+
+        self::assertNotSame('', $key);
+        self::assertTrue($session->hasScoped('_secret', 'key'));
+        self::assertSame($key, $session->getScoped('_secret', 'key'));
+    }
+
+    #[Test]
+    public function testFallsBackToLegacyBehaviourWithoutSessionWired(): void
+    {
+        // No setSession() call: the legacy code path stays unchanged
+        // (cookie wins, no payload migration attempted).
+        $_COOKIE[self::COOKIE_KEY] = 'cookie-key';
+        $cbc = $this->buildCbc();
+
+        self::assertSame('cookie-key', $cbc->getKey());
+    }
+
+    #[Test]
+    public function testSetKeyWritesToSessionAndCookie(): void
+    {
+        $_COOKIE[self::SESSION_COOKIE] = 'sess';
+        $session = $this->buildSession();
+        $cbc = $this->buildCbc($session);
+
+        $key = $cbc->setKey();
+
+        self::assertNotSame('', $key);
+        self::assertSame($key, $session->getScoped('_secret', 'key'));
+        self::assertArrayHasKey(self::COOKIE_KEY, $_COOKIE);
+        self::assertSame($key, $_COOKIE[self::COOKIE_KEY]);
+    }
+
+    #[Test]
+    public function testClearKeyClearsSessionAndCookie(): void
+    {
+        $_COOKIE[self::SESSION_COOKIE] = 'sess';
+        $_COOKIE[self::COOKIE_KEY] = 'cookie-key';
+        $session = $this->buildSession();
+        $session->setScoped('_secret', 'key', 'in-session-key');
+        $cbc = $this->buildCbc($session);
+
+        $cbc->clearKey();
+
+        self::assertFalse($session->hasScoped('_secret', 'key'));
+        self::assertArrayNotHasKey(self::COOKIE_KEY, $_COOKIE);
+    }
+
+    #[Test]
+    public function testEncryptDecryptRoundTripAcrossCookieLoss(): void
+    {
+        // Sanity-check the full happy path: write encrypted data while
+        // the cookie is present, then drop the cookie. The session-stored
+        // key must still let us decrypt.
+        $_COOKIE[self::SESSION_COOKIE] = 'sess';
+        $_COOKIE[self::COOKIE_KEY] = str_repeat('K', 32);
+        $session = $this->buildSession();
+        $cbc = $this->buildCbc($session);
+
+        $cipher = $cbc->write($cbc->getKey(), 'secret-payload');
+
+        // User refreshes; browser has dropped the key cookie. Session
+        // payload still carries the key.
+        unset($_COOKIE[self::COOKIE_KEY]);
+
+        $cbc2 = $this->buildCbc($session);
+        $plain = $cbc2->read($cbc2->getKey(), $cipher);
+
+        self::assertSame('secret-payload', $plain);
+    }
+}

--- a/test/Unit/Session/HordeSessionFactoryTest.php
+++ b/test/Unit/Session/HordeSessionFactoryTest.php
@@ -220,4 +220,31 @@ class HordeSessionFactoryTest extends TestCase
 
         self::assertSame(['first-key', 'second-key'], $observedKeys);
     }
+
+    /**
+     * The factory must hand the freshly-built session to the secret service
+     * via setSession(), so the secret service can read and write the
+     * per-session key from the session payload instead of relying on the
+     * legacy horde_secret_key cookie. Without this wiring, encrypted slots
+     * are bound to a cookie that can disappear (imp #66).
+     */
+    #[Test]
+    public function testCreateWiresSecretToSession(): void
+    {
+        $captured = null;
+        $secret = $this->createMock(Horde_Core_Secret_Cbc::class);
+        $secret->expects(self::once())
+            ->method('setSession')
+            ->willReturnCallback(static function ($session) use (&$captured): void {
+                $captured = $session;
+            });
+
+        $injector = new Injector(new TopLevel());
+        $injector->setInstance('Horde_Secret_Cbc', $secret);
+
+        $factory = new HordeSessionFactory();
+        $session = $factory->create($injector);
+
+        self::assertSame($session, $captured);
+    }
 }

--- a/test/Unit/Session/HordeSessionTest.php
+++ b/test/Unit/Session/HordeSessionTest.php
@@ -371,6 +371,234 @@ class HordeSessionTest extends TestCase
     }
 
     #[Test]
+    public function testGetEncryptedReturnsNullWhenDecryptorThrowsBlowfishException(): void
+    {
+        // Simulates the imp #66 path: the stored ciphertext was encrypted
+        // under a key the current decryptor no longer holds, so unpad()
+        // throws "Invalid PKCS#7 padding byte". The session must fail
+        // closed to null instead of letting the throwable escape and kill
+        // the request.
+        $writer = new HordeSession(
+            new SessionId('enc-test'),
+            [],
+            fn(string $p): string => 'ENC:' . $p,
+            fn(string $c): string => substr($c, 4),
+        );
+        $writer->setEncrypted('horde', 'auth_app/imp', ['password' => 'secret']);
+
+        $brokenDecryptor = function (string $c): string {
+            throw new \Horde\Crypt\Blowfish\EncryptionException(
+                'Invalid PKCS#7 padding byte: 0x61',
+            );
+        };
+        $reader = new HordeSession(
+            new SessionId('enc-test'),
+            $writer->toPayload(),
+            fn(string $p): string => 'ENC:' . $p,
+            $brokenDecryptor,
+        );
+
+        self::assertNull($reader->getEncrypted('horde', 'auth_app/imp'));
+    }
+
+    #[Test]
+    public function testGetEncryptedReturnsNullOnArbitraryThrowableFromDecryptor(): void
+    {
+        // Defensive: any Throwable from the decryptor closure is contained,
+        // not just the Blowfish-specific exception.
+        $writer = new HordeSession(
+            new SessionId('enc-test'),
+            [],
+            fn(string $p): string => 'ENC:' . $p,
+            fn(string $c): string => substr($c, 4),
+        );
+        $writer->setEncrypted('horde', 'secret', 'value');
+
+        $reader = new HordeSession(
+            new SessionId('enc-test'),
+            $writer->toPayload(),
+            fn(string $p): string => 'ENC:' . $p,
+            function (string $c): string {
+                throw new \RuntimeException('decryptor blew up');
+            },
+        );
+
+        self::assertNull($reader->getEncrypted('horde', 'secret'));
+    }
+
+    #[Test]
+    public function testGetEncryptedReturnsDecryptedBytesWhenPackUnpackFails(): void
+    {
+        // Regression guard: a successful decrypt whose result is NOT
+        // Horde_Pack-formatted must keep returning the raw decrypted
+        // bytes (legacy wire format). The new outer Throwable catch
+        // must not accidentally swallow this case to null.
+        $writer = new HordeSession(
+            new SessionId('enc-test'),
+            [],
+            fn(string $p): string => 'ENC:' . $p,
+            fn(string $c): string => substr($c, 4),
+        );
+        $writer->setEncrypted('horde', 'secret', 'placeholder');
+
+        // Decrypt succeeds and returns bytes that Horde_Pack will reject.
+        $reader = new HordeSession(
+            new SessionId('enc-test'),
+            $writer->toPayload(),
+            fn(string $p): string => 'ENC:' . $p,
+            fn(string $c): string => 'not-a-pack-payload',
+        );
+
+        self::assertSame('not-a-pack-payload', $reader->getEncrypted('horde', 'secret'));
+    }
+
+    // ---------------------------------------------------------------
+    // reEncryptAll() — rotation of the underlying encryption key
+    // ---------------------------------------------------------------
+
+    /**
+     * Build a session whose closures read a key from a mutable
+     * holder. Mutating the holder simulates a key rotation between
+     * drain and refill phases of reEncryptAll().
+     *
+     * @return array{0: HordeSession, 1: \stdClass} The session and the
+     *                                              key holder.
+     */
+    private function sessionWithMutableKey(string $initialKey = 'KEY1'): array
+    {
+        $holder = new \stdClass();
+        $holder->key = $initialKey;
+        // Encryption: tag the plaintext with the active key on write.
+        $encryptor = static function (string $plaintext) use ($holder): string {
+            return $holder->key . '|' . $plaintext;
+        };
+        // Decryption: only succeeds if the active key matches the tag.
+        $decryptor = static function (string $ciphertext) use ($holder): string {
+            $prefix = $holder->key . '|';
+            if (!str_starts_with($ciphertext, $prefix)) {
+                throw new \RuntimeException('wrong key');
+            }
+            return substr($ciphertext, strlen($prefix));
+        };
+        $session = new HordeSession(
+            new SessionId('rotate-test'),
+            [],
+            $encryptor,
+            $decryptor,
+        );
+
+        return [$session, $holder];
+    }
+
+    #[Test]
+    public function testReEncryptAllRoundTripsPlaintextAcrossKeyRotation(): void
+    {
+        [$session, $holder] = $this->sessionWithMutableKey('KEY1');
+        $session->setEncrypted('horde', 'auth_app/imp', ['password' => 'p1']);
+        $session->setEncrypted('horde', 'auth_app/turba', 'p2');
+
+        $rawBefore = $session->getScoped('horde', 'auth_app/imp');
+        self::assertStringStartsWith('KEY1|', $rawBefore);
+
+        $session->reEncryptAll(function () use ($holder) {
+            $holder->key = 'KEY2';
+        });
+
+        // Ciphertext has been re-bound to the new key.
+        $rawAfter = $session->getScoped('horde', 'auth_app/imp');
+        self::assertStringStartsWith('KEY2|', $rawAfter);
+
+        // Plaintext round-trips under the new key.
+        self::assertSame(
+            ['password' => 'p1'],
+            $session->getEncrypted('horde', 'auth_app/imp'),
+        );
+        self::assertSame(
+            'p2',
+            $session->getEncrypted('horde', 'auth_app/turba'),
+        );
+    }
+
+    #[Test]
+    public function testReEncryptAllDropsUndecryptableSlots(): void
+    {
+        // Seed two slots under KEY1, then swap one out for ciphertext
+        // bound to an unknown key. After reEncryptAll, the unrecoverable
+        // slot is removed from both $data and the encryption map; the
+        // healthy slot survives and is re-encrypted under KEY2.
+        [$session, $holder] = $this->sessionWithMutableKey('KEY1');
+        $session->setEncrypted('horde', 'good', 'value');
+        $session->setEncrypted('horde', 'bad', 'placeholder');
+        $session->setScoped('horde', 'bad', 'UNKNOWN|garbage');
+
+        $session->reEncryptAll(function () use ($holder) {
+            $holder->key = 'KEY2';
+        });
+
+        self::assertNull($session->getScoped('horde', 'bad'));
+        self::assertFalse($session->isEncrypted('horde', 'bad'));
+        self::assertTrue($session->isEncrypted('horde', 'good'));
+        self::assertSame('value', $session->getEncrypted('horde', 'good'));
+    }
+
+    #[Test]
+    public function testReEncryptAllRunsCallbackBetweenDecryptAndEncrypt(): void
+    {
+        // Pin the sequence: the callback must observe the OLD key (drain
+        // already happened) and may install the NEW key (refill happens
+        // after the callback returns).
+        [$session, $holder] = $this->sessionWithMutableKey('KEY1');
+        $session->setEncrypted('horde', 'slot', 'value');
+
+        $observed = null;
+        $session->reEncryptAll(function () use ($holder, &$observed) {
+            $observed = $holder->key;
+            $holder->key = 'KEY2';
+        });
+
+        self::assertSame('KEY1', $observed, 'callback runs with the old key in scope');
+        self::assertStringStartsWith('KEY2|', $session->getScoped('horde', 'slot'));
+    }
+
+    #[Test]
+    public function testReEncryptAllPropagatesCallbackExceptionWithoutReEncrypting(): void
+    {
+        [$session, $holder] = $this->sessionWithMutableKey('KEY1');
+        $session->setEncrypted('horde', 'slot', 'value');
+        $rawBefore = $session->getScoped('horde', 'slot');
+
+        try {
+            $session->reEncryptAll(function () use ($holder) {
+                $holder->key = 'KEY2';
+                throw new \LogicException('rotation aborted');
+            });
+            self::fail('expected exception');
+        } catch (\LogicException $e) {
+            self::assertSame('rotation aborted', $e->getMessage());
+        }
+
+        // The encrypted slot stays as it was. It would be re-readable
+        // only if the key holder is rolled back to KEY1 (the caller's
+        // responsibility); the session itself made no further mutation
+        // after the callback threw.
+        self::assertSame($rawBefore, $session->getScoped('horde', 'slot'));
+    }
+
+    #[Test]
+    public function testReEncryptAllNoEncryptedSlotsStillRunsCallback(): void
+    {
+        [$session, $holder] = $this->sessionWithMutableKey('KEY1');
+        $called = false;
+
+        $session->reEncryptAll(function () use ($holder, &$called) {
+            $holder->key = 'KEY2';
+            $called = true;
+        });
+
+        self::assertTrue($called);
+    }
+
+    #[Test]
     public function testIsEncrypted(): void
     {
         $encryptor = fn(string $p): string => 'ENC:' . $p;

--- a/test/Unit/Session/SessionLifecycleTest.php
+++ b/test/Unit/Session/SessionLifecycleTest.php
@@ -458,6 +458,136 @@ class SessionLifecycleTest extends TestCase
         self::assertTrue($session->shouldRegenerate());
         self::assertTrue($session->isDestroyed());
     }
+
+    // ---------------------------------------------------------------
+    // regenerate() — wiring the re-encryption dance
+    //
+    // The real regenerate() calls session_regenerate_id(true), which
+    // fails in CLI without a live PHP session. To exercise the wiring
+    // without booting one, we install a CapturingHordeSession test
+    // double in the injector. The double captures the callback that
+    // SessionLifecycle::regenerate() hands to reEncryptAll(), so the
+    // test can pin (a) that reEncryptAll IS called, and (b) that the
+    // callback wires through to the secret service's setKey() — both
+    // without invoking session_regenerate_id.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function testRegenerateDelegatesToReEncryptAll(): void
+    {
+        $session = new CapturingHordeSession(new SessionId('regen-wiring'), []);
+        $secret = new RecordingSessionSecret();
+        $lifecycle = $this->build([], $session, $secret);
+
+        try {
+            $lifecycle->regenerate();
+        } catch (\Throwable $e) {
+            self::fail('regenerate threw unexpectedly: ' . $e->getMessage());
+        }
+
+        self::assertTrue($session->reEncryptAllCalled, 'reEncryptAll invoked');
+        self::assertNotNull($session->capturedRotation, 'rotation callback captured');
+    }
+
+    #[Test]
+    public function testRegenerateCallbackInvokesSecretSetKey(): void
+    {
+        $session = new CapturingHordeSession(new SessionId('regen-setkey'), []);
+        $secret = new RecordingSessionSecret();
+        $lifecycle = $this->build([], $session, $secret);
+
+        $lifecycle->regenerate();
+
+        self::assertTrue($secret->setKeyCalled, 'rotation callback calls secret->setKey()');
+    }
+
+    #[Test]
+    public function testRegenerateUpdatesDeadline(): void
+    {
+        $session = new CapturingHordeSession(new SessionId('regen-deadline'), []);
+        $lifecycle = $this->build(
+            ['session' => ['regenerate_interval' => 60]],
+            $session,
+        );
+
+        $beforeDeadline = $session->getRegenerationDeadline();
+
+        $lifecycle->regenerate();
+
+        $afterDeadline = $session->getRegenerationDeadline();
+        self::assertNotSame($beforeDeadline, $afterDeadline);
+        self::assertIsInt($afterDeadline);
+    }
+
+    #[Test]
+    public function testRegenerateClearsLifecycleFlags(): void
+    {
+        $session = new CapturingHordeSession(new SessionId('regen-flags'), []);
+        $session->scheduleRegeneration();
+        $lifecycle = $this->build([], $session);
+
+        $lifecycle->regenerate();
+
+        self::assertFalse($session->shouldRegenerate());
+    }
+}
+
+/**
+ * HordeSession test double that captures the callback handed to
+ * reEncryptAll() and runs it under a warning-tolerant error handler.
+ * Lets us pin the SessionLifecycle::regenerate() wiring at unit
+ * scope without booting a real PHP session — session_regenerate_id()
+ * inside the callback emits a CLI warning that would otherwise trip
+ * phpunit.xml.dist's failOnWarning rule.
+ */
+class CapturingHordeSession extends HordeSession
+{
+    public bool $reEncryptAllCalled = false;
+    public ?\Closure $capturedRotation = null;
+
+    public function reEncryptAll(\Closure $rotate): void
+    {
+        $this->reEncryptAllCalled = true;
+        $this->capturedRotation = $rotate;
+
+        // Run the rotation but suppress the inevitable
+        // "Session ID cannot be regenerated when there is no active
+        // session" warning from session_regenerate_id(). The rest of
+        // the callback (e.g. secret->setKey) still runs.
+        set_error_handler(static fn() => true, \E_WARNING);
+        try {
+            $rotate();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}
+
+/**
+ * SessionSecret test double that records setKey() invocations.
+ */
+class RecordingSessionSecret implements SessionSecret
+{
+    public bool $setKeyCalled = false;
+    public bool $clearKeyCalled = false;
+    public ?HordeSession $wiredSession = null;
+
+    public function setKey($keyname = 'generic')
+    {
+        $this->setKeyCalled = true;
+        return 'recorded-key';
+    }
+
+    public function clearKey($keyname = 'generic')
+    {
+        $this->clearKeyCalled = true;
+        return true;
+    }
+
+    public function setSession(HordeSession $session): void
+    {
+        $this->wiredSession = $session;
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the "Invalid PKCS#7 padding byte" fatal that surfaces during portal render when an encrypted session slot's per-session key has drifted from the ciphertext it protects (cookie eviction, session-id rotation without re-encrypt, upgrade boundary).

Four layered changes in one commit:

1. **`HordeSession::getEncrypted`** catches decrypt failures and returns `null` instead of letting the throwable escape. `AuthCredentialStore::get` already turns null into `false`, so consumers degrade gracefully.
2. **`Horde_Core_Alarm_Handler_Mail`** (new, extends `Horde_Alarm_Handler` directly) defers `Horde_Mail` resolution to the first `notify()` call. Removes the eager IMAP-credential dereference from every portal render that touches the alarm notifier decorator.
3. **`SessionLifecycle::regenerate()`** drains plaintexts under the old key, calls `session_regenerate_id(true)` + `secret->setKey()`, re-encrypts under the new key. A new `HordeSession::reEncryptAll(\Closure $rotate)` packages the drain/rotate/refill sequence; slots that fail to decrypt under the current key are dropped from both the data and the encryption map.
4. **`Horde_Core_Secret_Cbc`** now persists the per-session key in the session payload (`$_SESSION['_secret']['key']`) via a new `SessionSecret::setSession()` wiring point on `HordeSessionFactory::create()`. Migrates the value from the legacy `horde_secret_key` cookie on first read; cookie continues to be written for BC. This removes the cookie-only dependency that made the bug reproducible in the wild.

Threat-model note: collocating the key with the ciphertext is a deliberate trade. The split-trust property (an attacker with only the session row gets useless bytes) is restored by a follow-up HKDF design filed under `~/php/horde-development/libraries/core/session-encryption-hkdf-strategy-2026-06-25.md`.

Related: horde/imp#66, horde/imp#72.