### PR TITLE
fix(core): resolve topbar/prefs app names with dgettext against ownin…

### DIFF
--- a/lib/Horde/Core/Topbar.php
+++ b/lib/Horde/Core/Topbar.php
@@ -167,6 +167,16 @@ class Horde_Core_Topbar
                 unset($prefs_apps['horde']);
             }
 
+            /* Resolve each app's translated name using its own domain, before
+             * sorting -- gettext's _() uses the currently active default domain,
+             * which may belong to a different app by this point in the request. */
+            foreach ($prefs_apps as $app => &$params) {
+                if (strlen((string) ($params['name'] ?? ''))) {
+                    $params['name'] = dgettext($app, $params['name']);
+                }
+            }
+            unset($params);
+
             uasort($prefs_apps, [$this, '_sortByName']);
             foreach ($prefs_apps as $app => $params) {
                 $menu['prefs_' . $app] = [
@@ -254,7 +264,7 @@ class Horde_Core_Topbar
                          * user's locale may not have been loaded when registry.php was
                          * parsed, and the translations of the application names are
                          * not in the Core package. */
-                        $name = strlen((string) ($params['name'] ?? '')) ? _($params['name']) : '';
+                        $name = strlen((string) ($params['name'] ?? '')) ? dgettext($app, $params['name']) : '';
 
                         /* Headings have no webroot; they're just containers for other
                          * menu items. */
@@ -319,7 +329,7 @@ class Horde_Core_Topbar
      */
     protected function _sortByName($a, $b)
     {
-        return strcoll(_($a['name']), _($b['name']));
+        return strcoll($a['name'], $b['name']);
     }
 
 }

--- a/lib/Horde/Core/Topbar.php
+++ b/lib/Horde/Core/Topbar.php
@@ -80,6 +80,15 @@ class Horde_Core_Topbar
                   && !($isAdmin && ($params['status'] == 'noadmin'))
                   && !(!$isAdmin && ($params['status'] == 'admin'))
                   && $registry->hasPermission((!empty($params['app']) ? $params['app'] : $app), Horde_Perms::SHOW)))) {
+                /* Resolve the display name now, while the owning app and its
+                 * status are still known. Application names live in the
+                 * owning app's gettext domain; headings/links keep the legacy
+                 * _() behaviour since they have no dedicated app domain. */
+                if (strlen((string) ($params['name'] ?? ''))) {
+                    $params['name'] = in_array($params['status'], ['heading', 'link'])
+                        ? _($params['name'])
+                        : $this->_appName($registry, $app, $params['name']);
+                }
                 $menu[$app] = $params;
             }
         }
@@ -167,12 +176,13 @@ class Horde_Core_Topbar
                 unset($prefs_apps['horde']);
             }
 
-            /* Resolve each app's translated name using its own domain, before
-             * sorting -- gettext's _() uses the currently active default domain,
-             * which may belong to a different app by this point in the request. */
+            /* Resolve each app's name via its own gettext domain before
+             * sorting; the comparator only sees values, not the app key, and
+             * _() would resolve against whatever default domain happens to be
+             * active at this point in the request. */
             foreach ($prefs_apps as $app => &$params) {
                 if (strlen((string) ($params['name'] ?? ''))) {
-                    $params['name'] = dgettext($app, $params['name']);
+                    $params['name'] = $this->_appName($registry, $app, $params['name']);
                 }
             }
             unset($params);
