### PR TITLE
fix: prevent double HTML encoding of logout URL in smartmobile header

### DIFF
--- a/lib/Horde/Core/Smartmobile/View/Helper.php
+++ b/lib/Horde/Core/Smartmobile/View/Helper.php
@@ -62,7 +62,7 @@ class Horde_Core_Smartmobile_View_Helper extends Horde_View_Helper_Base
         if (!empty($params['logout']) && $registry->showService('logout')) {
             $logout = $registry->getLogoutUrl([
                 'reason' => Horde_Auth::REASON_LOGOUT,
-            ])->setRaw(false);
+            ])->setRaw(true);
             $out .= '<a class="smartmobile-logout ui-btn-right" href="'
                 . htmlspecialchars((string) $logout)
                 . '" data-ajax="false" data-theme="e" data-icon="delete">'


### PR DESCRIPTION
setRaw(false) already encodes & as &amp;, then htmlspecialchars() encodes it again, resulting in amp;logout_reason as a GET parameter and a broken logout flow in mobile/smartmobile mode.

Fix: use setRaw(true) and let htmlspecialchars() do the HTML encoding once.

Closes #165