### PR TITLE
feat(core): modern session/CSRF stack — NoopController, middleware, meta renderer, Bearer support

### DIFF
--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -407,9 +407,24 @@ class Horde_PageOutput
 
     /**
      * Output META tags to page.
+     *
+     * Before emitting the accumulated tags, asks {@see
+     * \Horde\Core\PageOutput\SessionApiMetaRenderer} to populate the
+     * `session-api` and `csrf-api` tags so the standalone client-side
+     * JS (`SessionApiClient.fromMeta()`) has its bootstrap data. The
+     * helper resolves its dependencies (RegistryState, Token, current
+     * request) from the global injector — the legacy `Horde_PageOutput`
+     * is already a global-injector consumer, so this fits the existing
+     * idiom. Modern PSR-15 page-rendering controllers will inject the
+     * helper directly instead.
+     *
+     * Safe to call when no session exists: the helper renders nothing
+     * in that case.
      */
     public function outputMetaTags()
     {
+        $this->injectSessionApiMetaTags();
+
         foreach ($this->metaTags as $key => $val) {
             echo '<meta content="' . $val['c'] . '" '
                 . ($val['h'] ? 'http-equiv' : 'name')
@@ -417,6 +432,56 @@ class Horde_PageOutput
         }
 
         $this->metaTags = [];
+    }
+
+    /**
+     * Populate the modern session-api / csrf-api meta tags via the
+     * shared renderer.
+     *
+     * Resolves the renderer from the global injector (legacy stack
+     * idiom). Pulls the current `HordeSession` from the same place
+     * `Horde_Registry::__construct()` published it. Failures are
+     * swallowed: meta-tag rendering must never block page output.
+     */
+    private function injectSessionApiMetaTags()
+    {
+        if (!isset($GLOBALS['injector'])) {
+            return;
+        }
+        try {
+            $renderer = $GLOBALS['injector']->getInstance(
+                \Horde\Core\PageOutput\SessionApiMetaRenderer::class
+            );
+            $session = $GLOBALS['injector']->getInstance(
+                \Horde\Core\Session\HordeSession::class
+            );
+        } catch (\Throwable $e) {
+            return;
+        }
+
+        // Re-use the existing $metaTags accumulator so the renderer's
+        // output goes through the same HTML escaping + ordering path
+        // as every other tag this class emits. SessionApiMetaRenderer's
+        // own renderTags() composes the HTML directly; addToCollector()
+        // pushes into AssetCollector. Neither matches the legacy
+        // accumulator shape exactly, so we call the per-tag helper
+        // method via reflection-free direct duplication of the names.
+        //
+        // The renderer encapsulates the values; this class still owns
+        // the rendering format on the legacy path.
+        $this->addMetaTag(
+            \Horde\Core\PageOutput\SessionApiMetaRenderer::META_SESSION_API,
+            $renderer->getSessionApiUrl(),
+            false,
+        );
+        $token = $renderer->mintCsrfToken($session);
+        if ($token !== null) {
+            $this->addMetaTag(
+                \Horde\Core\PageOutput\SessionApiMetaRenderer::META_CSRF_API,
+                $token,
+                false,
+            );
+        }
     }
 
     /**

--- a/src/Controller/NoopController.php
+++ b/src/Controller/NoopController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Controller;
+
+use Horde\Http\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Generic terminal PSR-15 handler for routes whose response is fully
+ * produced by middleware.
+ *
+ * Returns 204 No Content with an empty body. Mount on any route where
+ * the middleware chain owns the complete response — for example a route
+ * that runs {@see \Horde\Core\Middleware\CsrfRotationMiddleware} to emit
+ * `X-Csrf-Token`, a readiness probe whose middleware sets the status
+ * code, a future CORS preflight, or a session-invalidate endpoint where
+ * middleware drives the destroy flag.
+ *
+ * Has no awareness of sessions, CSRF, identity, configuration, or any
+ * other domain concept. Pure structural mount point.
+ *
+ * The strategy doc explains why two distinct API endpoints
+ * (`/api/v1/session/ping` and `/api/v1/session/csrf-token`) share this
+ * single controller: see
+ * `horde-development/strategies/session-to-jwt/canonical-session-auth-csrf-strategy-2026-06-26.md`
+ * §4.2.
+ */
+final class NoopController implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new Response(status: 204);
+    }
+}

--- a/src/Middleware/CsrfRotationMiddleware.php
+++ b/src/Middleware/CsrfRotationMiddleware.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Middleware;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Token;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Outbound CSRF rotation middleware.
+ *
+ * After the inner handler returns, mints a fresh CSRF token bound to
+ * the current session and writes it to the `X-Csrf-Token` response
+ * header. Routes that compose this middleware participate in a uniform
+ * "every response can carry a fresh CSRF" contract that the standalone
+ * {@see \Horde\Base\Js\SessionApiClient} (and any future modern JS
+ * client) relies on.
+ *
+ * Pairs with {@see ConditionalCsrfMiddleware} which validates the
+ * inbound token on state-changing requests. Rotation middleware sits
+ * **after** validation in the chain so that an inbound request with a
+ * stale token gets rejected (419) before the controller runs and
+ * before a new token is minted — preventing a rotation oracle.
+ *
+ * No-op when no session is attached to the request. A response carrying
+ * no `X-Csrf-Token` header signals to the client that no CSRF state
+ * exists to update; the client retains whatever token it had.
+ *
+ * Operates entirely against PSR-15 interfaces and {@see HordeSession}.
+ * Does NOT import {@see \Horde_Registry}, does NOT read `$GLOBALS`,
+ * does NOT call PHP's session module directly.
+ */
+final class CsrfRotationMiddleware implements MiddlewareInterface
+{
+    /** Response header carrying the rotated CSRF token. */
+    public const RESPONSE_HEADER = 'X-Csrf-Token';
+
+    public function __construct(
+        private readonly Token $tokenService,
+    ) {}
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        $response = $handler->handle($request);
+
+        $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+        if (!$session instanceof HordeSession) {
+            // No session to bind a token to. The client carries no CSRF
+            // state for this request; nothing to rotate. Leave the
+            // response untouched.
+            return $response;
+        }
+
+        $generated = $this->tokenService->generate(HordeSession::CSRF_SEED);
+
+        return $response->withHeader(self::RESPONSE_HEADER, $generated->token);
+    }
+}

