### PR TITLE
feat/hashtable-wrapper-unwire + URL-escaping cleanup

### DIFF
--- a/lib/Horde/Core/Ajax/Response/HordeCore/NoAuth.php
+++ b/lib/Horde/Core/Ajax/Response/HordeCore/NoAuth.php
@@ -63,7 +63,7 @@ class Horde_Core_Ajax_Response_HordeCore_NoAuth extends Horde_Core_Ajax_Response
         ])->add('url', Horde::url('', false, [
             'app' => $this->_app,
             'append_session' => -1,
-        ])));
+        ]))->setRaw(true));
         $msg->type = 'horde.noauth';
 
         $ob = new stdClass();

--- a/lib/Horde/Core/Ajax/Response/HordeCore/SessionTimeout.php
+++ b/lib/Horde/Core/Ajax/Response/HordeCore/SessionTimeout.php
@@ -55,7 +55,7 @@ class Horde_Core_Ajax_Response_HordeCore_SessionTimeout extends Horde_Core_Ajax_
         ])->add('url', Horde::url('', false, [
             'app' => $this->_app,
             'append_session' => -1,
-        ])));
+        ]))->setRaw(true));
         $msg->type = 'horde.ajaxtimeout';
 
         $ob = new stdClass();

--- a/lib/Horde/Core/Factory/Cache.php
+++ b/lib/Horde/Core/Factory/Cache.php
@@ -63,10 +63,13 @@ class Horde_Core_Factory_Cache extends Horde_Core_Factory_Injector
             case 'hashtable':
                 // DEPRECATED
             case 'memcache':
-                /* Prefer the modern Horde\HashTable\HashTable when available;
-                 * fall back to the legacy Horde_Core_HashTable_Wrapper. The
-                 * Horde_Cache_Storage_Hashtable accepts both and routes to
-                 * Horde\Cache\HashtableStorage when given the modern one. */
+                /* Resolve a modern Horde\HashTable\HashTable so
+                 * Horde_Cache_Storage_Hashtable v3.0.0 routes to
+                 * Horde\Cache\HashtableStorage. A failure to resolve the
+                 * modern binding surfaces as Horde_Cache_Exception with a
+                 * descriptive message; the deprecated
+                 * Horde_Core_HashTable_Wrapper is no longer consulted (see
+                 * {@see _resolveHashTable()} and issue #159). */
                 $sparams['hashtable'] = $this->_resolveHashTable($injector);
                 $driver = 'Horde_Cache_Storage_Hashtable';
                 unset($sparams['driverconfig'], $sparams['umask']);
@@ -164,28 +167,70 @@ class Horde_Core_Factory_Cache extends Horde_Core_Factory_Injector
     }
 
     /**
-     * Resolve a HashTable instance for the cache storage.
+     * Resolve a modern Horde\HashTable\HashTable for cache storage.
      *
-     * Prefers the modern Horde\HashTable\HashTable interface (which supports
-     * phpredis as well as Predis); falls back to the legacy
-     * Horde_Core_HashTable_Wrapper when the modern binding is unavailable.
+     * The released Horde_Cache_Storage_Hashtable v3.0.0 dispatches on
+     * `instanceof Horde\HashTable\HashTable`. The legacy
+     * Horde_Core_HashTable_Wrapper does not implement that interface, so
+     * routing it through Storage_Hashtable lands in the legacy array-shaped
+     * get() branch and fails against modern drivers (issue #159). The
+     * wrapper is therefore not consulted as a fallback here. If the modern
+     * binding cannot be resolved the failure is surfaced loudly so
+     * operators see the misconfiguration instead of a silent backend swap.
      *
      * @param Horde_Injector|Injector $injector
      *
-     * @return HashTable|Horde_HashTable
+     * @return HashTable
+     *
+     * @throws Horde_Cache_Exception When the modern Horde\HashTable\HashTable
+     *                               binding cannot be resolved.
      */
-    protected function _resolveHashTable($injector)
+    protected function _resolveHashTable($injector): HashTable
     {
         try {
-            $modern = $injector->getInstance(HashTable::class);
-            if ($modern instanceof HashTable) {
-                return $modern;
-            }
-        } catch (Throwable) {
-            // Fall through to legacy.
+            return $injector->getInstance(HashTable::class);
+        } catch (Throwable $e) {
+            $hashtableDriver = $this->_describeConfiguredHashTableDriver();
+            /* Horde_Cache_Exception extends Horde_Exception_Wrapped, whose
+             * constructor accepts only (message, code) and drops a 3rd
+             * Throwable arg. The original error is preserved inline in the
+             * message so the diagnostic survives the wrapping. */
+            throw new Horde_Cache_Exception(
+                sprintf(
+                    'Cache is configured to use a hashtable backend '
+                    . '(cache.driver=%s%s), but the modern '
+                    . 'Horde\\HashTable\\HashTable binding could not be '
+                    . 'resolved: %s: %s. Check $conf[\'hashtable\'] and the '
+                    . 'memcache/redis client configuration. The deprecated '
+                    . 'Horde_Core_HashTable_Wrapper is no longer used as a '
+                    . 'fallback.',
+                    $this->getDriverName(),
+                    $hashtableDriver !== null
+                        ? ', hashtable.driver=' . $hashtableDriver
+                        : '',
+                    $e::class,
+                    $e->getMessage()
+                )
+            );
         }
+    }
 
