### PR TITLE
fix(prefs): guard config-file storage against null $registry global

### DIFF
--- a/lib/Horde/Core/Prefs/Storage/Configuration.php
+++ b/lib/Horde/Core/Prefs/Storage/Configuration.php
@@ -29,6 +29,17 @@ class Horde_Core_Prefs_Storage_Configuration extends Horde_Prefs_Storage_Base
     {
         global $registry;
 
+        /* Modern PSR-15 request paths (e.g. the admin REST API) never
+         * populate $GLOBALS['registry']. Config-file defaults are a
+         * best-effort layer atop user prefs; when we cannot reach the
+         * registry, return the scope unchanged and let downstream
+         * storage drivers (SQL etc.) supply real values. Same graceful
+         * fallback shape as the try/catch below for missing prefs.php
+         * files. */
+        if (!$registry instanceof Horde_Registry) {
+            return $scope_ob;
+        }
+
         /* Read the configuration file.
          * Values are in the $_prefs array. */
         try {


### PR DESCRIPTION
## Summary

`Horde_Core_Prefs_Storage_Configuration::get()` reaches out to `global $registry` to load `prefs.php` defaults. Under modern PSR-15 request paths (e.g. the admin REST API — `Horde\Horde\Admin\UserController::get()` → `IdentityService::getAll()` → `SqlPrefsService::getValue()`), `$GLOBALS['registry']` is never populated and the class fatals with `Call to a member function loadConfigFile() on null`.

Add a guard: when `$registry` isn't a `Horde_Registry` instance, return `$scope_ob` unchanged. Same graceful fallback shape the existing `try/catch` uses when `prefs.php` doesn't exist. Downstream storage drivers (SQL etc.) still supply real user preferences.

Reproducer against a locally-installed Horde:

    hordectl query user admin
    → ❌ 500 Internal Server Error (before)
    → 200 with user payload (after)

Config-file defaults are best-effort atop user prefs. When we can't reach the registry to load them, "skip defaults, fall through to real storage" is the right degrade.

Reported while dogfooding `hordectl webserver-config` in horde/hordectl PR #17 CI. Surfaces on any admin REST API call that touches `IdentityService`.