### PR TITLE
Fix RedBox.showHtml() with HTML string content

### DIFF
--- a/js/redbox.js
+++ b/js/redbox.js
@@ -145,6 +145,12 @@ var RedBox = {
 
     htmlWindowContents: function(html)
     {
+        // Accept either a DOM element/id or a raw HTML string. Passing a
+        // string to $() returns null (it is treated as an element id), so
+        // wrap string content in a container element first.
+        if (Object.isString(html)) {
+            html = new Element('DIV').update(html);
+        }
         html = $(html).show();
         var win = $('RB_window'), child;
 

--- a/js/redbox.js
+++ b/js/redbox.js
@@ -147,11 +147,12 @@ var RedBox = {
     {
         // Accept a DOM element, an element id, or a raw HTML string. $()
         // resolves an element or an id; if it resolves to nothing (a raw HTML
-        // string is treated as an id and not found), wrap the string in a
-        // container element instead.
+        // string is treated as an id and not found), parse the string and use
+        // its root element (firstDescendant() avoids an extra wrapper node so
+        // the content is inserted exactly as before).
         if (Object.isString(html)) {
             var resolved = $(html);
-            html = resolved ? resolved : new Element('DIV').update(html);
+            html = resolved ? resolved : new Element('DIV').update(html).firstDescendant();
         }
         html = $(html).show();
         var win = $('RB_window'), child;

--- a/js/redbox.js
+++ b/js/redbox.js
@@ -145,11 +145,13 @@ var RedBox = {
 
     htmlWindowContents: function(html)
     {
-        // Accept either a DOM element/id or a raw HTML string. Passing a
-        // string to $() returns null (it is treated as an element id), so
-        // wrap string content in a container element first.
+        // Accept a DOM element, an element id, or a raw HTML string. $()
+        // resolves an element or an id; if it resolves to nothing (a raw HTML
+        // string is treated as an id and not found), wrap the string in a
+        // container element instead.
         if (Object.isString(html)) {
-            html = new Element('DIV').update(html);
+            var resolved = $(html);
+            html = resolved ? resolved : new Element('DIV').update(html);
         }
         html = $(html).show();
         var win = $('RB_window'), child;


### PR DESCRIPTION
## Problem

`RedBox.showHtml()` fails when passed a raw HTML **string** instead of a DOM
element. `htmlWindowContents()` does:

```js
html = $(html).show();
```

Prototype's `$()` treats a string argument as an element **id**
(`document.getElementById`), so `$(htmlString)` returns `null` and
`null.show()` throws. The content is never inserted into `RB_window`, leaving
the modal empty.

Callers that pass an existing DOM element (e.g. event/task dialogs in
Kronolith) are unaffected — only string content breaks.

This is a H6 regression: the previous `Element#update()`-based insertion
accepted strings; the rewrite (which avoids `update()` to preserve
autocompleter state on reopen) dropped the string case.

## Fix

Wrap string content in a container element before `$()`:

```js
if (Object.isString(html)) {
    html = new Element('DIV').update(html);
}
html = $(html).show();
```

## Testing

Reproduced with Kronolith's calendar create/edit dialog (loaded via
`chunkContent` as a string). Before: empty modal. After: dialog renders
correctly. Verified on a live H6 dev instance.

Fixes horde/kronolith#65