-        return $injector->getInstance('Horde_Core_HashTable_Wrapper');
+    /**
+     * Describe the configured hashtable driver for diagnostic messages.
+     *
+     * Read-only inspection of $conf['hashtable']['driver']. Returns null if
+     * unset, so failure messages can omit the segment cleanly rather than
+     * print "hashtable.driver=".
+     *
+     * @return string|null
+     */
+    private function _describeConfiguredHashTableDriver(): ?string
+    {
+        global $conf;
+
+        return empty($conf['hashtable']['driver'])
+            ? null
+            : (string) $conf['hashtable']['driver'];
     }
 
 }

--- a/lib/Horde/Core/HashTable/Wrapper.php
+++ b/lib/Horde/Core/HashTable/Wrapper.php
@@ -13,21 +13,27 @@
  */
 
 /**
- * A wrapper around the Horde-wide HashTable instance, suitable for use with
- * objects that will be serialized.
+ * Legacy serializable forwarder over the 'Horde_HashTable' DI key.
  *
  * @author    Michael Slusarz <slusarz@horde.org>
  * @category  Horde
- * @copyright 2013-2017 Horde LLC
+ * @copyright 2013-2026 Horde LLC
  * @internal
  * @license   http://www.horde.org/licenses/lgpl21 LGPL-2.1
  * @package   Core
  *
- * @deprecated Used to bridge serializable wrappers to the legacy
- *             'Horde_HashTable' DI binding. New code should depend on the
- *             PSR-4 {@see Horde\HashTable\HashTable} interface and inject
- *             the instance directly. Once the legacy binding is removed this
- *             wrapper can be deleted.
+ * @deprecated since Horde_Core 3.0.0-RC12.
+ *
+ * No longer used by Horde_Core_Factory_Cache. The released cache storage
+ * (Horde_Cache_Storage_Hashtable v3.0.0) dispatches on
+ * `instanceof Horde\HashTable\HashTable`, which this interface-less wrapper
+ * does not satisfy. Routing the wrapper through it falls into the legacy
+ * array-shaped get() branch and breaks against modern drivers (issue #159).
+ *
+ * Retained as an orphan symbol so out-of-tree callers that constructed it
+ * directly still resolve. Do not add new uses. New code should depend on
+ * the PSR-4 {@see Horde\HashTable\HashTable} interface and inject the
+ * instance directly.
  */
 class Horde_Core_HashTable_Wrapper
 {

--- a/lib/Horde/Core/Smartmobile/View/Helper.php
+++ b/lib/Horde/Core/Smartmobile/View/Helper.php
@@ -49,9 +49,9 @@ class Horde_Core_Smartmobile_View_Helper extends Horde_View_Helper_Base
         }
 
         if (!empty($params['portal'])
-            && ($portal = $registry->getServiceLink('portal', 'horde')->setRaw(false))) {
+            && ($portal = $registry->getServiceLink('portal', 'horde')->setRaw(true))) {
             $out .= '<a class="smartmobile-portal ui-btn-left" '
-                . 'data-ajax="false" href="' . $portal . '">'
+                . 'data-ajax="false" href="' . htmlspecialchars((string) $portal) . '">'
                 . Horde_Core_Translation::t('Applications') . '</a>';
         }
 

