### PR TITLE
fix(core): keep Horde_Session::$begin readable after close() (imp#88)

### DIFF
--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -60,7 +60,7 @@ use Horde\Token\Token as ModernToken;
  * @package  Core
  *
  * @property-read integer $begin             The timestamp when this session
- *                                           began (0 if session is not active).
+ *                                           began (0 if unknown).
  * @property-read boolean $regenerate_due    True if session ID is due for
  *                                           regeneration (since 2.5.0).
  * @property-read integer $regenerate_interval  The regeneration interval
@@ -222,9 +222,15 @@ class Horde_Session implements Horde_Shutdown_Task
     {
         switch ($name) {
             case 'begin':
-                if (!$this->_active) {
-                    return 0;
-                }
+                // Read through to the modern session regardless of
+                // `_active`. close() (used by read-only service scripts
+                // such as download/view) flips `_active` to false but
+                // never clears the underlying data, so the previous
+                // "!$this->_active -> 0" short-circuit made `begin` (and
+                // thus Registry::checkExistingAuth()'s max_time check)
+                // report an unauthenticated session in every closed,
+                // read-only request once `session.max_time` was
+                // configured. See horde/imp#88.
                 $begin = $this->modern->getSessionBegin();
                 if ($begin !== null) {
                     return $begin->getTimestamp();

--- a/test/Unit/Session/HordeSessionShimBeginTest.php
+++ b/test/Unit/Session/HordeSessionShimBeginTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Torben Dannhauer <torben@dannhauer.de>
+ */
+
+namespace Horde\Core\Test\Unit\Session;
+
+use Horde\Core\Session\HordeSession;
+use Horde\SessionHandler\SessionId;
+use Horde_Session;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * Horde_Session::$begin must keep reading through to the modern
+ * HordeSession even after close() clears the shim's `_active` flag.
+ *
+ * Read-only service scripts (download, view) call close() right after
+ * bootstrap, but close() never clears the underlying session data -
+ * only session_write_close() runs. Registry::checkExistingAuth() reads
+ * $session->begin for the `session.max_time` check; if that getter
+ * collapsed to 0 once `_active` was false, max_time + 0 compares less
+ * than the current timestamp for any non-zero max_time, incorrectly
+ * failing auth for every closed, read-only request. See horde/imp#88.
+ */
+class HordeSessionShimBeginTest extends TestCase
+{
+    private function hordeSession(): HordeSession
+    {
+        return new HordeSession(new SessionId('begin-test'), []);
+    }
+
+    public function testBeginReadsThroughModernSessionWhenInactive(): void
+    {
+        $modern = $this->hordeSession();
+        $modern->setSessionBegin(1700000000);
+
+        $shim = new Horde_Session($modern);
+
+        $active = new ReflectionProperty(Horde_Session::class, '_active');
+        $active->setAccessible(true);
+        $active->setValue($shim, false);
+
+        self::assertFalse($shim->isActive());
+        self::assertSame(1700000000, $shim->begin);
+    }
+
+    public function testBeginFallsBackToZeroWhenNeverStarted(): void
+    {
+        $shim = new Horde_Session($this->hordeSession());
+
+        $active = new ReflectionProperty(Horde_Session::class, '_active');
+        $active->setAccessible(true);
+        $active->setValue($shim, false);
+
+        self::assertSame(0, $shim->begin);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix `Horde_Session::$begin` returning `0` after `close()`, which broke the `session.max_time` auth check for read-only service scripts.

## Motivation
Reported in [horde/imp#88](https://github.com/horde/imp/issues/88): downloading an attachment in IMP returned a 500 (`IMP_Exception: User is not authenticated.`), even for a fully logged-in user. The attachment download service boots with a read-only session and calls `close()` right after bootstrap.

`Horde_Session::__get('begin')` returned `0` whenever the shim's `_active` flag was false - which `close()` sets, without clearing the underlying session data. `Horde_Registry::checkExistingAuth()` uses `$session->begin` for the `session.max_time` check:

```php
if (!empty($conf['session']['max_time'])
    && (($conf['session']['max_time'] + $session->begin) < time())) {
    // -> auth check fails
}
```

With `begin` collapsed to `0`, `max_time + 0` is always less than the current Unix timestamp, so this check failed unconditionally for every closed, read-only request once `session.max_time` was configured - regardless of how recently the user actually authenticated.

## Changes
- `Horde_Session::__get('begin')` now reads through to the modern `HordeSession` unconditionally. Its data survives `close()` untouched, so this is safe for both the closed-but-was-active case and the never-started case (falls back to `0` via the existing `null` handling).
- Added `HordeSessionShimBeginTest` covering both cases.

## Test plan
- [x] `vendor/bin/phpunit test/Unit/Session/HordeSessionShimBeginTest.php` (2/2 passing)
- [x] Reporter confirmed on their own deployment that this fix resolves the attachment download 500 (see issue comments)
