### PR TITLE
fix(activesync): guard ResolveRecipients free/busy lookup failures

### DIFF
--- a/lib/Horde/Core/ActiveSync/Connector.php
+++ b/lib/Horde/Core/ActiveSync/Connector.php
@@ -514,7 +514,11 @@ class Horde_Core_ActiveSync_Connector
             try {
                 return [$query => $this->_registry->calendar->lookupFreeBusy($query, true)];
             } catch (Horde_Exception $e) {
-                return false; // ?
+                // Optional for many recipients (esp. external addresses without
+                // a free/busy URL); avoid flooding normal log levels.
+                $this->_logger->debug($e->getMessage());
+                // Keep the keyed array shape so callers can index by $query.
+                return [$query => false];
             }
         }
 

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -3362,7 +3362,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
             if (!empty($entry)) {
                 $fb = $this->_connector->resolveRecipient($search, $opts);
                 if ($availability_request) {
-                    $entry['availability'] = self::buildFbString($fb[$search], $opts['starttime'], $opts['endtime']);
+                    $fbData = (is_array($fb) && isset($fb[$search])) ? $fb[$search] : null;
+                    $entry['availability'] = self::buildFbString($fbData, $opts['starttime'], $opts['endtime']);
                 }
                 $return[] = $entry;
             }

--- a/test/Unit/ActiveSync/DriverResolveRecipientTest.php
+++ b/test/Unit/ActiveSync/DriverResolveRecipientTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Torben Dannhauer <torben@dannhauer.de>
+ * @category Horde
+ * @copyright 2026 The Horde Project
+ * @license http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package Core
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Core\Test\Unit\ActiveSync;
+
+use Horde\Core\Test\Support\MockSkipConstructorTrait;
+use Horde\Http\ServerRequest;
+use Horde_ActiveSync;
+use Horde_Core_ActiveSync_Auth;
+use Horde_Core_ActiveSync_Connector;
+use Horde_Core_ActiveSync_Driver;
+use Horde_Date;
+use Horde_Registry;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Horde_Core_ActiveSync_Driver::resolveRecipient().
+ */
+#[CoversMethod(Horde_Core_ActiveSync_Driver::class, 'resolveRecipient')]
+class DriverResolveRecipientTest extends TestCase
+{
+    use MockSkipConstructorTrait;
+
+    public function testAvailabilityIgnoresFalseFreeBusyLookup(): void
+    {
+        if (!class_exists('Horde_ActiveSync_State_Sql')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $email = 'alice@example.com';
+        $gal = 'gal';
+
+        $connector = $this->getMockSkipConstructor(
+            Horde_Core_ActiveSync_Connector::class,
+            ['resolveRecipient', 'contacts_getGal']
+        );
+        $connector->expects($this->exactly(2))
+            ->method('resolveRecipient')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $email => [
+                        [
+                            'name' => 'Alice Example',
+                            'email' => $email,
+                            'source' => $gal,
+                            'smimePublicKey' => null,
+                        ],
+                    ],
+                ],
+                false
+            );
+        $connector->expects($this->once())
+            ->method('contacts_getGal')
+            ->willReturn($gal);
+
+        $driver = new Horde_Core_ActiveSync_Driver([
+            'connector' => $connector,
+            'auth' => $this->getMockSkipConstructor(Horde_Core_ActiveSync_Auth::class),
+            'serverrequest' => new ServerRequest('POST', '/'),
+            'registry' => $this->getMockSkipConstructor(Horde_Registry::class),
+            'state' => $this->createDriverStateMock(),
+            'imap' => null,
+        ]);
+
+        $results = $driver->resolveRecipient('availability', $email, [
+            'maxambiguous' => 0,
+            'starttime' => new Horde_Date('2026-07-15T09:00:00.000Z', 'UTC'),
+            'endtime' => new Horde_Date('2026-07-15T17:00:00.000Z', 'UTC'),
+        ]);
+
+        $this->assertCount(1, $results);
+        $this->assertSame($email, $results[0]['emailaddress']);
+        $this->assertSame(Horde_ActiveSync::RESOLVE_RESULT_GAL, $results[0]['type']);
+        $this->assertFalse($results[0]['availability']);
+    }
+
+    public function testAvailabilityUsesKeyedFalseFreeBusyResult(): void
+    {
+        if (!class_exists('Horde_ActiveSync_State_Sql')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $email = 'alice@example.com';
+        $gal = 'gal';
+
+        $connector = $this->getMockSkipConstructor(
+            Horde_Core_ActiveSync_Connector::class,
+            ['resolveRecipient', 'contacts_getGal']
+        );
+        $connector->expects($this->exactly(2))
+            ->method('resolveRecipient')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $email => [
+                        [
+                            'name' => 'Alice Example',
+                            'email' => $email,
+                            'source' => $gal,
+                            'smimePublicKey' => null,
+                        ],
+                    ],
+                ],
+                [$email => false]
+            );
+        $connector->expects($this->once())
+            ->method('contacts_getGal')
+            ->willReturn($gal);
+
+        $driver = new Horde_Core_ActiveSync_Driver([
+            'connector' => $connector,
+            'auth' => $this->getMockSkipConstructor(Horde_Core_ActiveSync_Auth::class),
+            'serverrequest' => new ServerRequest('POST', '/'),
+            'registry' => $this->getMockSkipConstructor(Horde_Registry::class),
+            'state' => $this->createDriverStateMock(),
+            'imap' => null,
+        ]);
+
+        $results = $driver->resolveRecipient('availability', $email, [
+            'maxambiguous' => 0,
+            'starttime' => new Horde_Date('2026-07-15T09:00:00.000Z', 'UTC'),
+            'endtime' => new Horde_Date('2026-07-15T17:00:00.000Z', 'UTC'),
+        ]);
+
+        $this->assertCount(1, $results);
+        $this->assertFalse($results[0]['availability']);
+    }
+
+    private function createDriverStateMock(): MockObject
+    {
+        $state = $this->getMockSkipConstructor('Horde_ActiveSync_State_Sql');
+        $state->expects($this->once())->method('setLogger');
+        $state->expects($this->once())->method('setBackend');
+
+        return $state;
+    }
+}


### PR DESCRIPTION
## Summary
- Fix PHP warning when ActiveSync ResolveRecipients availability lookup fails
- Treat missing/failed free/busy as optional (debug log only)
- Add unit coverage for false and keyed-false connector results

## Motivation
Clients often request availability for addresses that have no free/busy
data (especially external invitees without a free/busy URL). The connector
returned bare `false`, and the driver indexed it as an array, producing
`Trying to access array offset on false` in the Horde log.

## Changes
- Connector: on `lookupFreeBusy` failure, log at debug and return `[$query => false]`
- Driver: only read `$fb[$search]` when `$fb` is an array with that key
- Tests: `DriverResolveRecipientTest` for both failure shapes

## Test plan
- [x] `DriverResolveRecipientTest` (2 tests)
- [ ] ActiveSync ResolveRecipients with availability for an external address without free/busy URL — no PHP warning; availability status not-found
- [ ] Same for a local Horde user with calendar — availability still returned
