### PR TITLE
feat(core): throttle ActiveSync auth and harden user resolution

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -257,10 +257,27 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             )
         );
 
+        // Brute-force throttle. Track credential failures per (username, client
+        // IP) in the cache and short-circuit once the configured threshold is
+        // exceeded within the window, so the ActiveSync endpoint cannot be used
+        // to bypass Horde's interactive-login protection. A successful
+        // credential check clears the counter, so devices that authenticate
+        // normally never accumulate. Automatically disabled when no cache
+        // backend is configured or when explicitly turned off.
+        $throttleKey = $this->_authThrottleKey($username);
+        if ($this->_authThrottleExceeded($throttleKey)) {
+            $injector->getInstance('Horde_Log_Logger')->warn(sprintf(
+                'ActiveSync: too many failed authentication attempts for user %s; temporarily refusing further attempts.',
+                $username
+            ));
+            return Horde_ActiveSync::AUTH_REASON_UNAVAILABLE;
+        }
+
         // First try transparent/X509. Happens for authtype == 'cert' || 'basic_cert'
         if ($conf['activesync']['auth']['type'] != 'basic') {
             if (!$this->_auth->transparent()) {
                 $injector->getInstance('Horde_Log_Logger')->notice(sprintf('Login failed ActiveSync client certificate for user %s.', $username));
+                $this->_recordAuthFailure($throttleKey);
                 return false;
             }
             if ($username != $GLOBALS['registry']->getAuth()) {
@@ -270,6 +287,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     $username
                 ));
                 $GLOBALS['registry']->clearAuth();
+                $this->_recordAuthFailure($throttleKey);
                 return false;
             }
             $this->_logger->info(
@@ -303,9 +321,14 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
 
             if (!$authResult) {
                 $injector->getInstance('Horde_Log_Logger')->notice(sprintf('Login failed from ActiveSync client for user %s.', $username));
+                $this->_recordAuthFailure($throttleKey);
                 return false;
             }
         }
+
+        // Credentials verified successfully; clear any brute-force failure
+        // counter for this (username, client IP) pair.
+        $this->_clearAuthThrottle($throttleKey);
 
         // Get the username from the registry so we capture it after any
         // hooks were run on it. In some setups this can be empty even after
