### PR TITLE
fix(core): stop ActiveSync log spam and folder loss on IMAP outage

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -586,9 +586,9 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      * Return an array of stats for the server's folder list.
      *
      * @return array|boolean  An array of folder stats
-     *                        (@see self::statFolder()), or false if the mail
-     *                        server is temporarily unavailable and folder
-     *                        change detection should be skipped this round.
+     *                        (@see self::statFolder()), or false if the folder
+     *                        hierarchy could not be built and folder change
+     *                        detection should be skipped this round.
      * @todo Horde 6 move to base class
      */
     public function getFolderList()
@@ -596,12 +596,14 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
         $this->_logger->meta('Horde_Core_ActiveSync_Driver::getFolderList()');
         try {
             $folderlist = $this->getFolders();
-        } catch (Horde_ActiveSync_Exception_TemporaryFailure $e) {
-            // Mail server temporarily unavailable. Returning false tells the
-            // state engine to skip folder-change detection this round instead
-            // of computing a diff against an empty hierarchy (which would
-            // delete the client's mail folders). The device retries on the
-            // next sync. Already logged once by the IMAP factory.
+        } catch (Horde_ActiveSync_Exception $e) {
+            // The folder hierarchy could not be built - the mail server is
+            // temporarily unavailable or returned a hard error. Returning
+            // false tells the state engine to skip folder-change detection
+            // this round instead of computing a diff against an incomplete
+            // hierarchy (which would delete the client's mail folders). The
+            // device retries on the next sync. The root cause was already
+            // logged once at its appropriate severity by the IMAP factory.
             return false;
         }
         $folders = [];
