### PR TITLE
Let a theme opt out of the default-theme CSS fallback

### DIFF
--- a/lib/Horde/Themes/Cache.php
+++ b/lib/Horde/Themes/Cache.php
@@ -240,13 +240,19 @@ class Horde_Themes_Cache implements Serializable
     protected function _inheritsDefault()
     {
         if (!isset($this->_inherits)) {
-            global $registry;
-
             $theme_inherits = true;
-            $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
-            if (is_readable($info)) {
-                include $info;
+
+            /* Theme names originate from user prefs/options, so guard against
+             * path traversal: only include info.php for a plain directory name
+             * (no separators, no '..'). Anything else falls back to inheriting. */
+            if (preg_match('/^[A-Za-z0-9_-]+$/', (string)$this->_theme)) {
+                global $registry;
+                $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
+                if (is_readable($info)) {
+                    include $info;
+                }
             }
+
             $this->_inherits = (bool)$theme_inherits;
         }
 
@@ -272,10 +278,10 @@ class Horde_Themes_Cache implements Serializable
         if ($entry & self::HORDE_THEME) {
             $out[] = $this->_getOutput('horde', $this->_theme, $item);
         }
-        if (($this->_theme != 'default') && $this->_inheritsDefault() && ($entry & self::APP_DEFAULT)) {
+        if (($entry & self::APP_DEFAULT) && ($this->_theme != 'default') && $this->_inheritsDefault()) {
             $out[] = $this->_getOutput($this->_app, 'default', $item);
         }
-        if (($this->_theme != 'default') && $this->_inheritsDefault() && ($entry & self::HORDE_DEFAULT)) {
+        if (($entry & self::HORDE_DEFAULT) && ($this->_theme != 'default') && $this->_inheritsDefault()) {
             $out[] = $this->_getOutput('horde', 'default', $item);
         }
 

--- a/lib/Horde/Themes/Cache.php
+++ b/lib/Horde/Themes/Cache.php
@@ -74,6 +74,13 @@ class Horde_Themes_Cache implements Serializable
     protected $_theme;
 
     /**
+     * Cached result of the theme's "inherits default" flag.
+     *
+     * @var boolean
+     */
+    protected $_inherits;
+
+    /**
      * Constructor.
      *
      * @param string $app    The application name.
@@ -222,6 +229,31 @@ class Horde_Themes_Cache implements Serializable
     }
 
     /**
+     * Whether the current theme inherits CSS from the default theme.
+     *
+     * A theme can opt out of the default-theme fallback by setting
+     * `$theme_inherits = false;` in its info.php. Themes without the flag
+     * keep inheriting from the default theme (backwards compatible).
+     *
+     * @return boolean  True if the default-theme fallback applies.
+     */
+    protected function _inheritsDefault()
+    {
+        if (!isset($this->_inherits)) {
+            global $registry;
+
+            $theme_inherits = true;
+            $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
+            if (is_readable($info)) {
+                include $info;
+            }
+            $this->_inherits = (bool)$theme_inherits;
+        }
+
+        return $this->_inherits;
+    }
+
+    /**
      */
     public function getAll($item, $mask = 0)
     {
@@ -240,10 +272,10 @@ class Horde_Themes_Cache implements Serializable
         if ($entry & self::HORDE_THEME) {
             $out[] = $this->_getOutput('horde', $this->_theme, $item);
         }
-        if (($this->_theme != 'default') && $entry & self::APP_DEFAULT) {
+        if (($this->_theme != 'default') && $this->_inheritsDefault() && ($entry & self::APP_DEFAULT)) {
             $out[] = $this->_getOutput($this->_app, 'default', $item);
         }
-        if (($this->_theme != 'default') && $entry & self::HORDE_DEFAULT) {
+        if (($this->_theme != 'default') && $this->_inheritsDefault() && ($entry & self::HORDE_DEFAULT)) {
             $out[] = $this->_getOutput('horde', 'default', $item);
         }
 

--- a/lib/Horde/Themes/Cache.php
+++ b/lib/Horde/Themes/Cache.php
@@ -74,11 +74,12 @@ class Horde_Themes_Cache implements Serializable
     protected $_theme;
 
     /**
-     * Cached result of the theme's "inherits default" flag.
+     * Cached list of apps the theme declares it covers completely (lower-cased,
+     * 'horde' meaning the shell). Read from the theme's info.php.
      *
-     * @var boolean
+     * @var string[]
      */
-    protected $_inherits;
+    protected $_covers;
 
     /**
      * Constructor.
@@ -229,22 +230,30 @@ class Horde_Themes_Cache implements Serializable
     }
 
     /**
-     * Whether the current theme inherits CSS from the default theme.
+     * Returns the list of "apps" (including the special 'horde' shell) that
+     * the current theme declares it covers completely.
      *
-     * A theme can opt out of the default-theme fallback by setting
-     * `$theme_inherits = false;` in its info.php. Themes without the flag
-     * keep inheriting from the default theme (backwards compatible).
+     * A theme opts out of the default-theme CSS fallback on a per-app basis by
+     * listing those apps in its info.php:
      *
-     * @return boolean  True if the default-theme fallback applies.
+     *   $theme_covers = array('horde', 'imp', 'kronolith');
+     *
+     * For a covered app the default-theme CSS is not loaded underneath the
+     * theme. Apps that are NOT listed keep inheriting their own default theme
+     * CSS, so a third-party app that ships its own default/ assets still works.
+     *
+     * Themes without the declaration inherit everything, exactly as before.
+     *
+     * @return string[]  Lower-cased app names fully covered by the theme.
      */
-    protected function _inheritsDefault()
+    protected function _coveredApps()
     {
-        if (!isset($this->_inherits)) {
-            $theme_inherits = true;
+        if (!isset($this->_covers)) {
+            $theme_covers = array();
 
             /* Theme names originate from user prefs/options, so guard against
              * path traversal: only include info.php for a plain directory name
-             * (no separators, no '..'). Anything else falls back to inheriting. */
+             * (no separators, no '..'). Anything else inherits everything. */
             if (preg_match('/^[A-Za-z0-9_-]+$/', (string)$this->_theme)) {
                 global $registry;
                 $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
@@ -253,10 +262,23 @@ class Horde_Themes_Cache implements Serializable
                 }
             }
 
-            $this->_inherits = (bool)$theme_inherits;
+            $this->_covers = array_map('strtolower', (array)$theme_covers);
         }
 
-        return $this->_inherits;
+        return $this->_covers;
+    }
+
+    /**
+     * Whether the theme covers the given app (so the default-theme CSS
+     * fallback for that app should be skipped).
+     *
+     * @param string $app  The app name ('horde' for the shell).
+     *
+     * @return boolean  True if the theme fully covers $app.
+     */
+    protected function _covers($app)
+    {
+        return in_array(strtolower($app), $this->_coveredApps(), true);
     }
 
     /**
@@ -278,10 +300,13 @@ class Horde_Themes_Cache implements Serializable
         if ($entry & self::HORDE_THEME) {
             $out[] = $this->_getOutput('horde', $this->_theme, $item);
         }
-        if (($entry & self::APP_DEFAULT) && ($this->_theme != 'default') && $this->_inheritsDefault()) {
+        /* Load the default-theme CSS as a fallback, unless the theme declares
+         * it fully covers this app (app-level) or the horde shell. Apps not
+         * listed in the theme's $theme_covers keep their default fallback. */
+        if (($entry & self::APP_DEFAULT) && ($this->_theme != 'default') && !$this->_covers($this->_app)) {
             $out[] = $this->_getOutput($this->_app, 'default', $item);
         }
-        if (($entry & self::HORDE_DEFAULT) && ($this->_theme != 'default') && $this->_inheritsDefault()) {
+        if (($entry & self::HORDE_DEFAULT) && ($this->_theme != 'default') && !$this->_covers('horde')) {
             $out[] = $this->_getOutput('horde', 'default', $item);
         }
 


### PR DESCRIPTION
## Summary
Allow a theme to declare that it is standalone and should NOT inherit CSS from the `default` theme, by setting `$theme_inherits = false;` in its `info.php`. Themes without the flag keep inheriting from `default` exactly as today (backwards compatible).

## Problem
`Horde_Themes_Cache::getAll()` always loads the `default` theme's CSS as a fallback for any non-default theme. This is the right behaviour for a theme that only overrides a few things, but it makes a **fully autonomous theme** impossible: the default CSS leaks through wherever the custom theme doesn't have an explicit rule, producing inconsistent styling. There is currently no way for a theme to say "I cover everything, don't load the default theme underneath me".

## Solution
`Horde_Themes::themeList()` already `include`s each theme's `info.php` (to read `$theme_name`). We reuse that file: a theme sets `$theme_inherits = false;` and a new `_inheritsDefault()` getter in `Horde_Themes_Cache` reads it to skip the fallback in `getAll()`.

Theme side:
```php
// themes/horde/<theme>/info.php
$theme_name = _("My Theme");
$theme_inherits = false; // standalone: skip the default-theme fallback
```

## Backwards compatibility
- A theme without `$theme_inherits` → `_inheritsDefault()` returns `true` → the default fallback is loaded exactly as before (verified: `default`, `dark`, `default_red` keep inheriting).
- `$_inherits` is not part of `__serialize()`, so it is recomputed per request (no stale cached value).
- The `!= 'default'` guard is kept so the default theme never loads itself twice.

Tested on a live Horde 6 instance with two standalone themes.

cc @ralflang @jcdelepine