--- a/src/Middleware/JwtSessionLoader.php
+++ b/src/Middleware/JwtSessionLoader.php
@@ -30,30 +30,41 @@ use Psr\Log\LoggerInterface;
 /**
  * Modern PSR-15 JWT-to-HordeSession loader.
  *
- * Reads the `horde_jwt_refresh` cookie, verifies the JWT, and loads
- * the matching {@see HordeSession} via {@see SessionHandler::load()}
- * keyed by the refresh token's `jti` (which IS the session id, per
- * the JWT-JTI architecture decision). The loaded session is set as
- * a request attribute under {@see ATTRIBUTE_SESSION}.
+ * Resolves a {@see HordeSession} from any of two JWT transports:
  *
- * Differs from the legacy {@see JwtSession} middleware in two ways:
+ * 1. **`Authorization: Bearer <access-jwt>`** — verified as an access
+ *    token. The session id comes from the access token's `refresh_jti`
+ *    claim, which points at the session row the paired refresh token
+ *    keys. Used by cross-domain SPAs, mobile clients, and any consumer
+ *    that cannot rely on cookies.
  *
- * - Uses {@see SessionHandler::load()} directly. Does NOT call
- *   `session_id()` and does NOT depend on PHP's session module
- *   running afterwards. Suited to modern PSR-15 routes that own
- *   their session lifecycle through {@see \Horde\Core\Session\SessionLifecycle}
- *   plus middleware, not through the legacy
- *   `Horde_Session::setup()` flow.
- * - Verifies the JWT before lookup. An unverified JTI must not be
- *   used to load a session row even though forging a valid JWT is
- *   computationally infeasible: verification catches expired
- *   refresh tokens and rejected signatures cheaply.
+ * 2. **`horde_jwt_refresh` cookie** — verified as a refresh token. The
+ *    session id IS the refresh token's `jti` claim (per the JWT-JTI
+ *    architecture decision). Used by browser flows that landed at
+ *    Horde-rendered login.
+ *
+ * Bearer wins when both are present, on the principle that the explicit
+ * header beats the passive cookie. Logs at info level so client bugs
+ * that send both inadvertently surface in logs.
+ *
+ * Both paths use {@see SessionHandler::load()} directly. Neither path
+ * calls `session_id()` and neither depends on PHP's session module
+ * running afterwards. Suited to modern PSR-15 routes that own their
+ * session lifecycle through {@see \Horde\Core\Session\SessionLifecycle}
+ * plus middleware, not through the legacy `Horde_Session::setup()` flow.
+ *
+ * The JWT is verified before the lookup in both paths. An unverified
+ * jti must not be used to load a session row even though forging a
+ * valid JWT is computationally infeasible: verification catches expired
+ * tokens and rejected signatures cheaply.
  *
  * Never short-circuits. Routes that need to demand authentication
  * compose this with {@see DemandAuthenticatedUser} or similar
- * downstream middleware. Failure modes (no cookie, invalid cookie,
- * verification failure, no matching session row) all leave the
- * request attribute unset and let the inner handler run normally.
+ * downstream middleware. Failure modes (no transport, invalid token,
+ * verification failure, no matching session row) all leave the request
+ * attribute unset and let the inner handler run normally; the
+ * downstream {@see HordeSessionMiddleware} then minds the `Horde`
+ * session-id cookie path.
  */
 class JwtSessionLoader implements MiddlewareInterface
 {
@@ -62,6 +73,12 @@ class JwtSessionLoader implements MiddlewareInterface
 
     /** Cookie name for the JWT refresh token. */
     public const COOKIE_NAME = 'horde_jwt_refresh';
+
+    /** Request header carrying the JWT access token (Bearer scheme). */
+    public const AUTHORIZATION_HEADER = 'Authorization';
+
+    /** Bearer scheme prefix in the Authorization header (case-insensitive match). */
+    private const BEARER_PREFIX = 'Bearer ';
 
     public function __construct(
         private readonly ?JwtService $jwtService,
@@ -81,11 +98,12 @@ class JwtSessionLoader implements MiddlewareInterface
     }
 
     /**
-     * Resolve a {@see HordeSession} from the request's JWT refresh cookie.
+     * Resolve a {@see HordeSession} from any JWT transport on the request.
      *
-     * Returns null and logs the reason for any failure. The middleware
-     * never raises; the worst case is that the inner handler runs
-     * without a session attribute and downstream code treats the
+     * Tries `Authorization: Bearer` first, then the `horde_jwt_refresh`
+     * cookie. Returns null and logs the reason for any failure. The
+     * middleware never raises; the worst case is that the inner handler
+     * runs without a session attribute and downstream code treats the
      * request as unauthenticated.
      */
     private function resolveSession(ServerRequestInterface $request): ?HordeSession
@@ -97,19 +115,103 @@ class JwtSessionLoader implements MiddlewareInterface
             return null;
         }
 
