### PR TITLE
fix(core): preserve descriptor schemas in ApiRegistry re-wrapping

### DIFF
--- a/src/Api/ApiRegistry.php
+++ b/src/Api/ApiRegistry.php
@@ -71,13 +71,7 @@ class ApiRegistry implements ApiProvider, MethodInvoker
             return null;
         }
 
-        return new MethodDescriptor(
-            name: $interface . '.' . $descriptor->name,
-            description: $descriptor->description,
-            parameters: $descriptor->parameters,
-            returnType: $descriptor->returnType,
-            permissions: $descriptor->permissions,
-        );
+        return $this->prefixDescriptor($interface, $descriptor);
     }
 
     /**
@@ -88,13 +82,7 @@ class ApiRegistry implements ApiProvider, MethodInvoker
         $all = [];
         foreach ($this->providers as $interface => $provider) {
             foreach ($provider->listMethods($context) as $descriptor) {
-                $all[] = new MethodDescriptor(
-                    name: $interface . '.' . $descriptor->name,
-                    description: $descriptor->description,
-                    parameters: $descriptor->parameters,
-                    returnType: $descriptor->returnType,
-                    permissions: $descriptor->permissions,
-                );
+                $all[] = $this->prefixDescriptor($interface, $descriptor);
             }
         }
 
@@ -151,6 +139,24 @@ class ApiRegistry implements ApiProvider, MethodInvoker
     public function getProviderForInterface(string $interface): ApiProvider|MethodInvoker|null
     {
         return $this->providers[$interface] ?? null;
+    }
+
+    /**
+     * Re-wrap a provider-local descriptor with the interface-prefixed name,
+     * preserving all other metadata (including the JSON schemas needed by
+     * MCP tool listings).
+     */
+    private function prefixDescriptor(string $interface, MethodDescriptor $descriptor): MethodDescriptor
+    {
+        return new MethodDescriptor(
+            name: $interface . '.' . $descriptor->name,
+            description: $descriptor->description,
+            parameters: $descriptor->parameters,
+            returnType: $descriptor->returnType,
+            inputSchema: $descriptor->inputSchema,
+            outputSchema: $descriptor->outputSchema,
+            permissions: $descriptor->permissions,
+        );
     }
 
     /**

--- a/test/Unit/Api/ApiRegistryTest.php
+++ b/test/Unit/Api/ApiRegistryTest.php
@@ -85,6 +85,42 @@ class ApiRegistryTest extends TestCase
         $this->assertSame('List items', $desc->description);
     }
 
+    public function testDescriptorSchemasPreserved(): void
+    {
+        $inputSchema = [
+            'type' => 'object',
+            'properties' => [
+                'pagename' => ['type' => 'string', 'description' => 'Page to edit'],
+            ],
+            'required' => ['pagename'],
+        ];
+        $outputSchema = ['type' => 'object'];
+        $provider = $this->makeProvider(
+            ['edit' => fn() => null],
+            ['edit' => new MethodDescriptor(
+                'edit',
+                description: 'Edit a page',
+                inputSchema: $inputSchema,
+                outputSchema: $outputSchema,
+            )],
+        );
+        $registry = new ApiRegistry();
+        $registry->registerProvider('wiki', $provider);
+
+        $desc = $registry->getMethodDescriptor('wiki.edit');
+
+        $this->assertNotNull($desc);
+        $this->assertSame($inputSchema, $desc->inputSchema);
+        $this->assertSame($outputSchema, $desc->outputSchema);
+
+        $listed = $registry->listMethods();
+
+        $this->assertCount(1, $listed);
+        $this->assertSame('wiki.edit', $listed[0]->name);
+        $this->assertSame($inputSchema, $listed[0]->inputSchema);
+        $this->assertSame($outputSchema, $listed[0]->outputSchema);
+    }
+
     public function testUnknownInterfaceHasMethodReturnsFalse(): void
     {
         $registry = new ApiRegistry();


### PR DESCRIPTION
## Summary
- `ApiRegistry::getMethodDescriptor()` and `::listMethods()` re-wrap provider
  descriptors to prefix the interface name (`wiki.edit`), but dropped the
  `inputSchema` / `outputSchema` fields in the process.

## Motivation
`MethodDescriptor::$inputSchema` / `$outputSchema` are the machine-readable
contract for API discovery: JSON-RPC discovery (`rpc.discover`) and the MCP
`tools/list` handler pass them to clients so callers know how to invoke a
method. AI/MCP clients especially depend on explicitly authored JSON schemas —
enums, nested objects, per-property descriptions — to make correct tool calls.
The auto-generated fallback from the flat `parameters` array cannot express
any of that.

Because the `ApiRegistry` re-wrap silently discarded these fields, every
discovery consumer saw degraded or empty schemas no matter how carefully a
provider declared them. Any effort to expose Horde app APIs to AI clients via
the MCP layer in `horde/rpc` is blocked until descriptors survive aggregation
intact, which is how the bug was found.

## Changes
- Route both re-wrap sites through a shared private `prefixDescriptor()`
  helper that preserves all `MethodDescriptor` fields.
- Add regression test `testDescriptorSchemasPreserved` covering
  `getMethodDescriptor()` and `listMethods()`.

## Test plan
- [x] `test/Unit/Api/` suite passes (20 tests, 35 assertions)
- [x] New regression test fails on the previous implementation
