### PR TITLE
fix(core): publish in-memory session for CLI SessionAccess

### DIFF
--- a/lib/Horde/Registry.php
+++ b/lib/Horde/Registry.php
@@ -356,6 +356,26 @@ class Horde_Registry implements Horde_Shutdown_Task
 
             $args['nocompress'] = true;
             $args['authentication'] = 'none';
+
+            /* CLI tools have never wanted a persisted PHP session — they
+             * are one-shot processes, cannot receive a session cookie,
+             * and their state (alarms, cache warmers, admin scripts)
+             * lives in the DB or hashtable, not $_SESSION. Historically
+             * the CLI branch below built a real Horde_Session but called
+             * setup(false) to skip session_start(); that left the modern
+             * SessionAccessor empty and every consumer that reached it
+             * during Registry::__construct() (Nlsconfig, notification
+             * handler, ...) fataled. Route CLI through session_control
+             * 'none' (Horde_Session_Null) instead: same "no persisted
+             * session" semantics, but Horde_Session_Null publishes an
+             * in-memory HordeSession to the accessor so consumers see a
+             * live session for the duration of the process.
+             *
+             * Only default; explicit callers may override. See
+             * horde/Core#207. */
+            if ($args['session_control'] === null) {
+                $args['session_control'] = 'none';
+            }
         }
 
         // For 'fallback' authentication, try authentication first.

--- a/lib/Horde/Session.php
+++ b/lib/Horde/Session.php
@@ -17,6 +17,7 @@ use Horde\Core\Factory\TokenServiceFactory;
 use Horde\Core\Horde;
 use Horde\Core\Session\HordeSession;
 use Horde\Core\Session\HordeSessionFactory;
+use Horde\Core\Session\PublishesModernSessionToAccessorTrait;
 use Horde\Core\Session\SessionAccess;
 use Horde\Core\Session\SessionLifecycle;
 use Horde\SessionHandler\SessionHandler as ModernSessionHandler;
@@ -71,6 +72,8 @@ use Horde\Token\Token as ModernToken;
  */
 class Horde_Session implements Horde_Shutdown_Task
 {
+    use PublishesModernSessionToAccessorTrait;
+
     /* Class constants. */
     public const BEGIN = '_b';
     public const ENCRYPTED = '_e'; /* @since 2.7.0 */
@@ -1005,6 +1008,12 @@ class Horde_Session implements Horde_Shutdown_Task
      * legacy fixtures) opted out of accessor-based resolution and
      * expect their pinned instance to stay authoritative regardless of
      * `$_SESSION` churn.
+     *
+     * The standard injector-plus-accessor publish is delegated to
+     * {@see PublishesModernSessionToAccessorTrait::publishModernSessionToAccessor()}
+     * so {@see Horde_Session_Null} can reuse the exact same behaviour
+     * without inheriting the two special branches this method wraps
+     * around it.
      */
     private function _rebuildModern(): void
     {
@@ -1021,21 +1030,7 @@ class Horde_Session implements Horde_Shutdown_Task
         }
 
         if (isset($GLOBALS['injector'])) {
-            $fresh = $GLOBALS['injector']->createInstance(HordeSession::class);
-            $GLOBALS['injector']->setInstance(HordeSession::class, $fresh);
-            // Also publish to the accessor if one is bound, so
-            // consumers reading through SessionAccess pick up the
-            // freshly-built instance.
-            try {
-                $access = $GLOBALS['injector']->getInstance(SessionAccess::class);
-                if ($access instanceof \Horde\Core\Session\SessionAccessor) {
-                    $access->replaceWith($fresh);
-                }
-            } catch (\Throwable) {
-                // No SessionAccess binding. Consumers still reach the
-                // fresh instance via getInstance(HordeSession::class)
-                // — the setInstance above.
-            }
+            $this->publishModernSessionToAccessor();
             return;
         }
 