@@ -260,11 +270,11 @@ class Horde_Core_Topbar
 
                 default:
                     try {
-                        /* Need to run the name through Horde's gettext since the
-                         * user's locale may not have been loaded when registry.php was
-                         * parsed, and the translations of the application names are
-                         * not in the Core package. */
-                        $name = strlen((string) ($params['name'] ?? '')) ? dgettext($app, $params['name']) : '';
+                        /* Names were already resolved against their owning
+                         * app's gettext domain when the menu was built (see
+                         * above); Core-owned entries are translated at
+                         * creation time. Use the value as-is. */
+                        $name = (string) ($params['name'] ?? '');
 
                         /* Headings have no webroot; they're just containers for other
                          * menu items. */
@@ -329,7 +339,44 @@ class Horde_Core_Topbar
      */
     protected function _sortByName($a, $b)
     {
-        return strcoll($a['name'], $b['name']);
+        return strcoll((string) ($a['name'] ?? ''), (string) ($b['name'] ?? ''));
+    }
+
+    /**
+     * Translate an application's display name using that application's own
+     * gettext domain.
+     *
+     * The registry stores raw (untranslated) msgids for application names:
+     * the user's locale may not have been loaded when registry.php was
+     * parsed, and the translations live in each app's own catalog, not in
+     * Core. Plain _() resolves against the currently active default domain,
+     * which may belong to a different app by this point in the request, so
+     * non-current apps would fall back to the raw English name.
+     *
+     * dgettext() resolves against an explicit domain, but only if that domain
+     * has been bound this request; an app that was never pushed has no
+     * binding, and dgettext() would then return the raw msgid. Bind it here
+     * before resolving. dgettext() does not change the active domain, so no
+     * save/restore of textdomain() is required.
+     *
+     * @param Horde_Registry $registry  The registry (for the app fileroot).
+     * @param string $app               The app whose domain owns the name.
+     * @param string $name              The raw application name (msgid).
+     *
+     * @return string  The translated name (or $name if no catalog entry).
+     */
+    protected function _appName(Horde_Registry $registry, $app, $name)
+    {
+        if (!strlen((string) $name)) {
+            return '';
+        }
+
+        bindtextdomain($app, $registry->get('fileroot', $app) . '/locale');
+        if (function_exists('bind_textdomain_codeset')) {
+            bind_textdomain_codeset($app, 'UTF-8');
+        }
+
+        return dgettext($app, (string) $name);
     }
 
 }

--- a/src/Topbar/TopbarBuilder.php
+++ b/src/Topbar/TopbarBuilder.php
@@ -168,7 +168,15 @@ class TopbarBuilder
                 continue;
             }
 
-            $name = strlen((string) ($params['name'] ?? '')) ? _($params['name']) : '';
+            $name = '';
+            if (strlen((string) ($params['name'] ?? ''))) {
+                /* Application names live in the owning app's gettext domain;
+                 * headings/links have no dedicated app domain, so keep the
+                 * legacy _() behaviour for them. */
+                $name = in_array($status, ['heading', 'link'], true)
+                    ? _($params['name'])
+                    : $this->appName($app, (string) $params['name']);
+            }
             $url = '';
             if (isset($params['url'])) {
                 $url = (string) $params['url'];
@@ -486,8 +494,18 @@ class TopbarBuilder
             unset($prefsApps['horde']);
         }
 
+        /* Resolve each app's name via its own gettext domain before sorting;
+         * the comparator only sees values, not the app key, and _() would
+         * resolve against whatever default domain is active here. */
+        foreach ($prefsApps as $app => &$params) {
+            if (strlen((string) ($params['name'] ?? ''))) {
+                $params['name'] = $this->appName($app, (string) $params['name']);
+            }
+        }
+        unset($params);
+
         uasort($prefsApps, static function ($a, $b) {
-            return strcoll(_($a['name']), _($b['name']));
+            return strcoll((string) ($a['name'] ?? ''), (string) ($b['name'] ?? ''));
         });
 
         foreach ($prefsApps as $app => $params) {
@@ -512,6 +530,33 @@ class TopbarBuilder
                 'parent' => 'prefs',
             ];
         }
+    }
+
+    /**
+     * Translate an application's display name using that application's own
+     * gettext domain.
+     *
+     * The registry stores raw msgids for application names; the translations
+     * live in each app's own catalog, not in Core. Plain _() resolves against
+     * the active default domain, which may belong to a different app by this
+     * point in the request, so non-current apps would fall back to the raw
+     * English name. dgettext() targets an explicit domain, but only resolves
+     * if that domain was bound this request (an app that was never pushed has
+     * no binding), so bind it first. dgettext() does not change the active
+     * domain, so no textdomain() save/restore is needed.
+     */
+    private function appName(string $app, string $name): string
+    {
+        if ($name === '') {
+            return '';
+        }
+
+        bindtextdomain($app, (string) $this->registry->get('fileroot', $app) . '/locale');
+        if (function_exists('bind_textdomain_codeset')) {
+            bind_textdomain_codeset($app, 'UTF-8');
+        }
+
+        return dgettext($app, $name);
     }
 
     private function callTopbarCreate(string $app, array $params, array &$flatNodes): void

--- a/test/Unit/Topbar/TopbarBuilderTest.php
+++ b/test/Unit/Topbar/TopbarBuilderTest.php
@@ -271,4 +271,200 @@ class TopbarBuilderTest extends TestCase
             $this->assertNotSame('emptyheading', $node->id, 'Empty heading should be filtered out');
         }
     }
