### PR TITLE
fix(activesync): refuse Draft Modify append-as-new for stale UIDs

### DIFF
--- a/doc/changelog.yml
+++ b/doc/changelog.yml
@@ -1,4 +1,14 @@
 ---
+3.2.1:
+  api: 3.2.1
+  state:
+    release: stable
+    api: stable
+  date: 2026-07-17
+  license:
+    identifier: LGPL-2.1-only
+    uri: https://spdx.org/licenses/LGPL-2.1-only.html
+  notes: "fix(activesync): refuse Draft Modify append-as-new for missing/stale IMAP UIDs (ActiveSync #85)"
 3.2.0:
   api: 3.2.0
   state:

--- a/doc/changelog.yml
+++ b/doc/changelog.yml
@@ -1,14 +1,4 @@
 ---
-3.2.1:
-  api: 3.2.1
-  state:
-    release: stable
-    api: stable
-  date: 2026-07-17
-  license:
-    identifier: LGPL-2.1-only
-    uri: https://spdx.org/licenses/LGPL-2.1-only.html
-  notes: "fix(activesync): refuse Draft Modify append-as-new for missing/stale IMAP UIDs (ActiveSync #85)"
 3.2.0:
   api: 3.2.0
   state:

--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -2565,8 +2565,10 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                                 $this->_user,
                                 $this->_version
                             );
-                            $draft->setDraftMessage($message);
 
+                            // Load the existing draft before setDraftMessage so
+                            // attachment carry-over works, and so a missing/
+                            // stale Modify ServerId fails before MIME build.
                             if ($id) {
                                 try {
                                     $draft->getExistingDraftMessage(
@@ -2574,9 +2576,25 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                                         $id
                                     );
                                 } catch (Horde_ActiveSync_Exception $e) {
-                                    // Stale UID from client; treat as new.
+                                    // Modify with a missing/stale UID must not
+                                    // append a new draft (retries after a lost
+                                    // Sync response would otherwise duplicate
+                                    // unbounded). Importer short-circuits when
+                                    // the prior apply was recorded; this is
+                                    // defense in depth when that record is absent.
+                                    $this->_logger->notice(
+                                        sprintf(
+                                            'Draft Modify for missing UID %s in %s; refusing append-as-new.',
+                                            $id,
+                                            $draft_folder
+                                        )
+                                    );
+                                    $this->_endBuffer();
+                                    return false;
                                 }
                             }
+
+                            $draft->setDraftMessage($message);
 
                             // Append the message and return results.
                             $results = $draft->append($draft_folder);
@@ -2585,6 +2603,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                             $stat['conversationid'] = bin2hex($message->subject);
                             $stat['conversationindex'] = time();
 
+                            $this->_endBuffer();
                             return $stat;
                         }
                     }