--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -687,7 +687,7 @@ class Horde_PageOutput
                 $this->addInlineJsVars([
                     'HordeMobile.conf' => [
                         'ajax_url' => $registry->getServiceLink('ajax', $registry->getApp())->url,
-                        'logout_url' => strval($registry->getServiceLink('logout')),
+                        'logout_url' => strval($registry->getServiceLink('logout')->setRaw(true)),
                         'sid' => SID,
                         'token' => (string) $tokenService->generate(Horde\Core\Session\HordeSession::CSRF_SEED),
                     ],
@@ -731,8 +731,8 @@ class Horde_PageOutput
             $js_conf = array_filter([
                 /* URLs */
                 'URI_AJAX' => $registry->getServiceLink('ajax', $registry->getApp())->url,
-                'URI_DLOAD' => strval($registry->getServiceLink('download', $registry->getApp())),
-                'URI_LOGOUT' => strval($registry->getServiceLink('logout')),
+                'URI_DLOAD' => strval($registry->getServiceLink('download', $registry->getApp())->setRaw(true)),
+                'URI_LOGOUT' => strval($registry->getServiceLink('logout')->setRaw(true)),
                 'URI_SNOOZE' => strval(Horde::url($registry->get('webroot', 'horde') . '/services/snooze.php', true, -1)),
 
                 /* Other constants */

--- a/src/PageOutput/ViewModeConfigurator.php
+++ b/src/PageOutput/ViewModeConfigurator.php
@@ -122,7 +122,7 @@ class ViewModeConfigurator
             $link = $app !== null
                 ? $this->registry->getServiceLink($service, $app)
                 : $this->registry->getServiceLink($service);
-            return (string) $link;
+            return (string) $link->setRaw(true);
         } catch (Exception) {
             return '';
         }

--- a/src/Topbar/TopbarBuilder.php
+++ b/src/Topbar/TopbarBuilder.php
@@ -577,7 +577,7 @@ class TopbarBuilder
                 return null;
             }
             $link = $this->registry->getServiceLink('logout');
-            return $link !== false ? (string) $link : null;
+            return $link !== false ? (string) $link->setRaw(true) : null;
         } catch (Exception) {
             return null;
         }
@@ -591,7 +591,7 @@ class TopbarBuilder
                 return null;
             }
             $link = $this->registry->getServiceLink('login');
-            return $link !== false ? (string) $link : null;
+            return $link !== false ? (string) $link->setRaw(true) : null;
         } catch (Exception) {
             return null;
         }
@@ -603,7 +603,7 @@ class TopbarBuilder
             $link = $app !== null
                 ? $this->registry->getServiceLink($service, $app)
                 : $this->registry->getServiceLink($service);
-            return $link !== false ? (string) $link : '';
+            return $link !== false ? (string) $link->setRaw(true) : '';
         } catch (Exception) {
             return '';
         }