@@ -338,6 +361,109 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     }
 
     /**
+     * Build the cache key used to track failed authentication attempts for
+     * brute-force throttling.
+     *
+     * @param string $username  The client-supplied username.
+     *
+     * @return string|null  The cache key, or null if throttling is not
+     *                      available (no cache backend), disabled by
+     *                      configuration, or no username was provided.
+     */
+    protected function _authThrottleKey($username)
+    {
+        global $conf;
+
+        if (empty($this->_cache) || (string) $username === '') {
+            return null;
+        }
+        if (isset($conf['activesync']['auth']['throttle']['enabled'])
+            && !$conf['activesync']['auth']['throttle']['enabled']) {
+            return null;
+        }
+
+        $ip = '';
+        if (!empty($this->_serverRequest)) {
+            $params = $this->_serverRequest->getServerParams();
+            $ip = isset($params['REMOTE_ADDR']) ? (string) $params['REMOTE_ADDR'] : '';
+        }
+
+        return 'HCASD:authfail:'
+            . hash('sha256', Horde_String::lower((string) $username) . '|' . $ip);
+    }
+
+    /**
+     * Return the configured brute-force throttle limit and window.
+     *
+     * Configurable via $conf['activesync']['auth']['throttle']['max_attempts']
+     * and ['window'] (seconds). Defaults to 15 failures per 300s, which is well
+     * above what a normally-configured device produces but low enough to blunt
+     * online password guessing.
+     *
+     * @return array  [max_attempts, window_seconds]
+     */
+    protected function _authThrottleLimits()
+    {
+        global $conf;
+
+        $throttle = isset($conf['activesync']['auth']['throttle'])
+            && is_array($conf['activesync']['auth']['throttle'])
+            ? $conf['activesync']['auth']['throttle']
+            : [];
+        $max = isset($throttle['max_attempts']) ? (int) $throttle['max_attempts'] : 15;
+        $window = isset($throttle['window']) ? (int) $throttle['window'] : 300;
+
+        return [max($max, 1), max($window, 1)];
+    }
+
+    /**
+     * Determine whether the failure count for the given key has reached the
+     * configured threshold within the throttle window.
+     *
+     * @param string|null $key  The throttle cache key.
+     *
+     * @return boolean  True if further attempts should be refused.
+     */
+    protected function _authThrottleExceeded($key)
+    {
+        if ($key === null || empty($this->_cache)) {
+            return false;
+        }
+        [$max, $window] = $this->_authThrottleLimits();
+
+        return (int) $this->_cache->get($key, $window) >= $max;
+    }
+
+    /**
+     * Record a failed authentication attempt for brute-force throttling.
+     *
+     * @param string|null $key  The throttle cache key (no-op if null).
+     */
+    protected function _recordAuthFailure($key)
+    {
+        if ($key === null || empty($this->_cache)) {
+            return;
+        }
+        [, $window] = $this->_authThrottleLimits();
+        $count = (int) $this->_cache->get($key, $window);
+        $this->_cache->set($key, (string) ($count + 1), $window);
+    }
+
+    /**
+     * Clear the failed authentication counter following a successful credential
+     * check.
+     *
+     * @param string|null $key  The throttle cache key (no-op if null).
+     */
+    protected function _clearAuthThrottle($key)
+    {
+        if ($key === null || empty($this->_cache)) {
+            return;
+        }
+        $this->_cache->expire($key);
+    }
+
+    /**
      * Clean up
      *
      * @see Horde_ActiveSync_Driver_Base#clearAuthentication()
@@ -366,22 +492,36 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      */
     public function getUser()
     {
-        // Priority 1: Authenticated user (from parent::authenticate())
+        // Priority 1: Authenticated user (from parent::authenticate()).
         $user = parent::getUser();
-
-        // Priority 2: GET parameter (Horde-specific ActiveSync extension)
-        // Used in device provisioning scenarios where auth hasn't completed yet
-        if (empty($user)) {
-            $queryParams = $this->_serverRequest->getQueryParams();
-            if (!empty($queryParams['User'])) {
-                $user = $queryParams['User'];
-            }
+        if (!empty($user)) {
+            return $user;
         }
 
-        // Priority 3: Registry auth fallback
-        // For scenarios where request comes from authenticated session
-        if (empty($user)) {
-            $user = $this->_registry->getAuth();
+        // Priority 2: Registry authenticated user. An authenticated identity
+        // MUST take precedence over any client-supplied value, so this is
+        // checked before the ?User= query parameter.
+        $registryUser = $this->_registry->getAuth();
+        if (!empty($registryUser)) {
+            return $registryUser;
+        }
+
+        // Priority 3: ?User= GET parameter (Horde-specific ActiveSync
+        // extension). This is client-controlled and is NOT proof of identity.
+        // It is only consulted here as a last resort so that device/state
+        // resolution has a username to work with during the transparent
+        // (X509 certificate) provisioning flow, before basic auth has run.
+        // The certificate auth path in self::authenticate() verifies that this
+        // value matches the certificate-authenticated identity (and clears the
+        // session on mismatch) before any data is served, so it can never be
+        // used on its own to impersonate another user.
+        $queryParams = $this->_serverRequest->getQueryParams();
+        if (!empty($queryParams['User'])) {
+            $this->_logger->warn(sprintf(
+                'ActiveSync: no authenticated user; falling back to client-supplied ?User=%s for user resolution. This value is verified against the authenticated identity before data is served.',
+                $queryParams['User']
+            ));
+            return $queryParams['User'];
         }
 
         return $user;

--- a/test/Unit/ActiveSync/DriverGetUserTest.php
+++ b/test/Unit/ActiveSync/DriverGetUserTest.php
@@ -95,7 +95,12 @@ class DriverGetUserTest extends TestCase
     }
 
     /**
-     * Test Priority 2: GET parameter when no authenticated user
+     * Test Priority 3: GET parameter is used only when neither an
+     * authenticated user nor a registry-authenticated user is present.
+     *
+     * The registry (priority 2) is consulted before the client-supplied
+     * ?User= value (priority 3); when it returns empty we fall back to the
+     * GET parameter.
      */
     public function testGetUserFallsBackToGetParameter(): void
     {
@@ -106,15 +111,20 @@ class DriverGetUserTest extends TestCase
         $serverRequest = (new ServerRequest('POST', '/'))
             ->withQueryParams(['User' => 'get_param_user', 'DeviceId' => '123']);
 
+        $registry = $this->getMockSkipConstructor(Horde_Registry::class);
+        $registry->expects($this->once())
+            ->method('getAuth')
+            ->willReturn('');
+
         $driver = new Horde_Core_ActiveSync_Driver([
             'connector' => $this->expectUntouched(Horde_Core_ActiveSync_Connector::class),
             'auth' => $this->expectUntouched(Horde_Core_ActiveSync_Auth::class),
             'serverrequest' => $serverRequest,
-            'registry' => $this->expectUntouched(Horde_Registry::class),
+            'registry' => $registry,
             'state' => $this->createDriverStateMock(),
         ]);
 
-        // No authentication, should use GET parameter
+        // No authenticated user and empty registry auth: use GET parameter.
         $this->assertEquals('get_param_user', $driver->getUser());
     }
 
@@ -171,9 +181,15 @@ class DriverGetUserTest extends TestCase
     }
 
     /**
-     * Test: GET parameter overrides registry
+     * Test: a registry-authenticated user overrides the client-supplied
+     * ?User= GET parameter.
+     *
+     * An authenticated identity MUST take precedence over any client-controlled
+     * value. The ?User= parameter is not proof of identity and is only used as
+     * a last resort when no authenticated user (auth flow or registry) exists,
+     * so a non-empty registry auth wins here.
      */
-    public function testGetParameterOverridesRegistry(): void
+    public function testRegistryOverridesGetParameter(): void
     {
         if (!class_exists('Horde_ActiveSync_State_Sql')) {
             $this->markTestSkipped('horde/activesync not available');
@@ -182,16 +198,20 @@ class DriverGetUserTest extends TestCase
         $serverRequest = (new ServerRequest('POST', '/'))
             ->withQueryParams(['User' => 'get_param_user']);
 
+        $registry = $this->getMockSkipConstructor(Horde_Registry::class);
+        $registry->expects($this->once())
+            ->method('getAuth')
+            ->willReturn('registry_user');
+
         $driver = new Horde_Core_ActiveSync_Driver([
             'connector' => $this->expectUntouched(Horde_Core_ActiveSync_Connector::class),
             'auth' => $this->expectUntouched(Horde_Core_ActiveSync_Auth::class),
             'serverrequest' => $serverRequest,
-            // GET param wins; registry must NOT be consulted.
-            'registry' => $this->expectUntouched(Horde_Registry::class),
+            'registry' => $registry,
             'state' => $this->createDriverStateMock(),
         ]);
 
-        $this->assertEquals('get_param_user', $driver->getUser());
+        $this->assertEquals('registry_user', $driver->getUser());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add a cache-backed brute-force throttle to the ActiveSync driver's `authenticate()`.
- Harden `getUser()` so an authenticated identity always takes precedence over the client-supplied `?User=` query parameter.

## Motivation
The ActiveSync endpoint runs a full backend authentication on every request but had no failure throttling, so it could be used for credential guessing in a way that bypasses Horde's interactive-login protection. Separately, `getUser()` consulted the client-controlled `?User=` query parameter before the registry-authenticated identity, which is fragile for a value that is not proof of identity.

## Changes
- **Brute-force throttle** (`Horde_Core_ActiveSync_Driver::authenticate()`): count credential failures per `(username, client IP)` in the cache and refuse further attempts once a threshold is reached within a window. A successful credential check clears the counter, so normally-configured devices never accumulate. Tunable via `$conf['activesync']['auth']['throttle']` (`enabled`, `max_attempts` default 15, `window` default 300s). Automatically inert when no cache backend is configured, so existing deployments without a cache are unaffected. When tripped it returns `AUTH_REASON_UNAVAILABLE` so the client backs off.
- **User resolution** (`getUser()`): reorder precedence to (1) authenticated user, (2) registry-authenticated user, (3) `?User=` query parameter. The `?User=` value is now only a last resort for the transparent X509 provisioning flow, is logged, and is documented as not proof of identity (the certificate path in `authenticate()` verifies it against the certificate-authenticated identity, clearing the session on mismatch, before any data is served).
- Update `DriverGetUserTest` to assert the new precedence (registry over `?User=`).

## Test plan
- [x] `php -l` clean on changed files
- [x] `test/Unit/ActiveSync` passes (22/22)
- [ ] Manual: repeated bad-password ActiveSync logins get throttled with a cache backend configured; a correct login clears the counter
- [ ] Manual: X509 certificate provisioning flow still resolves the user correctly