--- a/test/Unit/ActiveSync/DriverDraftModifyStaleUidTest.php
+++ b/test/Unit/ActiveSync/DriverDraftModifyStaleUidTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Torben Dannhauer <torben@dannhauer.de>
+ * @category Horde
+ * @copyright 2026 The Horde Project
+ * @license http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package Core
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Core\Test\Unit\ActiveSync;
+
+use Horde\Http\ServerRequest;
+use Horde_ActiveSync;
+use Horde_ActiveSync_Device;
+use Horde_ActiveSync_Imap_Adapter;
+use Horde_ActiveSync_Message_AirSyncBaseBody;
+use Horde_ActiveSync_Message_Mail;
+use Horde_Core_ActiveSync_Auth;
+use Horde_Core_ActiveSync_Connector;
+use Horde_Core_ActiveSync_Driver;
+use Horde_Log_Handler_Null;
+use Horde_Log_Logger;
+use Horde_Registry;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Defense-in-depth for Issue #85: Draft Modify must not append-as-new when
+ * the client ServerId is missing/stale on IMAP.
+ */
+#[CoversMethod(Horde_Core_ActiveSync_Driver::class, 'changeMessage')]
+class DriverDraftModifyStaleUidTest extends TestCase
+{
+    public function testDraftModifyMissingUidDoesNotAppend(): void
+    {
+        if (!class_exists('Horde_ActiveSync_Message_Mail')) {
+            $this->markTestSkipped('horde/activesync not available');
+        }
+
+        $folder = 'INBOX/Drafts';
+        $staleUid = 100;
+
+        $imap = $this->getMockBuilder(Horde_ActiveSync_Imap_Adapter::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getImapMessage', 'appendMessage', 'deleteMessages', 'getSpecialMailboxes', 'setLogger'])
+            ->getMock();
+        $imap->method('getSpecialMailboxes')->willReturn([
+            Horde_Core_ActiveSync_Driver::SPECIAL_DRAFTS => (object) ['value' => $folder],
+        ]);
+        $imap->expects($this->once())
+            ->method('getImapMessage')
+            ->with($folder, $staleUid)
+            ->willReturn([]);
+        $imap->expects($this->never())->method('appendMessage');
+        $imap->expects($this->never())->method('deleteMessages');
+
+        $state = $this->getMockBuilder('Horde_ActiveSync_State_Sql')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $state->method('setLogger');
+        $state->method('setBackend');
+
+        $connector = $this->getMockBuilder(Horde_Core_ActiveSync_Connector::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $auth = $this->getMockBuilder(Horde_Core_ActiveSync_Auth::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $registry = $this->getMockBuilder(Horde_Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $driver = new Horde_Core_ActiveSync_Driver([
+            'connector' => $connector,
+            'auth' => $auth,
+            'serverrequest' => new ServerRequest('POST', '/'),
+            'registry' => $registry,
+            'state' => $state,
+            'imap' => $imap,
+        ]);
+        $driver->setLogger(new Horde_Log_Logger(new Horde_Log_Handler_Null()));
+        $driver->setProtocolVersion(Horde_ActiveSync::VERSION_SIXTEEN);
+
+        $userProp = new \ReflectionProperty(
+            \Horde_ActiveSync_Driver_Base::class,
+            '_user'
+        );
+        $userProp->setAccessible(true);
+        $userProp->setValue($driver, 'alice@example.com');
+
+        $message = new Horde_ActiveSync_Message_Mail([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $message->to = 'alice@example.com';
+        $message->subject = 'Draft subject';
+        $body = new Horde_ActiveSync_Message_AirSyncBaseBody([
+            'protocolversion' => Horde_ActiveSync::VERSION_SIXTEEN,
+        ]);
+        $body->type = Horde_ActiveSync::BODYPREF_TYPE_PLAIN;
+        $body->data = 'body';
+        $message->airsyncbasebody = $body;
+
+        $device = $this->createMock(Horde_ActiveSync_Device::class);
+
+        $result = $driver->changeMessage($folder, $staleUid, $message, $device);
+
+        $this->assertFalse($result);
+    }
+}

--- a/test/Unit/ActiveSync/DriverDraftModifyStaleUidTest.php
+++ b/test/Unit/ActiveSync/DriverDraftModifyStaleUidTest.php
@@ -21,6 +21,7 @@ namespace Horde\Core\Test\Unit\ActiveSync;
 use Horde\Http\ServerRequest;
 use Horde_ActiveSync;
 use Horde_ActiveSync_Device;
+use Horde_ActiveSync_Driver_Base;
 use Horde_ActiveSync_Imap_Adapter;
 use Horde_ActiveSync_Message_AirSyncBaseBody;
 use Horde_ActiveSync_Message_Mail;
@@ -32,6 +33,7 @@ use Horde_Log_Logger;
 use Horde_Registry;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 /**
  * Defense-in-depth for Issue #85: Draft Modify must not append-as-new when
@@ -90,8 +92,8 @@ class DriverDraftModifyStaleUidTest extends TestCase
         $driver->setLogger(new Horde_Log_Logger(new Horde_Log_Handler_Null()));
         $driver->setProtocolVersion(Horde_ActiveSync::VERSION_SIXTEEN);
 
-        $userProp = new \ReflectionProperty(
-            \Horde_ActiveSync_Driver_Base::class,
+        $userProp = new ReflectionProperty(
+            Horde_ActiveSync_Driver_Base::class,
             '_user'
         );
         $userProp->setAccessible(true);


### PR DESCRIPTION
## Summary
- Refuse EAS 16 Drafts-folder `Modify` when the client ServerId (IMAP UID) is already missing: do not append a new draft
- Load the existing draft before `setDraftMessage` so stale UIDs fail fast and attachment carry-over order stays correct
- Unit test covers the no-append path

## Motivation
Defense in depth for [horde/ActiveSync#85](https://github.com/horde/ActiveSync/issues/85). The ActiveSync importer short-circuits retries when the prior apply was recorded; if that map write never landed, the previous Core behaviour (“stale UID → treat as new”) could still append unbounded copies on retry.

## Changes
- `Horde_Core_ActiveSync_Driver::changeMessage` Drafts branch: missing Modify UID → log notice, return `false`
- `DriverDraftModifyStaleUidTest`

## Test plan
- [x] `DriverDraftModifyStaleUidTest`
- [ ] Together with ActiveSync #85: retry Draft Modify after lost response does not grow Drafts
