### PR TITLE
fix: horde/core#182 issues with incongruent session access.

### DIFF
--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -605,11 +605,24 @@ class Horde_Registry implements Horde_Shutdown_Task
             $GLOBALS['session'] = $session = new Horde_Session();
             $session->setup(true, $args['session_cache_limiter'] ?? null);
 
+            /* Resolve HordeSession once and pin it as the top-level
+             * injector singleton. Every subsequent lookup — including
+             * from child injectors created by `#[Factory]` binders —
+             * falls through to this instance via parent-scope lookup,
+             * so there is only ever one HordeSession per request. Under
+             * HKDF derivation the per-session key is bound to the
+             * `_secret/salt` slot on the specific HordeSession
+             * instance; two divergent instances for the same PHP
+             * session id decrypt each other's ciphertext with
+             * different keys. See horde/Core#182. */
+            $hordeSession = $injector->getInstance(HordeSession::class);
+            $injector->setInstance(HordeSession::class, $hordeSession);
+
             /* Ensure the per-session CSRF secret exists before closing a
              * read-only session, so view/download scripts can validate
              * tokens generated on full page views. */
             $injector->getInstance(TokenServiceFactory::class)
-                ->createForSession($injector->getInstance(HordeSession::class));
+                ->createForSession($hordeSession);
 
             if ($session_flags & self::SESSION_READONLY) {
                 /* Close the session immediately so no changes can be made but

--- a/src/Session/SessionLifecycle.php
+++ b/src/Session/SessionLifecycle.php
@@ -515,11 +515,26 @@ class SessionLifecycle implements Horde_Shutdown_Task
      * Sets the freshly-built instance as the injector singleton so callers
      * resolving HordeSession via getInstance see the same object the
      * lifecycle synchronises with.
+     *
+     * The instance is also published on `$GLOBALS['injector']` when that
+     * is a different scope. `SessionLifecycle` is resolved through a
+     * `#[Factory]` binder, which passes a fresh child injector into the
+     * factory (see {@see \Horde\Injector\Binder\Factory::create}), so
+     * `$this->injector` is typically a child of the top-level container.
+     * A `setInstance` on the child is invisible to consumers that resolve
+     * HordeSession via `$GLOBALS['injector']` — notably the
+     * `Horde_Session` shim's `_resolveModern()`. Publishing to both
+     * scopes keeps them in agreement after a rotation. See
+     * horde/Core#182.
      */
     private function rebuildHordeSession(): void
     {
         $fresh = $this->injector->createInstance(HordeSession::class);
         $this->injector->setInstance(HordeSession::class, $fresh);
+        if (isset($GLOBALS['injector'])
+            && $GLOBALS['injector'] !== $this->injector) {
+            $GLOBALS['injector']->setInstance(HordeSession::class, $fresh);
+        }
     }
 
     /**


### PR DESCRIPTION
# Fix duplicate objects for the same session with different content

The GLOBALS access in SessionLifecycle is a smell but at least it's conditional (won't break in lean environments) and we can deprecate/remove it without breaking how it works in lean stack.

Adresses #182 