-        $cookies = $request->getCookieParams();
-        $jwt = $cookies[self::COOKIE_NAME] ?? null;
-        if (!is_string($jwt) || $jwt === '') {
+        $bearerToken = $this->extractBearerToken($request);
+        $cookieToken = $this->extractCookieToken($request);
+
+        if ($bearerToken !== null && $cookieToken !== null) {
+            // Both transports present. Use Bearer (explicit header beats
+            // passive cookie) but log so client misconfigurations are
+            // visible in operator logs.
+            $this->logger->info(
+                'JwtSessionLoader: both Authorization: Bearer header and '
+                . self::COOKIE_NAME . ' cookie are present; using Bearer'
+            );
+        }
+
+        if ($bearerToken !== null) {
+            $session = $this->loadFromBearer($bearerToken);
+            if ($session !== null) {
+                return $session;
+            }
+            // Bearer failed verification or session lookup. Do NOT fall
+            // through to the cookie: if the caller sent a Bearer, they
+            // were explicit about which transport to use. Falling through
+            // could log a user in via a stale cookie when the Bearer
+            // intentionally pointed at a different session.
             return null;
         }
 
+        if ($cookieToken !== null) {
+            return $this->loadFromCookie($cookieToken);
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the Bearer token from the Authorization header.
+     *
+     * Returns null when no Authorization header is present or the scheme
+     * is not Bearer (e.g. Basic auth). Empty Bearer token strings (just
+     * `Bearer ` with no value) are treated as absent.
+     */
+    private function extractBearerToken(ServerRequestInterface $request): ?string
+    {
+        $header = $request->getHeaderLine(self::AUTHORIZATION_HEADER);
+        if ($header === '') {
+            return null;
+        }
+        if (stripos($header, self::BEARER_PREFIX) !== 0) {
+            // Non-Bearer Authorization (Basic, Digest, etc.). Not our concern.
+            return null;
+        }
+        $token = trim(substr($header, strlen(self::BEARER_PREFIX)));
+        return $token !== '' ? $token : null;
+    }
+
+    /**
+     * Extract the refresh-token JWT from the cookie.
+     */
+    private function extractCookieToken(ServerRequestInterface $request): ?string
+    {
+        $cookies = $request->getCookieParams();
+        $jwt = $cookies[self::COOKIE_NAME] ?? null;
+        return is_string($jwt) && $jwt !== '' ? $jwt : null;
+    }
+
+    /**
+     * Verify an access token and load the session row via the
+     * `refresh_jti` claim.
+     */
+    private function loadFromBearer(string $token): ?HordeSession
+    {
         try {
-            $verified = $this->jwtService->verifyRefreshToken($jwt);
+            $verified = $this->jwtService->verifyAccessToken($token);
         } catch (InvalidArgumentException $e) {
-            // Expired, malformed, or signature-rejected. The session row
-            // (if it exists) is no longer reachable by this token. Treat
-            // as unauthenticated and let downstream code redirect to
-            // login.
+            $this->logger->debug('JWT access token verification failed', [
+                'exception' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        $refreshJti = $verified->getClaim('refresh_jti');
+        if (!is_string($refreshJti) || $refreshJti === '') {
+            $this->logger->debug('JWT access token has no refresh_jti claim');
+            return null;
+        }
+
+        return $this->loadSessionRow($refreshJti, 'bearer');
+    }
+
+    /**
+     * Verify a refresh token and load the session row via the `jti`
+     * claim.
+     */
+    private function loadFromCookie(string $token): ?HordeSession
+    {
+        try {
+            $verified = $this->jwtService->verifyRefreshToken($token);
+        } catch (InvalidArgumentException $e) {
             $this->logger->debug('JWT refresh token verification failed', [
                 'exception' => $e->getMessage(),
             ]);
@@ -122,13 +224,22 @@ class JwtSessionLoader implements MiddlewareInterface
             return null;
         }
 
+        return $this->loadSessionRow($jti, 'cookie');
+    }
+
+    /**
+     * Load a session row by id. Shared tail of both transports.
+     */
+    private function loadSessionRow(string $sessionId, string $transport): ?HordeSession
+    {
         try {
-            $session = $this->sessionHandler->load(new SessionId($jti));
+            $session = $this->sessionHandler->load(new SessionId($sessionId));
         } catch (SessionException $e) {
             // Backend storage error. Same outcome as a missing row:
             // unauthenticated.
             $this->logger->warning('JWT session lookup failed', [
-                'jti' => $jti,
+                'sid' => $sessionId,
+                'transport' => $transport,
                 'exception' => $e->getMessage(),
             ]);
             return null;
@@ -138,7 +249,10 @@ class JwtSessionLoader implements MiddlewareInterface
             // Token is valid (signature OK, not expired) but the session
             // row is gone. Logout destroyed it; or it was pruned by GC.
             // Token is effectively dead.
-            $this->logger->info('JWT session row not found', ['jti' => $jti]);
+            $this->logger->info('JWT session row not found', [
+                'sid' => $sessionId,
+                'transport' => $transport,
+            ]);
             return null;
         }
 
@@ -146,7 +260,8 @@ class JwtSessionLoader implements MiddlewareInterface
             // SessionHandler is configured with a non-HordeSession
             // factory. Defensive check; should not happen in production.
             $this->logger->warning('JWT session row is not a HordeSession', [
-                'jti' => $jti,
+                'sid' => $sessionId,
+                'transport' => $transport,
                 'class' => get_debug_type($session),
             ]);
             return null;

--- a/src/Middleware/SessionLifetimeMiddleware.php
+++ b/src/Middleware/SessionLifetimeMiddleware.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Middleware;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionConfig;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Inbound session-lifetime touch + outbound session-telemetry headers.
+ *
+ * On the way in (before the inner handler runs):
+ *
+ * - Touches the session's `_last_seen` slot to `time()`. The slot write
+ *   marks the session dirty, so {@see HordeSessionMiddleware}'s outbound
+ *   save-if-dirty persists the row, extending its backend TTL on file /
+ *   SQL / cache backends that key off update timestamps.
+ * - Reads the session's regeneration deadline via
+ *   {@see HordeSession::getRegenerationDeadline()}. If the wall clock
+ *   has passed it, calls {@see HordeSession::scheduleRegeneration()}.
+ *   The intent flag is consumed by
+ *   {@see HordeSessionMiddleware::finaliseRegenerated()} on response,
+ *   which rotates the id, re-keys, and emits a fresh `Set-Cookie`.
+ *
+ * On the way out (after the inner handler returns):
+ *
+ * - Emits `X-Next-Ping` carrying the cadence in seconds the JS client
+ *   should use for its next heartbeat. Computed as
+ *   `lifetime / 3` with a floor of 60 seconds, falling back to the
+ *   constructor's `$defaultNextPingSeconds` when the configured
+ *   lifetime is 0 (browser-session lifetime).
+ * - Emits `X-Session-Ts` carrying server `time()` so the client can
+ *   detect clock skew against its local time.
+ *
+ * No-op when no session is attached to the request — neither the
+ * inbound side effects nor the outbound headers happen, so the
+ * middleware is safe to compose on routes that don't always have a
+ * session.
+ *
+ * Reusable across any modern PSR-15 route that wants real traffic to
+ * extend session lifetime and broadcast the keep-alive cadence. The
+ * `/api/v1/session/ping` endpoint is the explicit consumer; any other
+ * authenticated API endpoint that composes this middleware also keeps
+ * the user's session alive for free.
+ *
+ * Operates entirely against PSR-15 interfaces and {@see HordeSession}.
+ * Does NOT import {@see \Horde_Registry}, does NOT read `$GLOBALS`,
+ * does NOT call PHP's session module directly.
+ */
+final class SessionLifetimeMiddleware implements MiddlewareInterface
+{
+    /** Response header carrying the next-ping cadence hint, in seconds. */
+    public const HEADER_NEXT_PING = 'X-Next-Ping';
+
+    /** Response header carrying the server's `time()` echo. */
+    public const HEADER_SESSION_TS = 'X-Session-Ts';
+
+    /** Session slot updated on every request through this middleware. */
+    public const SLOT_LAST_SEEN = '_last_seen';
+
+    /** Floor for `X-Next-Ping`, regardless of configured lifetime. */
+    public const MIN_PING_INTERVAL = 60;
+
+    public function __construct(
+        private readonly SessionConfig $sessionConfig,
+        private readonly int $defaultNextPingSeconds = 1200,
+    ) {}
+
+    public function process(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler,
+    ): ResponseInterface {
+        $session = $request->getAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION);
+
+        if ($session instanceof HordeSession) {
+            $this->touchLifetime($session);
+            $this->scheduleRotationIfDue($session);
+        }
+
+        $response = $handler->handle($request);
+
+        if ($session instanceof HordeSession) {
+            $response = $this->emitTelemetryHeaders($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Mark the session dirty so HordeSessionMiddleware persists it,
+     * which on TTL-based backends refreshes the row's expiry.
+     */
+    private function touchLifetime(HordeSession $session): void
+    {
+        $session->setScoped('horde', self::SLOT_LAST_SEEN, time());
+    }
+
+    /**
+     * Set the regeneration intent flag if the deadline has passed. The
+     * actual rotation runs in {@see HordeSessionMiddleware::finaliseRegenerated()}.
+     */
+    private function scheduleRotationIfDue(HordeSession $session): void
+    {
+        $deadline = $session->getRegenerationDeadline();
+        if ($deadline !== null && time() >= $deadline) {
+            $session->scheduleRegeneration();
+        }
+    }
+
+    /**
+     * Add `X-Next-Ping` and `X-Session-Ts` to the response.
+     */
+    private function emitTelemetryHeaders(ResponseInterface $response): ResponseInterface
+    {
+        return $response
+            ->withHeader(self::HEADER_NEXT_PING, (string) $this->resolveNextPingSeconds())
+            ->withHeader(self::HEADER_SESSION_TS, (string) time());
+    }
+
+    /**
+     * Compute the next-ping cadence hint in seconds.
+     *
+     * `lifetime / 3` gives the client roughly three heartbeats per
+     * session lifetime — enough margin to survive one missed ping
+     * before the session would otherwise time out. Floor at 60 seconds
+     * to keep the heartbeat sensible on aggressive short-lifetime
+     * deployments. Fall back to the constructor default when lifetime
+     * is 0 (PHP browser-session lifetime, no explicit timeout).
+     */
+    private function resolveNextPingSeconds(): int
+    {
+        $lifetime = $this->sessionConfig->lifetime;
+        if ($lifetime <= 0) {
+            return $this->defaultNextPingSeconds;
+        }
+        return max(self::MIN_PING_INTERVAL, (int) floor($lifetime / 3));
+    }
+}

--- a/src/PageOutput/SessionApiMetaRenderer.php
+++ b/src/PageOutput/SessionApiMetaRenderer.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\PageOutput;
+
+use Horde\Core\Config\RegistryState;
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Token;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Render the `<meta>` tags that bootstrap the modern session API for
+ * client-side JS.
+ *
+ * Emits two tags:
+ *
+ *   <meta name="session-api" content="https://webmail.example.com/horde/api/v1">
+ *   <meta name="csrf-api"    content="<initial CSRF token>">
+ *
+ * The values are derived from {@see RegistryState} (NOT
+ * {@see \Horde_Registry}) plus the active PSR-7 request and the active
+ * {@see HordeSession}:
+ *
+ * - The base URL composes the request's scheme + host + (non-default)
+ *   port with the `horde` app's `webroot` from `RegistryState` and the
+ *   constant API path `/api/v1`. Cross-subdomain deployments serving
+ *   `webmail.example.com/calendar.example.com` get the right host
+ *   automatically because the request carries it. Non-standard ports
+ *   (`:8443`, `:8080`) are preserved.
+ *
+ * - The CSRF token is minted via {@see Token::generate()} bound to
+ *   {@see HordeSession::CSRF_SEED}. The {@see Token} service's storage
+ *   guarantees a freshly-minted token validates on the next
+ *   state-changing request.
+ *
+ * Anonymous sessions are emitted just like authenticated ones; anonymous
+ * forms need CSRF protection too.
+ *
+ * The helper itself touches no globals. Legacy `Horde_PageOutput`
+ * resolves it via the global injector (`$GLOBALS['injector']`) but the
+ * resolution stays in the legacy caller; this class only depends on
+ * what it gets in the constructor. Modern PSR-15 page-rendering
+ * controllers inject this directly and call {@see addToCollector()}
+ * with their request-attribute session.
+ *
+ * @see \Horde\Core\PageOutput\AssetCollector::addMetaTag()
+ * @see \Horde\Base\Js\SessionApiClient.fromMeta() (consumer side)
+ */
+final class SessionApiMetaRenderer
+{
+    public const META_SESSION_API = 'session-api';
+    public const META_CSRF_API = 'csrf-api';
+
+    private const API_PATH = '/api/v1';
+
+    public function __construct(
+        private readonly RegistryState $registryState,
+        private readonly Token $tokenService,
+        private readonly ?ServerRequestInterface $request = null,
+    ) {}
+
+    /**
+     * Render both meta tags as a single HTML string.
+     *
+     * Returns an empty string when no session is available; without a
+     * session there is no CSRF token to mint and the client has no use
+     * for a half-populated bootstrap.
+     */
+    public function renderTags(?HordeSession $session): string
+    {
+        if ($session === null) {
+            return '';
+        }
+
+        $sessionApi = $this->getSessionApiUrl();
+        $csrfApi = $this->mintCsrfToken($session);
+
+        return $this->renderMeta(self::META_SESSION_API, $sessionApi)
+            . $this->renderMeta(self::META_CSRF_API, $csrfApi);
+    }
+
+    /**
+     * Add both meta tags to a modern {@see AssetCollector}.
+     *
+     * No-op when no session is available.
+     */
+    public function addToCollector(AssetCollector $collector, ?HordeSession $session): void
+    {
+        if ($session === null) {
+            return;
+        }
+
+        $collector->addMetaTag(self::META_SESSION_API, $this->getSessionApiUrl(), httpEquiv: false);
+        $collector->addMetaTag(self::META_CSRF_API, $this->mintCsrfToken($session), httpEquiv: false);
+    }
+
+    /**
+     * Compose the absolute API URL.
+     *
+     * Public accessor so legacy callers (Horde_PageOutput) can route
+     * the value through their own accumulator without going through
+     * renderTags() / addToCollector(). Modern callers usually prefer
+     * the bulk methods above.
+     *
+     * Pulls scheme + host + non-default port from the active request,
+     * the `horde` app's `webroot` from {@see RegistryState}, and the
+     * fixed API path. Falls back to a relative URL (webroot + path)
+     * when no request is available (CLI rendering, tests).
+     */
+    public function getSessionApiUrl(): string
+    {
+        $webroot = $this->hordeWebroot();
+        $path = rtrim($webroot, '/') . self::API_PATH;
+
+        if ($this->request === null) {
+            return $path;
+        }
+
+        $uri = $this->request->getUri();
+        $scheme = $uri->getScheme();
+        $host = $uri->getHost();
+        if ($scheme === '' || $host === '') {
+            return $path;
+        }
+
+        $absolute = $scheme . '://' . $host;
+        $port = $uri->getPort();
+        if ($port !== null && !$this->isDefaultPort($scheme, $port)) {
+            $absolute .= ':' . $port;
+        }
+        return $absolute . $path;
+    }
+
+    /**
+     * Mint a fresh CSRF token bound to the session-CSRF seed.
+     *
+     * Public accessor so legacy callers can fetch a token without
+     * going through renderTags() / addToCollector(). Returns null when
+     * no session is given so callers can omit the tag rather than
+     * emit an empty value.
+     */
+    public function mintCsrfToken(?HordeSession $session): ?string
+    {
+        if ($session === null) {
+            return null;
+        }
+        return $this->tokenService->generate(HordeSession::CSRF_SEED)->token;
+    }
+
+    /**
+     * Resolve the horde app's webroot from {@see RegistryState}.
+     *
+     * Defaults to `/horde` when the app is missing or has no webroot
+     * key. The fallback preserves the most common operator deployment
+     * shape, but a missing horde app entry indicates a misconfiguration
+     * worth fixing rather than papering over with silent defaults — the
+     * fallback's role is to keep meta-tag rendering working while the
+     * operator is diagnosing.
+     */
+    private function hordeWebroot(): string
+    {
+        $app = $this->registryState->getApplication('horde');
+        if ($app === null) {
+            return '/horde';
+        }
+        $webroot = $app['webroot'] ?? '/horde';
+        return is_string($webroot) && $webroot !== '' ? $webroot : '/horde';
+    }
+
+    /**
+     * Render a single `<meta name="..." content="...">` tag.
+     *
+     * Uses the `name=` attribute (not `http-equiv=`) for both tags;
+     * these are not HTTP-equivalent directives.
+     */
+    private function renderMeta(string $name, string $content): string
+    {
+        return '<meta name="'
+            . htmlspecialchars($name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            . '" content="'
+            . htmlspecialchars($content, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            . "\" />\n";
+    }
+
+    /**
+     * Whether the given port is the scheme's default and should be
+     * omitted from the rendered URL.
+     */
+    private function isDefaultPort(string $scheme, int $port): bool
+    {
+        return match (strtolower($scheme)) {
+            'http' => $port === 80,
+            'https' => $port === 443,
+            default => false,
+        };
+    }
+}

--- a/test/Unit/Controller/NoopControllerTest.php
+++ b/test/Unit/Controller/NoopControllerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\Controller;
+
+use Horde\Core\Controller\NoopController;
+use Horde\Http\ServerRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NoopController::class)]
+final class NoopControllerTest extends TestCase
+{
+    #[Test]
+    public function returns204NoContent(): void
+    {
+        $controller = new NoopController();
+        $request = new ServerRequest('GET', 'http://localhost/');
+
+        $response = $controller->handle($request);
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function returnsEmptyBody(): void
+    {
+        $controller = new NoopController();
+        $request = new ServerRequest('GET', 'http://localhost/');
+
+        $response = $controller->handle($request);
+
+        self::assertSame('', (string) $response->getBody());
+    }
+
+    #[Test]
+    public function ignoresRequestEntirely(): void
+    {
+        // The controller must produce the same response regardless of
+        // request method, body, headers, or attributes. Mounted at
+        // arbitrary routes, it has no domain logic.
+        $controller = new NoopController();
+
+        $getRequest = new ServerRequest('GET', 'http://localhost/health');
+        $postRequest = (new ServerRequest('POST', 'http://localhost/csrf-token'))
+            ->withHeader('X-Csrf-Token', 'arbitrary')
+            ->withAttribute('session', 'arbitrary');
+
+        $getResp = $controller->handle($getRequest);
+        $postResp = $controller->handle($postRequest);
+
+        self::assertSame(204, $getResp->getStatusCode());
+        self::assertSame(204, $postResp->getStatusCode());
+        self::assertSame('', (string) $getResp->getBody());
+        self::assertSame('', (string) $postResp->getBody());
+    }
+}

--- a/test/Unit/Middleware/CsrfRotationMiddlewareTest.php
+++ b/test/Unit/Middleware/CsrfRotationMiddlewareTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\Middleware;
+
+use Horde\Core\Middleware\CsrfRotationMiddleware;
+use Horde\Core\Middleware\HordeSessionMiddleware;
+use Horde\Core\Session\HordeSession;
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\SessionHandler\SessionId;
+use Horde\Token\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(CsrfRotationMiddleware::class)]
+final class CsrfRotationMiddlewareTest extends TestCase
+{
+    private Token $tokenService;
+    private ResponseFactory $responseFactory;
+
+    protected function setUp(): void
+    {
+        $this->tokenService = Token::null('test-secret-key');
+        $this->responseFactory = new ResponseFactory();
+    }
+
+    private function passthroughHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects(self::once())
+            ->method('handle')
+            ->willReturn($this->responseFactory->createResponse(200));
+        return $handler;
+    }
+
+    #[Test]
+    public function noSessionAttributeLeavesResponseUntouched(): void
+    {
+        $middleware = new CsrfRotationMiddleware($this->tokenService);
+        $request = new ServerRequest('POST', 'http://localhost/api/v1/session/ping');
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertFalse(
+            $response->hasHeader(CsrfRotationMiddleware::RESPONSE_HEADER),
+            'X-Csrf-Token must not be set when no session is attached',
+        );
+    }
+
+    #[Test]
+    public function sessionAttributeAddsFreshCsrfHeader(): void
+    {
+        $middleware = new CsrfRotationMiddleware($this->tokenService);
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertTrue($response->hasHeader(CsrfRotationMiddleware::RESPONSE_HEADER));
+        $token = $response->getHeaderLine(CsrfRotationMiddleware::RESPONSE_HEADER);
+        self::assertNotEmpty($token);
+        // The token must validate against the same service and seed.
+        self::assertTrue(
+            $this->tokenService->isValid($token, HordeSession::CSRF_SEED),
+            'Emitted token must validate against the CSRF seed',
+        );
+    }
+
+    #[Test]
+    public function twoCallsEmitDifferentTokens(): void
+    {
+        $middleware = new CsrfRotationMiddleware($this->tokenService);
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $first = $middleware->process($request, $this->passthroughHandler())
+            ->getHeaderLine(CsrfRotationMiddleware::RESPONSE_HEADER);
+        $second = $middleware->process($request, $this->passthroughHandler())
+            ->getHeaderLine(CsrfRotationMiddleware::RESPONSE_HEADER);
+
+        self::assertNotSame($first, $second, 'Each call should mint a fresh token');
+        self::assertTrue($this->tokenService->isValid($first, HordeSession::CSRF_SEED));
+        self::assertTrue($this->tokenService->isValid($second, HordeSession::CSRF_SEED));
+    }
+}

--- a/test/Unit/Middleware/JwtSessionLoaderTest.php
+++ b/test/Unit/Middleware/JwtSessionLoaderTest.php
@@ -278,4 +278,213 @@ class JwtSessionLoaderTest extends TestCase
         self::assertSame($this->defaultPayloadResponse, $response);
         self::assertNotNull($this->recentlyHandledRequest);
     }
+
+    // ===============================================================
+    // Bearer-header transport (added 2026-06-26)
+    //
+    // Authorization: Bearer <access-jwt> carries an access token whose
+    // `refresh_jti` claim points at the session row. The middleware
+    // verifies as an access token and loads the row by refresh_jti.
+    // ===============================================================
+
+    /** Stub a verified access token exposing a `refresh_jti` claim. */
+    private function verifiedAccessJwtWithRefreshJti(string $refreshJti): VerifiedJwt
+    {
+        $verified = $this->createStub(VerifiedJwt::class);
+        $verified->method('getClaim')->willReturnCallback(
+            static fn(string $name, mixed $default = null): mixed
+                => $name === 'refresh_jti' ? $refreshJti : $default,
+        );
+        return $verified;
+    }
+
+    /** Build a request with the given Authorization header. */
+    private function requestWithAuthHeader(string $value)
+    {
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        return $request->withHeader('Authorization', $value);
+    }
+
+    #[Test]
+    public function testNoAuthorizationHeaderAndNoCookieLeavesAttributeUnset(): void
+    {
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::never())->method('verifyAccessToken');
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestFactory->createServerRequest('GET', '/test'),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testNonBearerAuthorizationHeaderIsIgnored(): void
+    {
+        // Basic auth, Digest auth, etc. — not our concern.
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::never())->method('verifyAccessToken');
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithAuthHeader('Basic dXNlcjpwYXNz'),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testEmptyBearerTokenIsIgnored(): void
+    {
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::never())->method('verifyAccessToken');
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithAuthHeader('Bearer '),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testValidBearerLoadsSessionViaRefreshJti(): void
+    {
+        $refreshJti = 'session-id-from-refresh-jti';
+        $serialised = new SerializedSessionPayload(
+            serialize(['horde' => ['auth/userId' => 'bob']])
+        );
+
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())
+            ->method('verifyAccessToken')
+            ->with('access-token-value')
+            ->willReturn($this->verifiedAccessJwtWithRefreshJti($refreshJti));
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())->method('load')->willReturnCallback(
+            static fn(SessionId $id): ?SerializedSessionPayload
+                => (string) $id === $refreshJti ? $serialised : null,
+        );
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithAuthHeader('Bearer access-token-value'),
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertSame('bob', $session->getAuthenticatedUser());
+    }
+
+    #[Test]
+    public function testBearerVerifyFailureLeavesAttributeUnsetAndDoesNotFallThroughToCookie(): void
+    {
+        // When the caller sent a Bearer header, they were explicit about
+        // which transport to use. A failure must NOT silently fall back
+        // to a cookie that may point at a different session.
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())
+            ->method('verifyAccessToken')
+            ->willThrowException(new InvalidArgumentException('signature mismatch'));
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $request = $this->requestWithAuthHeader('Bearer bad-token')
+            ->withCookieParams([JwtSessionLoader::COOKIE_NAME => 'cookie-token']);
+
+        $this->middleware($jwt, $backend)->process(
+            $request,
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testBearerAccessTokenWithoutRefreshJtiClaimLeavesAttributeUnset(): void
+    {
+        $verified = $this->createStub(VerifiedJwt::class);
+        $verified->method('getClaim')->willReturn(null);
+
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())->method('verifyAccessToken')->willReturn($verified);
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::never())->method('load');
+
+        $this->middleware($jwt, $backend)->process(
+            $this->requestWithAuthHeader('Bearer access-token'),
+            $this->defaultPayloadHandler,
+        );
+
+        self::assertNull(
+            $this->recentlyHandledRequest->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION),
+        );
+    }
+
+    #[Test]
+    public function testBearerWinsWhenBothTransportsPresent(): void
+    {
+        // Both transports carry valid JWTs that resolve to *different*
+        // sessions. Bearer must win and the cookie path must NOT run.
+        $bearerRefreshJti = 'session-from-bearer';
+        $bearerSession = new SerializedSessionPayload(
+            serialize(['horde' => ['auth/userId' => 'bearer-user']])
+        );
+
+        $jwt = $this->createMock(JwtService::class);
+        $jwt->expects(self::once())
+            ->method('verifyAccessToken')
+            ->with('access-token')
+            ->willReturn($this->verifiedAccessJwtWithRefreshJti($bearerRefreshJti));
+        $jwt->expects(self::never())->method('verifyRefreshToken');
+
+        $backend = $this->createMock(SessionStorageBackend::class);
+        $backend->expects(self::once())->method('load')->willReturnCallback(
+            static fn(SessionId $id): ?SerializedSessionPayload
+                => (string) $id === $bearerRefreshJti ? $bearerSession : null,
+        );
+
+        $request = $this->requestWithAuthHeader('Bearer access-token')
+            ->withCookieParams([JwtSessionLoader::COOKIE_NAME => 'cookie-refresh-token']);
+
+        $this->middleware($jwt, $backend)->process(
+            $request,
+            $this->defaultPayloadHandler,
+        );
+
+        $session = $this->recentlyHandledRequest
+            ->getAttribute(JwtSessionLoader::ATTRIBUTE_SESSION);
+
+        self::assertInstanceOf(HordeSession::class, $session);
+        self::assertSame('bearer-user', $session->getAuthenticatedUser());
+    }
 }

--- a/test/Unit/Middleware/SessionLifetimeMiddlewareTest.php
+++ b/test/Unit/Middleware/SessionLifetimeMiddlewareTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\Middleware;
+
+use Horde\Core\Middleware\HordeSessionMiddleware;
+use Horde\Core\Middleware\SessionLifetimeMiddleware;
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionConfig;
+use Horde\Http\ResponseFactory;
+use Horde\Http\ServerRequest;
+use Horde\SessionHandler\SessionId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(SessionLifetimeMiddleware::class)]
+final class SessionLifetimeMiddlewareTest extends TestCase
+{
+    private ResponseFactory $responseFactory;
+
+    protected function setUp(): void
+    {
+        $this->responseFactory = new ResponseFactory();
+    }
+
+    private function config(int $lifetime = 3600, int $regenerateInterval = 21600): SessionConfig
+    {
+        return new SessionConfig(
+            cookieName: 'Horde',
+            cookieDomain: null,
+            cookiePath: '/',
+            secure: false,
+            lifetime: $lifetime,
+            regenerateInterval: $regenerateInterval,
+            cacheLimiter: null,
+        );
+    }
+
+    private function passthroughHandler(): RequestHandlerInterface
+    {
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects(self::once())
+            ->method('handle')
+            ->willReturn($this->responseFactory->createResponse(200));
+        return $handler;
+    }
+
+    #[Test]
+    public function noSessionAttributeIsPassThroughWithoutHeaders(): void
+    {
+        $middleware = new SessionLifetimeMiddleware($this->config());
+        $request = new ServerRequest('GET', 'http://localhost/api/v1/something');
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertFalse($response->hasHeader(SessionLifetimeMiddleware::HEADER_NEXT_PING));
+        self::assertFalse($response->hasHeader(SessionLifetimeMiddleware::HEADER_SESSION_TS));
+    }
+
+    #[Test]
+    public function sessionAttributeWritesLastSeenSlot(): void
+    {
+        $middleware = new SessionLifetimeMiddleware($this->config());
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $before = time();
+        $middleware->process($request, $this->passthroughHandler());
+        $after = time();
+
+        $value = $session->getScoped('horde', SessionLifetimeMiddleware::SLOT_LAST_SEEN);
+        self::assertIsInt($value);
+        self::assertGreaterThanOrEqual($before, $value);
+        self::assertLessThanOrEqual($after, $value);
+    }
+
+    #[Test]
+    public function deadlineNotPastDoesNotScheduleRotation(): void
+    {
+        $middleware = new SessionLifetimeMiddleware($this->config());
+        $session = new HordeSession(new SessionId('test-sid'));
+        $session->setRegenerationDeadline(time() + 3600); // 1h in the future
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $middleware->process($request, $this->passthroughHandler());
+
+        self::assertFalse($session->shouldRegenerate());
+    }
+
+    #[Test]
+    public function deadlinePastSchedulesRotation(): void
+    {
+        $middleware = new SessionLifetimeMiddleware($this->config());
+        $session = new HordeSession(new SessionId('test-sid'));
+        $session->setRegenerationDeadline(time() - 60); // 1m in the past
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $middleware->process($request, $this->passthroughHandler());
+
+        self::assertTrue($session->shouldRegenerate());
+    }
+
+    #[Test]
+    public function emitsNextPingHeaderAsLifetimeOverThree(): void
+    {
+        // lifetime 3600 → next ping 1200
+        $middleware = new SessionLifetimeMiddleware($this->config(lifetime: 3600));
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertSame(
+            '1200',
+            $response->getHeaderLine(SessionLifetimeMiddleware::HEADER_NEXT_PING),
+        );
+    }
+
+    #[Test]
+    public function nextPingFlooredAt60Seconds(): void
+    {
+        // lifetime 60 → /3 = 20, but the floor is 60
+        $middleware = new SessionLifetimeMiddleware($this->config(lifetime: 60));
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertSame(
+            (string) SessionLifetimeMiddleware::MIN_PING_INTERVAL,
+            $response->getHeaderLine(SessionLifetimeMiddleware::HEADER_NEXT_PING),
+        );
+    }
+
+    #[Test]
+    public function nextPingFallbackWhenLifetimeIsZero(): void
+    {
+        // lifetime 0 → constructor default
+        $middleware = new SessionLifetimeMiddleware($this->config(lifetime: 0), defaultNextPingSeconds: 900);
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $response = $middleware->process($request, $this->passthroughHandler());
+
+        self::assertSame(
+            '900',
+            $response->getHeaderLine(SessionLifetimeMiddleware::HEADER_NEXT_PING),
+        );
+    }
+
+    #[Test]
+    public function emitsSessionTsHeaderAsServerTime(): void
+    {
+        $middleware = new SessionLifetimeMiddleware($this->config());
+        $session = new HordeSession(new SessionId('test-sid'));
+        $request = (new ServerRequest('POST', 'http://localhost/api/v1/session/ping'))
+            ->withAttribute(HordeSessionMiddleware::ATTRIBUTE_SESSION, $session);
+
+        $before = time();
+        $response = $middleware->process($request, $this->passthroughHandler());
+        $after = time();
+
+        $ts = (int) $response->getHeaderLine(SessionLifetimeMiddleware::HEADER_SESSION_TS);
+        self::assertGreaterThanOrEqual($before, $ts);
+        self::assertLessThanOrEqual($after, $ts);
+    }
+}