--- a/test/Unit/Factory/CacheResolveHashTableTest.php
+++ b/test/Unit/Factory/CacheResolveHashTableTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @package  Core
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ */
+
+namespace Horde\Core\Test\Unit\Factory;
+
+use Horde\HashTable\HashTable;
+use Horde_Cache_Exception;
+use Horde_Core_Factory_Cache;
+use Horde_Injector;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use RuntimeException;
+
+/**
+ * Unit tests for {@see Horde_Core_Factory_Cache::_resolveHashTable()}.
+ *
+ * The factory's full create() path touches Horde::getDriverConfig and a
+ * matrix of globals that are out of scope for this regression suite. The
+ * change under test is local to _resolveHashTable() and its diagnostic
+ * helper. Reflection invokes them on a real factory instance so the test
+ * exercises the production class without subclassing.
+ *
+ * Issue horde/Core#159: a misresolved modern HashTable used to silently fall
+ * back to the deprecated Horde_Core_HashTable_Wrapper, which an out-of-tree
+ * rebind of 'Horde_HashTable' could then route into the modern-shape get()
+ * and produce a TypeError. The factory now refuses the silent swap and
+ * raises a descriptive Horde_Cache_Exception instead; the wrapper is never
+ * consulted.
+ */
+#[CoversClass(Horde_Core_Factory_Cache::class)]
+class CacheResolveHashTableTest extends TestCase
+{
+    /**
+     * Track $conf so each test starts from a clean slate. Some tests poke
+     * $conf['cache']['driver'] and $conf['hashtable']['driver']; tearDown
+     * restores whatever was there.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $savedConf = null;
+
+    protected function setUp(): void
+    {
+        global $conf;
+        $this->savedConf = $conf ?? null;
+        $conf = [];
+    }
+
+    protected function tearDown(): void
+    {
+        global $conf;
+        $conf = $this->savedConf;
+    }
+
+    /**
+     * Build a Horde_Core_Factory_Cache around a mocked injector with the
+     * supplied bindings. Unknown keys throw RuntimeException to mimic
+     * Horde_Injector behaviour for unbound keys.
+     *
+     * Critically: 'Horde_Core_HashTable_Wrapper' is NEVER added to
+     * $instances. A test that fails by reaching the wrapper would surface
+     * here as "No binding for Horde_Core_HashTable_Wrapper" — which is the
+     * exact protection the regression test is asserting.
+     *
+     * @param array<string, object|callable> $instances Either an object to
+     *                                                  return, or a callable
+     *                                                  invoked to compute the
+     *                                                  return value (used to
+     *                                                  inject Throwables).
+     */
+    private function makeFactory(array $instances): Horde_Core_Factory_Cache
+    {
+        $injector = $this->createMock(Horde_Injector::class);
+        $injector->expects($this->atLeastOnce())
+            ->method('getInstance')
+            ->willReturnCallback(function (string $key) use ($instances) {
+                if (!array_key_exists($key, $instances)) {
+                    throw new RuntimeException("No binding for $key");
+                }
+                $binding = $instances[$key];
+                if (is_callable($binding)) {
+                    return $binding();
+                }
+                return $binding;
+            });
+
+        return new Horde_Core_Factory_Cache($injector);
+    }
+
+    /**
+     * Invoke the protected _resolveHashTable via reflection so the test
+     * exercises the production class instead of a subclass.
+     */
+    private function callResolve(Horde_Core_Factory_Cache $factory, Horde_Injector $injector): mixed
+    {
+        $method = new ReflectionMethod(Horde_Core_Factory_Cache::class, '_resolveHashTable');
+
+        return $method->invoke($factory, $injector);
+    }
+
+    /**
+     * Capture the injector the factory was built with, so we can hand it
+     * back to _resolveHashTable through reflection. Horde_Core_Factory_Cache
+     * stores it as $_injector on the Base parent.
+     */
+    private function injectorOf(Horde_Core_Factory_Cache $factory): Horde_Injector
+    {
+        $prop = new \ReflectionProperty(\Horde_Core_Factory_Base::class, '_injector');
+
+        return $prop->getValue($factory);
+    }
+
+    #[Test]
+    public function testReturnsModernHashTableWhenBound(): void
+    {
+        $hashtable = $this->createStub(HashTable::class);
+        $factory = $this->makeFactory([
+            HashTable::class => $hashtable,
+        ]);
+
+        $result = $this->callResolve($factory, $this->injectorOf($factory));
+
+        self::assertSame($hashtable, $result);
+    }
+
+    #[Test]
+    public function testThrowsDescriptiveExceptionWhenModernResolutionFails(): void
+    {
+        global $conf;
+        $conf['cache']['driver'] = 'memcache';
+        $conf['hashtable']['driver'] = 'memcache';
+
+        $original = new RuntimeException('Redis client refused connection');
+        $factory = $this->makeFactory([
+            HashTable::class => static function () use ($original): never {
+                throw $original;
+            },
+        ]);
+
+        try {
+            $this->callResolve($factory, $this->injectorOf($factory));
+            self::fail('Expected Horde_Cache_Exception was not thrown.');
+        } catch (Horde_Cache_Exception $e) {
+            self::assertStringContainsString('cache.driver=memcache', $e->getMessage());
+            self::assertStringContainsString('hashtable.driver=memcache', $e->getMessage());
+            // The original throwable's class and message are folded into the
+            // diagnostic. Horde_Exception_Wrapped's two-arg constructor drops
+            // a 3rd $previous; inlining the cause keeps the operator-visible
+            // trail intact through the wrapping.
+            self::assertStringContainsString(RuntimeException::class, $e->getMessage());
+            self::assertStringContainsString('Redis client refused connection', $e->getMessage());
+            self::assertStringContainsString(
+                'Horde_Core_HashTable_Wrapper is no longer used as a fallback',
+                $e->getMessage()
+            );
+        }
+    }
+
+    #[Test]
+    public function testFailureMessageOmitsHashtableDriverWhenUnset(): void
+    {
+        global $conf;
+        $conf['cache']['driver'] = 'memcache';
+        // Deliberately leave $conf['hashtable']['driver'] unset.
+
+        $factory = $this->makeFactory([
+            HashTable::class => static function (): never {
+                throw new RuntimeException('boom');
+            },
+        ]);
+
+        try {
+            $this->callResolve($factory, $this->injectorOf($factory));
+            self::fail('Expected Horde_Cache_Exception was not thrown.');
+        } catch (Horde_Cache_Exception $e) {
+            self::assertStringContainsString('cache.driver=memcache', $e->getMessage());
+            self::assertStringNotContainsString('hashtable.driver=', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function testWrapperFallbackIsNotConsultedOnFailure(): void
+    {
+        // The makeFactory mock throws "No binding for X" for any key not in
+        // $instances. By omitting 'Horde_Core_HashTable_Wrapper' here and
+        // asserting we receive Horde_Cache_Exception (not RuntimeException
+        // from the mock), we prove the wrapper was never looked up.
+        $factory = $this->makeFactory([
+            HashTable::class => static function (): never {
+                throw new RuntimeException('modern resolution failed');
+            },
+        ]);
+
+        $this->expectException(Horde_Cache_Exception::class);
+
+        $this->callResolve($factory, $this->injectorOf($factory));
+    }
+}


### PR DESCRIPTION
## Summary

- `refactor(Core): unwire deprecated HashTable wrapper from Cache factory`
- `fix(smartmobile): align portal link with modern URL-escaping convention`
- `fix(core): emit raw URLs in JS and JSON configuration`

The two `fix:` commits are follow-up cleanup to #178, applying the same build-raw + escape-at-print convention to the remaining first-party URL emission sites.