+
+    /**
+     * Regression guard for the topbar i18n fix: application names must be
+     * resolved against the owning app's gettext domain (a per-app fileroot
+     * lookup + bindtextdomain + dgettext), while headings/links must keep the
+     * ambient _() behaviour and must NOT be resolved via a per-app domain.
+     *
+     * This is deterministic (no locale/.mo dependency): it only checks that
+     * the code looks up 'fileroot' for real apps and never for headings.
+     */
+    public function testHeadingNamesBypassOwningAppDomainResolution(): void
+    {
+        $filerootLookups = [];
+        $registry = $this->registryWithNoServiceLinks();
+        $registry->method('get')->willReturnCallback(
+            function ($param, $app = null) use (&$filerootLookups) {
+                if ($param === 'fileroot') {
+                    $filerootLookups[] = $app;
+                }
+                return '/horde';
+            }
+        );
+        $registry->method('listApps')->willReturn([
+            'imp' => ['name' => 'Mail', 'status' => 'active', 'webroot' => '/imp'],
+            'myheading' => ['name' => 'Group', 'status' => 'heading'],
+            'child' => [
+                'name' => 'Child',
+                'status' => 'active',
+                'webroot' => '/child',
+                'menu_parent' => 'myheading',
+            ],
+        ]);
+        $registry->method('isAdmin')->willReturn(false);
+        $registry->method('getInitialPage')->willReturn('/x/');
+
+        $permissions = $this->createMock(PermissionService::class);
+        $permissions->method('exists')->willReturn(false);
+
+        $session = $this->createMock(HordeSession::class);
+        $session->method('getAuthId')->willReturn(null);
+
+        $builder = new TopbarBuilder(
+            $registry,
+            $this->createStub(PrefsService::class),
+            $permissions,
+            $session,
+        );
+        $builder->build('horde');
+
+        $this->assertContains(
+            'imp',
+            $filerootLookups,
+            'Real app names must be resolved against the app\'s own gettext domain'
+        );
+        $this->assertNotContains(
+            'myheading',
+            $filerootLookups,
+            'Heading names must not be resolved via a per-app domain'
+        );
+    }
+
+    /**
+     * Behavioural regression guard: prove the app name is translated via the
+     * owning app's domain even when that app is not the active default gettext
+     * domain -- exactly the scenario that produced English names before the
+     * fix. Uses a self-contained .mo fixture; skips where the environment
+     * cannot perform gettext translation at all.
+     */
+    public function testResolvesAppNameViaOwningAppDomain(): void
+    {
+        $dir = sys_get_temp_dir() . '/topbar_gt_' . uniqid('', true);
+        $lang = 'tstlang';
+        /* Unique domain so PHP's per-process gettext cache can't collide with
+         * another test that bound the same domain to a different directory. */
+        $domain = 'fixtureapp' . substr(md5($dir), 0, 8);
+        $moDir = $dir . '/locale/' . $lang . '/LC_MESSAGES';
+        mkdir($moDir, 0777, true);
+        self::writeMo($moDir . '/' . $domain . '.mo', [
+            '' => "Content-Type: text/plain; charset=UTF-8\n",
+            'Mail' => 'FIXTURE-MAIL',
+        ]);
+
+        $oldLang = getenv('LANGUAGE');
+        putenv('LANGUAGE=' . $lang);
+        setlocale(LC_MESSAGES, 'en_US.UTF-8', 'C.UTF-8', 'en_US.utf8', 'C');
+
+        $restore = static function () use ($oldLang): void {
+            if ($oldLang === false) {
+                putenv('LANGUAGE');
+            } else {
+                putenv('LANGUAGE=' . $oldLang);
+            }
+        };
+
+        /* Confirm gettext can translate in this environment before asserting;
+         * otherwise the test would be a false negative rather than a guard. */
+        bindtextdomain($domain, $dir . '/locale');
+        if (function_exists('bind_textdomain_codeset')) {
+            bind_textdomain_codeset($domain, 'UTF-8');
+        }
+        if (dgettext($domain, 'Mail') !== 'FIXTURE-MAIL') {
+            $restore();
+            $this->markTestSkipped('gettext translation not available in this environment');
+        }
+
+        $registry = $this->registryWithNoServiceLinks();
+        $registry->method('get')->willReturnCallback(
+            static function ($param, $app = null) use ($domain, $dir) {
+                return ($param === 'fileroot' && $app === $domain) ? $dir : '/horde';
+            }
+        );
+        $registry->method('listApps')->willReturn([
+            $domain => ['name' => 'Mail', 'status' => 'active', 'webroot' => '/x'],
+        ]);
+        $registry->method('isAdmin')->willReturn(false);
+        $registry->method('getInitialPage')->willReturn('/x/');
+
+        $permissions = $this->createMock(PermissionService::class);
+        $permissions->method('exists')->willReturn(false);
+
+        $session = $this->createMock(HordeSession::class);
+        $session->method('getAuthId')->willReturn(null);
+
+        $builder = new TopbarBuilder(
+            $registry,
+            $this->createStub(PrefsService::class),
+            $permissions,
+            $session,
+        );
+        $data = $builder->build('horde');
+        $restore();
+
+        $node = null;
+        foreach ($data->menuTree as $candidate) {
+            if ($candidate->id === $domain) {
+                $node = $candidate;
+                break;
+            }
+        }
+
+        $this->assertNotNull($node, 'The app node should be present in the menu tree');
+        $this->assertSame(
+            'FIXTURE-MAIL',
+            $node->label,
+            'App name must be translated via the owning app\'s gettext domain, '
+                . 'not the active default domain'
+        );
+    }
+
+    /**
+     * Write a minimal little-endian GNU gettext .mo catalog.
+     *
+     * @param string               $path     Target .mo path.
+     * @param array<string,string> $entries  msgid => msgstr (include the ''
+     *                                        header entry).
+     */
+    private static function writeMo(string $path, array $entries): void
+    {
+        ksort($entries, SORT_STRING);
+        $ids = array_keys($entries);
+        $strs = array_values($entries);
+        $count = count($entries);
+
+        $idBlock = '';
+        $idTable = [];
+        foreach ($ids as $id) {
+            $idTable[] = [strlen($id), strlen($idBlock)];
+            $idBlock .= $id . "\0";
+        }
+
+        $strBlock = '';
+        $strTable = [];
+        foreach ($strs as $str) {
+            $strTable[] = [strlen($str), strlen($strBlock)];
+            $strBlock .= $str . "\0";
+        }
+
+        $headerSize = 28;
+        $oTableOffset = $headerSize;
+        $tTableOffset = $oTableOffset + ($count * 8);
+        $idBlockOffset = $tTableOffset + ($count * 8);
+        $strBlockOffset = $idBlockOffset + strlen($idBlock);
+
+        $out = pack('V', 0x950412de) . pack('V', 0) . pack('V', $count)
+            . pack('V', $oTableOffset) . pack('V', $tTableOffset)
+            . pack('V', 0) . pack('V', 0);
+
+        foreach ($idTable as [$len, $off]) {
+            $out .= pack('V', $len) . pack('V', $idBlockOffset + $off);
+        }
+        foreach ($strTable as [$len, $off]) {
+            $out .= pack('V', $len) . pack('V', $strBlockOffset + $off);
+        }
+
+        file_put_contents($path, $out . $idBlock . $strBlock);
+    }
 }


### PR DESCRIPTION
**Problem**

`Horde_Core_Topbar` renders app names via plain `_()`, which uses the
currently active default gettext domain rather than the domain owning
the string. Since `$params['name']` holds each app's raw msgid
(left untranslated at registry-parse time), non-current apps in the
menu silently fall back to the raw English name whenever the active
domain doesn't match.

**Symptom**

Topbar/prefs menu shows English app names ("Mail", "Calendar", "Task")
instead of localized ones, depending on which app is current. Confirmed
on two identical checkouts (same commit, same `.mo` files), each with a
different pattern — consistent with the active domain depending on
request execution order, not persisted state.

**Fix**

Use `dgettext($app, $params['name'])`, resolved explicitly per app
instead of relying on the ambient default domain. For the prefs
submenu, translation happens in a pass over `$prefs_apps` before
`uasort()`, since the comparator only sees values, not app keys;
`_sortByName()` now just does `strcoll()` on already-resolved names.

Already-translated entries (Administration, Preferences, Help, etc.)
are unaffected — verified, not assumed.

**Testing**

Reproduced reliably on two independent installs from the same commit;
fix verified correct for kronolith/turba/imp/nag/mnemo in both the
topbar and preferences menu regardless of current app.