--- a/test/Unit/PageOutput/SessionApiMetaRendererTest.php
+++ b/test/Unit/PageOutput/SessionApiMetaRendererTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\PageOutput;
+
+use Horde\Core\Config\RegistryState;
+use Horde\Core\PageOutput\AssetCollector;
+use Horde\Core\PageOutput\SessionApiMetaRenderer;
+use Horde\Core\Session\HordeSession;
+use Horde\Http\ServerRequest;
+use Horde\SessionHandler\SessionId;
+use Horde\Token\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SessionApiMetaRenderer::class)]
+final class SessionApiMetaRendererTest extends TestCase
+{
+    private function makeRegistryState(string $webroot = '/horde'): RegistryState
+    {
+        return new RegistryState([
+            'horde' => [
+                'status' => 'active',
+                'webroot' => $webroot,
+                'fileroot' => '/var/www/horde',
+                'jsuri' => $webroot . '/js',
+                'themesuri' => $webroot . '/themes',
+                'staticuri' => $webroot . '/static',
+            ],
+        ]);
+    }
+
+    private function makeToken(): Token
+    {
+        return Token::null('test-secret-key');
+    }
+
+    private function makeSession(): HordeSession
+    {
+        return new HordeSession(new SessionId('test-sid'));
+    }
+
+    #[Test]
+    public function renderTagsReturnsEmptyWhenNoSession(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+
+        self::assertSame('', $renderer->renderTags(null));
+    }
+
+    #[Test]
+    public function renderTagsEmitsBothMetaTagsWithName(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+            request: null,
+        );
+
+        $html = $renderer->renderTags($this->makeSession());
+
+        self::assertStringContainsString('name="session-api"', $html);
+        self::assertStringContainsString('name="csrf-api"', $html);
+        // The tags must not use http-equiv — they are not HTTP-equivalent directives.
+        self::assertStringNotContainsString('http-equiv="session-api"', $html);
+        self::assertStringNotContainsString('http-equiv="csrf-api"', $html);
+    }
+
+    #[Test]
+    public function getSessionApiUrlIsRelativeWhenNoRequest(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState('/horde'),
+            $this->makeToken(),
+            request: null,
+        );
+
+        self::assertSame('/horde/api/v1', $renderer->getSessionApiUrl());
+    }
+
+    #[Test]
+    public function getSessionApiUrlIsAbsoluteWhenRequestAvailable(): void
+    {
+        $request = new ServerRequest('GET', 'https://webmail.example.com/horde/services/portal');
+
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState('/horde'),
+            $this->makeToken(),
+            request: $request,
+        );
+
+        self::assertSame(
+            'https://webmail.example.com/horde/api/v1',
+            $renderer->getSessionApiUrl(),
+        );
+    }
+
+    #[Test]
+    public function getSessionApiUrlPreservesNonStandardHttpsPort(): void
+    {
+        $request = new ServerRequest('GET', 'https://webmail.example.com:8443/horde/');
+
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState('/horde'),
+            $this->makeToken(),
+            request: $request,
+        );
+
+        self::assertSame(
+            'https://webmail.example.com:8443/horde/api/v1',
+            $renderer->getSessionApiUrl(),
+        );
+    }
+
+    #[Test]
+    public function getSessionApiUrlOmitsDefaultHttpsPort(): void
+    {
+        // Note: PSR-7 URIs may or may not preserve a default port at
+        // parse time. The renderer must omit :443 regardless.
+        $request = (new ServerRequest('GET', 'https://webmail.example.com/horde/'))
+            ->withUri(
+                (new ServerRequest('GET', 'https://webmail.example.com/horde/'))
+                    ->getUri()
+                    ->withPort(443)
+            );
+
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState('/horde'),
+            $this->makeToken(),
+            request: $request,
+        );
+
+        self::assertSame(
+            'https://webmail.example.com/horde/api/v1',
+            $renderer->getSessionApiUrl(),
+        );
+    }
+
+    #[Test]
+    public function getSessionApiUrlPreservesNonStandardHttpPort(): void
+    {
+        $request = new ServerRequest('GET', 'http://localhost:8080/horde/');
+
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState('/horde'),
+            $this->makeToken(),
+            request: $request,
+        );
+
+        self::assertSame(
+            'http://localhost:8080/horde/api/v1',
+            $renderer->getSessionApiUrl(),
+        );
+    }
+
+    #[Test]
+    public function getSessionApiUrlFallsBackToDefaultWebrootWhenHordeAppMissing(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            new RegistryState([]), // no horde app at all
+            $this->makeToken(),
+            request: null,
+        );
+
+        self::assertSame('/horde/api/v1', $renderer->getSessionApiUrl());
+    }
+
+    #[Test]
+    public function mintCsrfTokenReturnsNullForNullSession(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+
+        self::assertNull($renderer->mintCsrfToken(null));
+    }
+
+    #[Test]
+    public function mintCsrfTokenProducesValidatableToken(): void
+    {
+        $token = $this->makeToken();
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $token,
+        );
+
+        $minted = $renderer->mintCsrfToken($this->makeSession());
+
+        self::assertIsString($minted);
+        self::assertNotEmpty($minted);
+        self::assertTrue(
+            $token->isValid($minted, HordeSession::CSRF_SEED),
+            'Minted token must validate against the CSRF seed',
+        );
+    }
+
+    #[Test]
+    public function mintCsrfTokenReturnsDifferentValueEachCall(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+
+        $a = $renderer->mintCsrfToken($this->makeSession());
+        $b = $renderer->mintCsrfToken($this->makeSession());
+
+        self::assertNotSame($a, $b);
+    }
+
+    #[Test]
+    public function addToCollectorIsNoOpWhenNoSession(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+        $collector = new AssetCollector();
+
+        $renderer->addToCollector($collector, null);
+
+        self::assertStringNotContainsString('session-api', $collector->renderMetaTags());
+        self::assertStringNotContainsString('csrf-api', $collector->renderMetaTags());
+    }
+
+    #[Test]
+    public function addToCollectorPushesBothTagsWhenSessionPresent(): void
+    {
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+        $collector = new AssetCollector();
+
+        $renderer->addToCollector($collector, $this->makeSession());
+        $html = $collector->renderMetaTags();
+
+        self::assertStringContainsString('name="session-api"', $html);
+        self::assertStringContainsString('name="csrf-api"', $html);
+        self::assertStringContainsString('/horde/api/v1', $html);
+    }
+
+    #[Test]
+    public function metaContentIsHtmlEscaped(): void
+    {
+        // The CSRF token is opaque bytes; if any character requires
+        // escaping it must be HTML-escaped, not passed through raw.
+        // We can't easily force a known-escapable token from Token::null,
+        // so this test ensures the render path uses htmlspecialchars on
+        // attributes by verifying no raw quotes leak into the output.
+        $renderer = new SessionApiMetaRenderer(
+            $this->makeRegistryState(),
+            $this->makeToken(),
+        );
+
+        $html = $renderer->renderTags($this->makeSession());
+        // Each meta tag has exactly four `"` quote chars: name="..." content="..."
+        // Tags are 2, so 8 total. More would indicate unescaped content.
+        $quoteCount = substr_count($html, '"');
+        self::assertSame(8, $quoteCount, 'Unexpected quote count suggests unescaped content');
+    }
+}


