### PR TITLE
fix(activesync): drop print_r from calendar_delete meta log

### DIFF
--- a/lib/Horde/Core/ActiveSync/Driver.php
+++ b/lib/Horde/Core/ActiveSync/Driver.php
@@ -2291,7 +2291,7 @@ class Horde_Core_ActiveSync_Driver extends Horde_ActiveSync_Driver_Base
                     $this->_logger->meta(
                         sprintf(
                             'calendar_delete: %s %s %s',
-                            print_r($deleteIds, true),
+                            is_array($deleteIds) ? implode(',', $deleteIds) : $deleteIds,
                             $folder_id,
                             $instanceid
                         )


### PR DESCRIPTION
Follow up to #213 