### PR TITLE
fix(activesync): avoid foreach on string after calendar instance delete

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -2248,7 +2248,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
      * @param string $folderid      The folder id
      * @param array $ids            The message ids to delete
      * @param boolean $instanceids  If true, $ids is a hash of
-     *                              instanceids => uids. @since 2.23.0
+     *                              uids => instanceids. @since 2.23.0
      *
      * @return array  An array of succesfully deleted messages (currently
      *                only guarenteed for email messages).
@@ -2277,22 +2277,26 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
 
         switch ($class) {
             case Horde_ActiveSync::CLASS_CALENDAR:
+                // Keep $ids as an array for the catch-path foreach below.
+                // Callers pass [uid => instanceid] when $instanceids is true
+                // (see Horde_ActiveSync_Connector_Importer).
                 if ($instanceids) {
                     $instanceid = reset($ids);
-                    $ids = key($ids);
+                    $deleteIds = key($ids);
                 } else {
                     $instanceid = false;
+                    $deleteIds = $ids;
                 }
                 try {
                     $this->_logger->meta(
                         sprintf(
                             'calendar_delete: %s %s %s',
-                            print_r($ids, true),
+                            print_r($deleteIds, true),
                             $folder_id,
                             $instanceid
                         )
                     );
-                    $this->_connector->calendar_delete($ids, $folder_id, $instanceid);
+                    $this->_connector->calendar_delete($deleteIds, $folder_id, $instanceid);
                 } catch (Horde_Exception $e) {
                     // Since we don't get back successfully deleted ids and we can
                     // can pass an array of ids to delete, we need to see what ids
@@ -2301,7 +2305,8 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     // deleted ids.
                     $this->_logger->err($e->getMessage());
                     $success = [];
-                    foreach ($ids as $uid) {
+                    $checkIds = is_array($deleteIds) ? $deleteIds : [$deleteIds];
+                    foreach ($checkIds as $uid) {
                         if ($mod_time = $this->_connector->calendar_getActionTimestamp($uid, 'delete', $folder_id)) {
                             $success[] = $uid;
                         }

--- a/test/Unit/ActiveSync/DriverDeleteMessageInstanceTest.php
+++ b/test/Unit/ActiveSync/DriverDeleteMessageInstanceTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @author Torben Dannhauer <torben@dannhauer.de>
+ * @category Horde
+ * @copyright 2026 The Horde Project
+ * @license http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package Core
+ * @subpackage UnitTests
+ */
+
+namespace Horde\Core\Test\Unit\ActiveSync;
+
+use Horde\Http\ServerRequest;
+use Horde_ActiveSync;
+use Horde_Core_ActiveSync_Auth;
+use Horde_Core_ActiveSync_Connector;
+use Horde_Core_ActiveSync_Driver;
+use Horde_Exception;
+use Horde_Log_Handler_Null;
+use Horde_Log_Logger;
+use Horde_Registry;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression: calendar instance deletes must not foreach() a string UID when
+ * calendar_delete() throws (PHP 8 TypeError / warning on recovery path).
+ */
+#[CoversMethod(Horde_Core_ActiveSync_Driver::class, 'deleteMessage')]
+class DriverDeleteMessageInstanceTest extends TestCase
+{
+    private function createDriver(Horde_Core_ActiveSync_Connector $connector): Horde_Core_ActiveSync_Driver
+    {
+        $state = $this->getMockBuilder('Horde_ActiveSync_State_Sql')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $state->method('setLogger');
+        $state->method('setBackend');
+
+        $auth = $this->getMockBuilder(Horde_Core_ActiveSync_Auth::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $registry = $this->getMockBuilder(Horde_Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $driver = new Horde_Core_ActiveSync_Driver([
+            'connector' => $connector,
+            'auth' => $auth,
+            'serverrequest' => new ServerRequest('POST', '/'),
+            'registry' => $registry,
+            'state' => $state,
+        ]);
+        $driver->setLogger(new Horde_Log_Logger(new Horde_Log_Handler_Null()));
+
+        return $driver;
+    }
+
+    public function testCalendarInstanceDeleteErrorPathDoesNotForeachString(): void
+    {
+        $uid = 'event-uid-example';
+        $instanceId = '20250808T153000Z';
+        $folder = 'Calendar:cal-example';
+
+        $connector = $this->getMockBuilder(Horde_Core_ActiveSync_Connector::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['calendar_delete', 'calendar_getActionTimestamp'])
+            ->getMock();
+        $connector->expects($this->once())
+            ->method('calendar_delete')
+            ->with($uid, 'cal-example', $instanceId)
+            ->willThrowException(new Horde_Exception('not found'));
+        $connector->expects($this->once())
+            ->method('calendar_getActionTimestamp')
+            ->with($uid, 'delete', 'cal-example')
+            ->willReturn(false);
+
+        $driver = $this->createDriver($connector);
+        $results = $driver->deleteMessage($folder, [$uid => $instanceId], true);
+
+        $this->assertSame([], $results);
+    }
+
+    public function testCalendarInstanceDeleteErrorPathReportsSuccessfulUid(): void
+    {
+        $uid = 'event-uid-example';
+        $instanceId = '20250808T153000Z';
+        $folder = 'Calendar:cal-example';
+
+        $connector = $this->getMockBuilder(Horde_Core_ActiveSync_Connector::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['calendar_delete', 'calendar_getActionTimestamp'])
+            ->getMock();
+        $connector->method('calendar_delete')
+            ->willThrowException(new Horde_Exception('not found'));
+        $connector->method('calendar_getActionTimestamp')
+            ->willReturn(1234567890);
+
+        $driver = $this->createDriver($connector);
+        $results = $driver->deleteMessage($folder, [$uid => $instanceId], true);
+
+        $this->assertSame([$uid], $results);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix PHP warning in ActiveSync `deleteMessage()` when a recurring calendar instance delete fails and the recovery path iterates a string UID.
- Correct the `$instanceids` docblock to match callers (`uids => instanceids`).
- Add regression tests for the instance-delete error path.

## Motivation
An iPhone SYNC that removed a recurring instance (`AirSyncBase:InstanceId`) caused `calendar_delete` to throw (item not found). The catch block then ran `foreach ($ids as $uid)` after `$ids` had been overwritten with `key($ids)` (a string), producing:

`foreach() argument must be of type array|object, string given`

## Changes
- Keep the original `$ids` array; use `$deleteIds` for the connector call.
- Normalize `$deleteIds` to an array before the recovery `foreach`.
- Unit tests covering failed instance delete with and without a successful action timestamp.

## Test plan
- [x] `vendor/bin/phpunit --bootstrap /tmp/core-test-bootstrap.php -c vendor/horde/core/phpunit.xml.dist vendor/horde/core/test/Unit/ActiveSync/DriverDeleteMessageInstanceTest.php`
- [ ] Reproduce: ActiveSync Remove of a recurring instance that is already gone — confirm no PHP warning in `/tmp-horde/horde.log`
