### PR TITLE
feat(core): reconnect IMAP for ActiveSync mail via mail API

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -357,6 +357,50 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             }
         }
 
+        if (!$this->_ensureMailAuthenticated($username, $password)) {
+            return Horde_ActiveSync::AUTH_REASON_UNAVAILABLE;
+        }
+
+        return true;
+    }
+
+    /**
+     * Ensure the mail backend session exists when email sync is enabled.
+     *
+     * ActiveSync authenticates to Horde; mail operations need a separate
+     * login to the mail app (including hordeauth transparent login to the
+     * IMAP backend). Delegated to the registered 'mail' application via the
+     * optional 'mail/ensureImapConnection' API method, so Core stays
+     * agnostic of the concrete mail app.
+     *
+     * @param string $username  The authenticated Horde username.
+     * @param string $password  The ActiveSync password.
+     *
+     * @return boolean  True if mail is not required or the connection is ready.
+     */
+    protected function _ensureMailAuthenticated($username, $password)
+    {
+        global $registry;
+
+        if (empty($this->_imap)
+            || !$registry->hasMethod('mail/ensureImapConnection')) {
+            return true;
+        }
+
+        try {
+            $registry->mail->ensureImapConnection([
+                'userId' => $username,
+                'password' => $password,
+            ]);
+        } catch (Horde_Exception $e) {
+            $this->_logger->warn(sprintf(
+                'ActiveSync: mail server authentication failed for user %s: %s',
+                $username,
+                $e->getMessage()
+            ));
+            return false;
+        }
+
         return true;
     }
 

--- a/lib/Horde/Core/ActiveSync/Imap/Factory.php
+++ b/lib/Horde/Core/ActiveSync/Imap/Factory.php
@@ -39,6 +39,20 @@ class Horde_Core_ActiveSync_Imap_Factory implements Horde_ActiveSync_Interface_I
             } catch (Horde_Exception $e) {
                 throw new Horde_ActiveSync_Exception($e);
             }
+
+            if (empty($this->_adapter)
+                && $GLOBALS['registry']->hasMethod('mail/ensureImapConnection')) {
+                try {
+                    $GLOBALS['registry']->mail->ensureImapConnection();
+                    $this->_adapter = $GLOBALS['registry']->mail->imapOb();
+                } catch (Horde_Exception $e) {
+                    throw new Horde_ActiveSync_Exception($e);
+                }
+            }
+        }
+
+        if (empty($this->_adapter)) {
+            throw new Horde_ActiveSync_Exception('IMAP client is not available.');
         }
 
         return $this->_adapter;


### PR DESCRIPTION
## Summary
- On ActiveSync auth and lazily in the IMAP factory, ensure the mail app has a live IMAP connection via the optional `mail/ensureImapConnection` API method.
- The IMAP factory now throws a clear `Horde_ActiveSync_Exception` instead of returning an empty client.

## Motivation
ActiveSync authenticates to Horde, but with `hordeauth` mail backends the mail app may not have an established IMAP login on stateless or long-running (PING) requests. `$registry->mail->imapOb()` then returns an empty client, and `Horde_ActiveSync_Imap_Adapter` ends up calling `status()` on `null` (see horde/ActiveSync#78).

## Changes
- `Horde_Core_ActiveSync_Driver::authenticate()`: after successful Horde auth, call `_ensureMailAuthenticated()`, which triggers `$registry->mail->ensureImapConnection([...])` when email sync is enabled.
- `Horde_Core_ActiveSync_Imap_Factory::getImapOb()`: if `imapOb()` yields an empty client, call `ensureImapConnection()` and retry; throw a clear exception if still unavailable.
- Both call sites are guarded by `Registry::hasMethod('mail/ensureImapConnection')`, so Core remains agnostic of the concrete mail app and no-ops when the capability is absent.

## Dependencies
- Uses the `mail/ensureImapConnection` API method added in horde/imp #89.

## Notes
- The failure is timing/heartbeat-dependent and hard to reproduce deterministically; this is a defensive fix that pairs with the null-client guard in horde/ActiveSync#78.

## Test plan
- [ ] EAS device with mail sync on a hordeauth backend; confirm mail folders sync after idle/PING without `status() on null`.
- [ ] Install without the mail method: confirm ActiveSync auth still succeeds (no-op).