--- a/lib/Horde/Session/Null.php
+++ b/lib/Horde/Session/Null.php
@@ -26,6 +26,8 @@
  */
 class Horde_Session_Null extends Horde_Session implements Horde_Shutdown_Task
 {
+    use \Horde\Core\Session\PublishesModernSessionToAccessorTrait;
+
     /**
      * Constructor.
      */
@@ -97,6 +99,21 @@ class Horde_Session_Null extends Horde_Session implements Horde_Shutdown_Task
     {
         $this->_active = true;
         $this->_data[Horde_Session::BEGIN] = time();
+
+        /* Publish an in-memory HordeSession to the modern SessionAccessor
+         * so consumers reading through SessionAccess (Nlsconfig, prefs
+         * cache, notification handler, ...) see a current session value
+         * for the duration of this request. Nothing here calls
+         * session_start(); this is purely the in-memory
+         * publish-to-accessor step that Horde_Session performs from its
+         * _rebuildModern() path. Without it, every request that boots
+         * with session_control='none' (rpc.php → ActiveSync, WebDAV,
+         * SyncML, EAS Autodiscover; and CLI tools via appInit()) hits
+         * SessionAccessor::current() during Registry::__construct()'s
+         * setLanguageEnvironment() call and fatals.
+         *
+         * See horde/Core#207. */
+        $this->publishModernSessionToAccessor();
     }
 
     /**

--- a/src/Session/PublishesModernSessionToAccessorTrait.php
+++ b/src/Session/PublishesModernSessionToAccessorTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Ralf Lang <ralf.lang@ralf-lang.de>
+ */
+
+namespace Horde\Core\Session;
+
+use Throwable;
+
+/**
+ * Shared "publish a fresh HordeSession to the injector and the accessor"
+ * behavior for both {@see \Horde_Session} and {@see \Horde_Session_Null}.
+ *
+ * Neither the parent shim nor the null shim can (or should) reach into
+ * {@see SessionLifecycle::rebuildHordeSession()} directly. Both need
+ * the same three-step operation:
+ *
+ *  1. Build a fresh {@see HordeSession} via the injector so encryption
+ *     closures ({@see HordeSessionFactory}) are wired up.
+ *  2. Pin it as the shared singleton so `getInstance(HordeSession::class)`
+ *     returns the fresh value.
+ *  3. Publish it to the {@see SessionAccessor} so consumers reading
+ *     through {@see SessionAccess} see a current session.
+ *
+ * The trait is deliberately stateless: no properties, no `use` clashes,
+ * no visibility relaxation on the classes that include it. Callers whose
+ * class carries its own extra state (the parent shim's `explicitModern`
+ * pin) handle those branches locally before delegating here.
+ */
+trait PublishesModernSessionToAccessorTrait
+{
+    /**
+     * Build a fresh HordeSession via the injector, register it as the
+     * shared singleton, and publish it to the SessionAccessor.
+     *
+     * No-op when no injector is present (bootstrap-only test contexts).
+     * The SessionAccess binding may legitimately be missing on some
+     * routes; the injector-singleton path still delivers the fresh
+     * HordeSession to callers that look it up directly, so silence the
+     * accessor exception rather than fail the whole publish.
+     */
+    private function publishModernSessionToAccessor(): void
+    {
+        if (!isset($GLOBALS['injector'])) {
+            return;
+        }
+
+        $fresh = $GLOBALS['injector']->createInstance(HordeSession::class);
+        $GLOBALS['injector']->setInstance(HordeSession::class, $fresh);
+
+        try {
+            $access = $GLOBALS['injector']->getInstance(SessionAccess::class);
+            if ($access instanceof SessionAccessor) {
+                $access->replaceWith($fresh);
+            }
+        } catch (Throwable) {
+            // No SessionAccess binding wired. Consumers still reach the
+            // fresh instance via getInstance(HordeSession::class) above.
+        }
+    }
+}

--- a/test/Unit/Session/HordeSessionNullTest.php
+++ b/test/Unit/Session/HordeSessionNullTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Core\Test\Unit\Session;
+
+use Horde\Core\Session\HordeSession;
+use Horde\Core\Session\SessionAccess;
+use Horde\Core\Session\SessionAccessor;
+use Horde\Injector\Injector;
+use Horde\Injector\TopLevel;
+use Horde_Core_Secret_Cbc;
+use Horde_Session_Null;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for horde/Core#207.
+ *
+ * `session_control = 'none'` boots consumers (rpc.php → ActiveSync,
+ * WebDAV, SyncML, EAS Autodiscover; CLI tools via appInit()) through
+ * {@see Horde_Session_Null}. The refactor in horde/Core#203 moved
+ * bootstrap consumers (Nlsconfig, prefs cache, notification handler)
+ * onto {@see SessionAccess}, whose accessor throws until something
+ * calls {@see SessionAccessor::replaceWith()}. Before this fix,
+ * `Horde_Session_Null::_start()` never touched the accessor, and the
+ * very next line in `Horde_Registry::__construct()` — the
+ * `setLanguageEnvironment()` call — fataled on
+ * `SessionAccessor::current()`.
+ *
+ * The fix moves the injector-plus-accessor publish into a shared
+ * trait ({@see PublishesModernSessionToAccessorTrait}) and calls it
+ * from `Horde_Session_Null::_start()`. These tests pin that
+ * contract.
+ */
+#[CoversClass(Horde_Session_Null::class)]
+class HordeSessionNullTest extends TestCase
+{
+    private ?Injector $previousInjector = null;
+
+    /** @var array<mixed>|null */
+    private ?array $previousSession = null;
+
+    protected function setUp(): void
+    {
+        // Preserve any injector and $_SESSION contents the surrounding
+        // suite may have wired so we can restore them after the test.
+        // Horde_Session_Null::__construct() and _start() mutate the
+        // global $_SESSION via a live reference; without restoration
+        // sibling tests (HordeSessionShimBeginTest) that assume a
+        // pristine `$_SESSION[BEGIN]` slot fail.
+        $this->previousInjector = $GLOBALS['injector'] ?? null;
+        $this->previousSession = $_SESSION ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousInjector === null) {
+            unset($GLOBALS['injector']);
+        } else {
+            $GLOBALS['injector'] = $this->previousInjector;
+        }
+        if ($this->previousSession === null) {
+            unset($_SESSION);
+        } else {
+            $_SESSION = $this->previousSession;
+        }
+    }
+
+    #[Test]
+    public function testSetupPublishesInMemorySessionToAccessor(): void
+    {
+        $injector = new Injector(new TopLevel());
+        $accessor = new SessionAccessor();
+        $injector->setInstance(SessionAccess::class, $accessor);
+        // HordeSessionFactory::create() resolves Horde_Secret_Cbc for
+        // its encryptor closures; a stub is enough because this test
+        // never encrypts anything.
+        $injector->setInstance(
+            'Horde_Secret_Cbc',
+            $this->createStub(Horde_Core_Secret_Cbc::class),
+        );
+        $GLOBALS['injector'] = $injector;
+
+        self::assertFalse(
+            $accessor->hasCurrent(),
+            'accessor must start empty — this is the state horde/Core#207 reported',
+        );
+
+        $null = new Horde_Session_Null();
+        // Do not call setup() here: the parent's setup() calls
+        // session_start()/session_write_close() which is unsuitable for
+        // a unit test under phpunit. The publish path runs from
+        // _start(), which is what setup() eventually calls; invoke it
+        // directly to isolate the publish step from PHP's session
+        // machinery.
+        (new \ReflectionMethod($null, '_start'))->invoke($null);
+
+        self::assertTrue(
+            $accessor->hasCurrent(),
+            'Horde_Session_Null::_start() must publish a HordeSession to the accessor',
+        );
+        self::assertInstanceOf(HordeSession::class, $accessor->current());
+    }
+
+    #[Test]
+    public function testPublishedSessionIsAlsoRegisteredAsSharedSingleton(): void
+    {
+        $injector = new Injector(new TopLevel());
+        $accessor = new SessionAccessor();
+        $injector->setInstance(SessionAccess::class, $accessor);
+        $injector->setInstance(
+            'Horde_Secret_Cbc',
+            $this->createStub(Horde_Core_Secret_Cbc::class),
+        );
+        $GLOBALS['injector'] = $injector;
+
+        $null = new Horde_Session_Null();
+        (new \ReflectionMethod($null, '_start'))->invoke($null);
+
+        // Consumers that resolve HordeSession directly (not through the
+        // accessor) must reach the same instance the accessor points at,
+        // otherwise scoped writes through one route wouldn't be visible
+        // through the other during the request.
+        self::assertSame(
+            $accessor->current(),
+            $injector->getInstance(HordeSession::class),
+            'HordeSession singleton and SessionAccessor current() diverged',
+        );
+    }
+
+    #[Test]
+    public function testScopedWritesFlowThroughAccessor(): void
+    {
+        // The whole point of publishing to the accessor is that
+        // Nlsconfig-style callers (curr_default, valid_lang cache,
+        // etc.) can call SessionAccess::setScoped()/getScoped()
+        // without fataling. This test proves the round trip.
+        $injector = new Injector(new TopLevel());
+        $accessor = new SessionAccessor();
+        $injector->setInstance(SessionAccess::class, $accessor);
+        $injector->setInstance(
+            'Horde_Secret_Cbc',
+            $this->createStub(Horde_Core_Secret_Cbc::class),
+        );
+        $GLOBALS['injector'] = $injector;
+
+        $null = new Horde_Session_Null();
+        (new \ReflectionMethod($null, '_start'))->invoke($null);
+
+        $accessor->setScoped('horde', 'nls/curr_default', 'de_DE');
+        self::assertTrue($accessor->hasScoped('horde', 'nls/curr_default'));
+        self::assertSame(
+            'de_DE',
+            $accessor->getScoped('horde', 'nls/curr_default'),
+        );
+    }
+
+    #[Test]
+    public function testStartDoesNotMarkPersistedSessionActive(): void
+    {
+        // Horde_Session_Null publishes to the accessor but must not
+        // pretend to have a persisted PHP session. session_status()
+        // must remain PHP_SESSION_NONE from the trait's perspective;
+        // we test the publish path in isolation (bypassing the
+        // parent's session_start()) and verify no session was
+        // opened by the publish step itself.
+        $injector = new Injector(new TopLevel());
+        $accessor = new SessionAccessor();
+        $injector->setInstance(SessionAccess::class, $accessor);
+        $injector->setInstance(
+            'Horde_Secret_Cbc',
+            $this->createStub(Horde_Core_Secret_Cbc::class),
+        );
+        $GLOBALS['injector'] = $injector;
+
+        // Bail out cleanly if the surrounding suite already opened a
+        // session — the assertion below would be meaningless.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            self::markTestSkipped('a session is already active in this process');
+        }
+
+        $null = new Horde_Session_Null();
+        (new \ReflectionMethod($null, '_start'))->invoke($null);
+
+        self::assertNotSame(
+            PHP_SESSION_ACTIVE,
+            session_status(),
+            'the publish path must not call session_start()',
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Fix fatal `SessionAccessor::current()` during CLI `appInit` (e.g. `horde-alarms`) after the SessionAccess refactor.
- Publish an in-memory `HordeSession` for `setup(false)` without calling `session_start()`.
- Guard Nlsconfig session caching with `hasCurrent()`.

## Motivation
CLI scripts deliberately skip PHP session files (`Horde_Session::setup(false)`). After consumers switched to `SessionAccess`, that left the accessor empty, so language setup and notification handler attach crashed with `LogicException`.

## Changes
- `SessionLifecycle::publishInMemory()` — publish accessor/injector binding; keep `isActive()` false (no `$_SESSION` mirror).
- `Horde_Session::setup(false)` calls `publishInMemory()` when a lifecycle is wired.
- `Horde_Registry_Nlsconfig` skips session cache when no current session is published.
- Unit coverage for both paths.

## Test plan
- [x] `vendor/bin/horde-alarms` completes (exit 0) on a Horde 6 deployment
- [x] `SessionLifecycleTest::testPublishInMemory…`
- [x] `NlsconfigTest` cases without established session
- [ ] Spot-check a normal web login still starts a real PHP session
