### PR TITLE
fix(core): omit TCP defaults for Unix-socket SQL config

### DIFF
--- a/src/Factory/DbServiceFactory.php
+++ b/src/Factory/DbServiceFactory.php
@@ -38,6 +38,7 @@ use InvalidArgumentException;
  * @category Horde
  * @package  Core
  * @author   Ralf Lang <ralf.lang@ralf-lang.de>
+ * @author   Torben Dannhauer <torben@dannhauer.de>
  * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
  */
 class DbServiceFactory
@@ -196,6 +197,11 @@ class DbServiceFactory
      *
      * Normalizes config keys across different naming conventions.
      *
+     * For protocol=unix, do not inject TCP host/port defaults. The PDO
+     * adapters strip `protocol` when building the DSN; if host=localhost
+     * and port=3306 remain, PostgreSQL tries TCP to MySQL's port and
+     * fails on socket-only deployments (see Horde Core#198 follow-up).
+     *
      * @param array $sqlConfig Raw SQL configuration
      * @return array Normalized adapter configuration
      */
@@ -205,20 +211,37 @@ class DbServiceFactory
             'username' => $sqlConfig['username'] ?? '',
             'password' => $sqlConfig['password'] ?? '',
             'database' => $sqlConfig['database'] ?? $sqlConfig['dbname'] ?? '',
-            'host' => $sqlConfig['hostspec'] ?? $sqlConfig['host'] ?? 'localhost',
-            'port' => $sqlConfig['port'] ?? 3306,
             'charset' => $sqlConfig['charset'] ?? 'UTF-8',
         ];
 
-        // Preserve Unix-socket connection settings when the config asks
-        // for them; without this the adapter falls back to the TCP
-        // host/port defaults above and breaks socket deployments.
         if (isset($sqlConfig['protocol'])) {
             $config['protocol'] = $sqlConfig['protocol'];
         }
         if (isset($sqlConfig['socket'])) {
             $config['socket'] = $sqlConfig['socket'];
         }
+
+        $protocol = $sqlConfig['protocol'] ?? null;
+        $hasExplicitHost = isset($sqlConfig['hostspec']) || isset($sqlConfig['host']);
+
+        // Unix socket: only pass host/port when the config sets them.
+        // Omitting them lets PDO_pgsql use the default server socket.
+        if ($protocol === 'unix') {
+            if ($hasExplicitHost) {
+                $config['host'] = $sqlConfig['hostspec'] ?? $sqlConfig['host'];
+            }
+            if (isset($sqlConfig['port'])) {
+                $config['port'] = $sqlConfig['port'];
+            }
+
+            return $config;
+        }
+
+        $phptype = $sqlConfig['phptype'] ?? 'mysqli';
+        $defaultPort = ($phptype === 'pgsql') ? 5432 : 3306;
+
+        $config['host'] = $sqlConfig['hostspec'] ?? $sqlConfig['host'] ?? 'localhost';
+        $config['port'] = $sqlConfig['port'] ?? $defaultPort;
 
         return $config;
     }

--- a/test/Unit/Factory/DbServiceFactoryTest.php
+++ b/test/Unit/Factory/DbServiceFactoryTest.php
@@ -39,6 +39,41 @@ final class DbServiceFactoryTest extends TestCase
         self::assertSame('unix', $config['protocol']);
         self::assertSame('/var/run/postgresql/.s.PGSQL.5432', $config['socket']);
         self::assertSame('horde', $config['database']);
+        // Must not invent TCP defaults — PDO would dial localhost:3306.
+        self::assertArrayNotHasKey('host', $config);
+        self::assertArrayNotHasKey('port', $config);
+    }
+
+    public function testBuildConnectionConfigUnixWithoutSocketOmitsTcpDefaults(): void
+    {
+        $config = $this->buildConnectionConfig([
+            'username' => 'horde',
+            'password' => 'secret',
+            'protocol' => 'unix',
+            'database' => 'horde',
+            'phptype' => 'pgsql',
+        ]);
+
+        self::assertSame('unix', $config['protocol']);
+        self::assertArrayNotHasKey('host', $config);
+        self::assertArrayNotHasKey('port', $config);
+        self::assertArrayNotHasKey('socket', $config);
+    }
+
+    public function testBuildConnectionConfigUnixKeepsExplicitHostAndPort(): void
+    {
+        $config = $this->buildConnectionConfig([
+            'username' => 'horde',
+            'password' => 'secret',
+            'protocol' => 'unix',
+            'hostspec' => '/var/run/postgresql',
+            'port' => 5432,
+            'database' => 'horde',
+            'phptype' => 'pgsql',
+        ]);
+
+        self::assertSame('/var/run/postgresql', $config['host']);
+        self::assertSame(5432, $config['port']);
     }
 
     public function testBuildConnectionConfigRenamesHostspecToHost(): void
@@ -57,6 +92,20 @@ final class DbServiceFactoryTest extends TestCase
         self::assertSame(5433, $config['port']);
     }
 
+    public function testBuildConnectionConfigDefaultsPgsqlTcpPort(): void
+    {
+        $config = $this->buildConnectionConfig([
+            'username' => 'horde',
+            'password' => 'secret',
+            'protocol' => 'tcp',
+            'database' => 'horde',
+            'phptype' => 'pgsql',
+        ]);
+
+        self::assertSame('localhost', $config['host']);
+        self::assertSame(5432, $config['port']);
+    }
+
     public function testBuildConnectionConfigDefaultsCharset(): void
     {
         $config = $this->buildConnectionConfig([
@@ -67,6 +116,8 @@ final class DbServiceFactoryTest extends TestCase
         ]);
 
         self::assertSame('UTF-8', $config['charset']);
+        self::assertSame('localhost', $config['host']);
+        self::assertSame(3306, $config['port']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Stop `DbServiceFactory` from injecting `host=localhost` / `port=3306` when SQL `protocol=unix`.
- Use phptype-aware TCP port defaults (5432 for pgsql, 3306 otherwise).
- Extend unit coverage for unix-without-socket, explicit unix host/port, and pgsql TCP defaults.

## Motivation
Follow-up to #198. That change preserved `protocol`/`socket` keys, but still always set TCP host/port defaults. PDO adapters strip `protocol` when building the DSN, so socket-based PostgreSQL deployments still attempted `localhost:3306` and failed with connection refused.

This showed up after smartmobile login for non-admin users: the modern portal resolves SQL-backed `Token` / `PermissionService` via `DbServiceFactory`. Admins / legacy app entry points often avoided that path.

## Changes
- `buildConnectionConfig()`: for `protocol=unix`, only pass host/port when explicitly configured.
- TCP path: default port 5432 for `pgsql`, 3306 otherwise.
- Unit tests updated accordingly.

## Test plan
- [ ] `vendor/bin/phpunit -c vendor/horde/core/phpunit.xml.dist --bootstrap vendor/autoload.php vendor/horde/core/test/Unit/Factory/DbServiceFactoryTest.php`
- [ ] Smartmobile login as a non-admin user on a Unix-socket PostgreSQL deployment reaches the portal without PDO localhost:3306 errors
- [ ] TCP PostgreSQL and MySQL configs still connect with expected host/port defaults