### PR DESCRIPTION
## Summary

Five small commits adding the server-side substrate for a standalone modern session/CSRF API the JS side can talk to without going through HordeCore/HordeMobile.

- `Horde\Core\Controller\NoopController` — generic 204 terminal handler for routes whose response is fully produced by middleware. Reusable for ping, csrf-refresh, readiness, future CORS preflight, etc.
- `Horde\Core\Middleware\JwtSessionLoader` — extended to also handle `Authorization: Bearer` access tokens (resolving `refresh_jti` claim) alongside its existing `horde_jwt_refresh` cookie path. Bearer wins on dual presence with an info log.
- `Horde\Core\Middleware\CsrfRotationMiddleware` — emits `X-Csrf-Token` response header bound to the request's HordeSession.
- `Horde\Core\Middleware\SessionLifetimeMiddleware` — touches `_last_seen` slot to refresh backend TTL, schedules regeneration when deadline past, emits `X-Next-Ping` + `X-Session-Ts` response headers.
- `Horde\Core\PageOutput\SessionApiMetaRenderer` — renders the bootstrap `<meta name="session-api">` and `<meta name="csrf-api">` tags from `RegistryState` + `Token` + the current request. Legacy `Horde_PageOutput::outputMetaTags()` now calls it before emitting accumulated tags so existing pages get the bootstrap automatically.

Strategy doc: `horde-development/strategies/session-to-jwt/canonical-session-auth-csrf-strategy-2026-06-26.md` §4.2.

Companion routes + JS client land in horde/base.