@@ -790,18 +792,18 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             // at least an INBOX, even with email sync turned off.
             try {
                 $folders = array_merge($folders, $this->_getMailFolders());
-            } catch (Horde_ActiveSync_Exception_TemporaryFailure $e) {
-                // Mail server temporarily unreachable. Do not fall through to
-                // returning a partial/empty hierarchy (that can make clients
-                // drop their mail folders); propagate so the caller can defer
-                // the sync and the device retries later. Already logged once
-                // by the IMAP factory.
+            } catch (Horde_ActiveSync_Exception $e) {
+                // The mail folders could not be retrieved - either a transient
+                // outage (Horde_ActiveSync_Exception_TemporaryFailure) or a
+                // hard IMAP error. In neither case may we fall through to
+                // returning a partial hierarchy that omits the mail folders:
+                // FOLDERSYNC would diff against the reduced list and the client
+                // could delete the user's mail folders. Propagate so the caller
+                // (getFolderList()) can skip folder-change detection this round;
+                // the device retries later. The root cause was already logged
+                // once by the IMAP factory (NOTICE for transient, ERR for hard).
                 $this->_endBuffer();
                 throw $e;
-            } catch (Horde_ActiveSync_Exception $e) {
-                $this->_logger->meta($e->getMessage());
-                $this->_endBuffer();
-                return [];
             }
 
             $this->_endBuffer();

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -585,13 +585,25 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
     /**
      * Return an array of stats for the server's folder list.
      *
-     * @return array  An array of folder stats @see self::statFolder()
+     * @return array|boolean  An array of folder stats
+     *                        (@see self::statFolder()), or false if the mail
+     *                        server is temporarily unavailable and folder
+     *                        change detection should be skipped this round.
      * @todo Horde 6 move to base class
      */
     public function getFolderList()
     {
         $this->_logger->meta('Horde_Core_ActiveSync_Driver::getFolderList()');
-        $folderlist = $this->getFolders();
+        try {
+            $folderlist = $this->getFolders();
+        } catch (Horde_ActiveSync_Exception_TemporaryFailure $e) {
+            // Mail server temporarily unavailable. Returning false tells the
+            // state engine to skip folder-change detection this round instead
+            // of computing a diff against an empty hierarchy (which would
+            // delete the client's mail folders). The device retries on the
+            // next sync. Already logged once by the IMAP factory.
+            return false;
+        }
         $folders = [];
         foreach ($folderlist as $f) {
             $folders[] = $this->statFolder(
@@ -610,6 +622,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      * Return an array of the server's folder objects.
      *
      * @return array  An array of Horde_ActiveSync_Message_Folder objects.
+     * @throws Horde_ActiveSync_Exception_TemporaryFailure  If the mail server
+     *         is temporarily unreachable (transient connection failure).
      */
     public function getFolders()
     {
@@ -776,8 +790,16 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             // at least an INBOX, even with email sync turned off.
             try {
                 $folders = array_merge($folders, $this->_getMailFolders());
+            } catch (Horde_ActiveSync_Exception_TemporaryFailure $e) {
+                // Mail server temporarily unreachable. Do not fall through to
+                // returning a partial/empty hierarchy (that can make clients
+                // drop their mail folders); propagate so the caller can defer
+                // the sync and the device retries later. Already logged once
+                // by the IMAP factory.
+                $this->_endBuffer();
+                throw $e;
             } catch (Horde_ActiveSync_Exception $e) {
-                $this->_logger->err($e->getMessage());
+                $this->_logger->meta($e->getMessage());
                 $this->_endBuffer();
                 return [];
             }
@@ -4122,9 +4144,14 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                 try {
                     $imap_folders = $this->_imap->getMailboxes(true);
                 } catch (Horde_ActiveSync_Exception $e) {
-                    $this->_logger->err(
+                    // The IMAP factory already logged the root cause once; do
+                    // not re-log the same failure at every layer. Keep a debug
+                    // trace and re-throw the original (which preserves the
+                    // Horde_ActiveSync_Exception_TemporaryFailure type on a
+                    // transient connection failure).
+                    $this->_logger->meta(
                         sprintf(
-                            'Problem loading mail folders from IMAP server: %s',
+                            'Mail folder list unavailable: %s',
                             $e->getMessage()
                         )
                     );

--- a/lib/Horde/Core/ActiveSync/Imap/Factory.php
+++ b/lib/Horde/Core/ActiveSync/Imap/Factory.php
@@ -7,8 +7,6 @@
  * @package   Core
  */
 
-use Horde\Core\Horde;
-
 /**
  * Horde_Core_ActiveSync_Imap_Factory implements a factory/builder for
  * providing a Horde_ActiveSync_Imap_Adapter object as well as building a tree
@@ -24,6 +22,30 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
     protected $_adapter;
     protected $_mailboxlist;
     protected $_specialMailboxlist;
+
+    /**
+     * Logger.
+     *
+     * @var Horde_Log_Logger
+     */
+    protected $_logger;
+
+    /**
+     * Constructor.
+     *
+     * @param array $params  Parameters:
+     *   - logger: (Horde_Log_Logger) The logger to use. Optional; a null
+     *             logger is used when none is supplied.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     */
+    public function __construct(array $params = [])
+    {
+        $this->_logger = (isset($params['logger'])
+            && $params['logger'] instanceof Horde_Log_Logger)
+            ? $params['logger']
+            : new Horde_Log_Logger(new Horde_Log_Handler_Null());
+    }
 
     /**
      * Return a Horde_Imap_Client
@@ -93,13 +115,13 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
                     // the caller defer the sync instead of treating it as a
                     // hard error (which spams the log at every layer and can
                     // make clients drop their mail folders).
-                    Horde::log(sprintf(
+                    $this->_logger->log(sprintf(
                         'Mail server temporarily unavailable while retrieving mailbox list: %s',
                         $e->getMessage()
                     ), Horde_Log::NOTICE);
                     throw new Horde_ActiveSync_Exception_TemporaryFailure($e);
                 }
-                Horde::log(sprintf(
+                $this->_logger->log(sprintf(
                     'Error retrieving mailbox list: %s',
                     $e->getMessage()
                 ), Horde_Log::ERR);
@@ -132,7 +154,7 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
             try {
                 $this->_specialMailboxlist = $registry->mail->getSpecialMailboxes();
             } catch (Horde_Exception $e) {
-                Horde::log(sprintf(
+                $this->_logger->log(sprintf(
                     'Error retrieving specialmailbox list: %s',
                     $e->getMessage()
                 ), Horde_Log::ERR);

--- a/lib/Horde/Core/ActiveSync/Imap/Factory.php
+++ b/lib/Horde/Core/ActiveSync/Imap/Factory.php
@@ -86,6 +86,19 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
                     }
                 }
             } catch (Horde_Exception $e) {
+                if ($this->_isTransientImapError($e)) {
+                    // The mail server is temporarily unreachable. This is an
+                    // expected, recoverable condition during ActiveSync
+                    // polling, so log it once here at a low severity and let
+                    // the caller defer the sync instead of treating it as a
+                    // hard error (which spams the log at every layer and can
+                    // make clients drop their mail folders).
+                    Horde::log(sprintf(
+                        'Mail server temporarily unavailable while retrieving mailbox list: %s',
+                        $e->getMessage()
+                    ), Horde_Log::NOTICE);
+                    throw new Horde_ActiveSync_Exception_TemporaryFailure($e);
+                }
                 Horde::log(sprintf(
                     'Error retrieving mailbox list: %s',
                     $e->getMessage()
@@ -172,6 +185,39 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
         }
 
         return $msgFlags;
+    }
+
+    /**
+     * Determine whether an exception represents a transient IMAP failure
+     * (mail server unreachable or connection dropped) as opposed to a hard
+     * error such as an authentication or configuration problem.
+     *
+     * The relevant Horde_Imap_Client_Exception is preserved in the previous
+     * exception chain even when wrapped by outer exceptions (e.g. the
+     * injector's "Cannot create IMP_Ftree"), so walk the chain to classify.
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     *
+     * @param Throwable $e  The caught exception.
+     *
+     * @return boolean  True if the failure looks transient/connection related.
+     */
+    protected function _isTransientImapError($e)
+    {
+        $transient = [
+            Horde_Imap_Client_Exception::DISCONNECT,
+            Horde_Imap_Client_Exception::SERVER_CONNECT,
+            Horde_Imap_Client_Exception::LOGIN_UNAVAILABLE,
+        ];
+
+        for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+            if ($current instanceof Horde_Imap_Client_Exception
+                && in_array($current->getCode(), $transient, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 }

--- a/lib/Horde/Core/Factory/ActiveSyncBackend.php
+++ b/lib/Horde/Core/Factory/ActiveSyncBackend.php
@@ -31,7 +31,9 @@ class Horde_Core_Factory_ActiveSyncBackend extends Horde_Core_Factory_Injector
 
         // Backend driver and dependencies
         $params = ['registry' => $registry];
-        $adapter_params = ['factory' => new Horde_Core_ActiveSync_Imap_Factory()];
+        $adapter_params = ['factory' => new Horde_Core_ActiveSync_Imap_Factory([
+            'logger' => $injector->getInstance('Horde_Log_Logger'),
+        ])];
 
         // Determine emailsync setting - force to off if we don't have a mail API.
         // Use local variable instead of mutating global $conf.


### PR DESCRIPTION
## Summary
- Collapse the multi-layer ERR/WARN logging cascade on an IMAP outage down to a single NOTICE.
- Distinguish transient IMAP connection failures from hard errors and surface them as `Horde_ActiveSync_Exception_TemporaryFailure`.
- Stop returning an empty folder hierarchy on a transient failure (which could delete the client's mail folders); defer the FOLDERSYNC instead.

## Motivation
With a device polling ActiveSync while the IMAP server is down, one connection failure was caught, logged, and re-thrown at every layer, spamming `horde.log` at ERR/WARN once per poll per device. `getFolders()` returning `[]` also caused FOLDERSYNC to diff against an empty hierarchy, risking removal of the user's mail folders on the device.

## Changes
- `Horde_Core_ActiveSync_Imap_Factory::getMailboxes()`: new `_isTransientImapError()` walks the exception chain (the underlying `Horde_Imap_Client_Exception` code survives inside wrappers such as the injector's "Cannot create IMP_Ftree"). Transient failures log once at `NOTICE` and throw `Horde_ActiveSync_Exception_TemporaryFailure`; other errors keep the `ERR` + `Horde_ActiveSync_Exception` behavior.
- `Horde_Core_ActiveSync_Driver::_getMailFolders()`: drop the duplicate `ERR` re-log (kept a debug trace), re-throw preserving the exception type.
- `Horde_Core_ActiveSync_Driver::getFolders()`: propagate `TemporaryFailure` instead of returning `[]`; downgrade the non-transient log to debug.
- `Horde_Core_ActiveSync_Driver::getFolderList()`: catch `TemporaryFailure` and return `false`, the state engine's "skip folder diff" signal.

## Dependencies
Relies on horde/ActiveSync PR *"report no folder changes when getFolderList() is false"* so the `false` return is handled without a `count(null)` fatal. Merge that first.

## Test plan
- [ ] With IMAP reachable: FOLDERSYNC/SYNC behave as before.
- [ ] With IMAP down: `horde.log` shows a single NOTICE per poll (not the ERR/WARN cascade); FOLDERSYNC returns no changes with the same synckey; device keeps its folders and recovers when IMAP returns.
- [ ] Auth/config (non-connection) IMAP errors still log at ERR.
