### PR TITLE
Let a theme ship its own javascript files

### DIFF
--- a/lib/Horde/PageOutput.php
+++ b/lib/Horde/PageOutput.php
@@ -714,6 +714,8 @@ class Horde_PageOutput
 
         $view->stylesheetOpts['sub'] = Horde_Themes::viewDir($this->_view);
 
+        $this->_addThemeScripts();
+
         if ($this->ajax || $this->growler) {
             $this->addScriptFile(new Horde_Script_File_JsFramework('hordecore.js', 'horde'));
 
@@ -830,6 +832,39 @@ class Horde_PageOutput
         if (Horde::contentSent()) {
             echo Horde::endBuffer();
             flush();
+        }
+    }
+
+    /**
+     * Adds the scripts shipped by the current theme, if any.
+     *
+     * A theme declares them in its info.php:
+     *
+     *   $theme_scripts = array('theme.js');
+     *
+     * Themes already ship CSS, images and sounds; this lets them ship the
+     * behaviour that goes with their markup as well, without the installer
+     * having to wire anything up. Only plain file names inside the theme
+     * directory are accepted (see Horde_Themes_Cache::themeScripts()).
+     */
+    protected function _addThemeScripts()
+    {
+        global $injector, $prefs, $registry;
+
+        $theme = $prefs->getValue('theme');
+        if (!strlen((string) $theme)) {
+            return;
+        }
+
+        /* The cache instance may come back unserialized; themeScripts() is
+         * derived on demand (not serialized), like the covered-apps list. */
+        $cache = $injector->getInstance('Horde_Core_Factory_ThemesCache')
+            ->create($registry->getApp(), $theme);
+
+        foreach ($cache->themeScripts() as $script) {
+            $this->addScriptFile(
+                new Horde_Script_File_ThemeDir($script, $theme, 'horde')
+            );
         }
     }
 

--- a/lib/Horde/Script/File/ThemeDir.php
+++ b/lib/Horde/Script/File/ThemeDir.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright 2012-2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category  Horde
+ * @copyright 2012-2026 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+
+/**
+ * This class represents a javascript script file located in a theme's
+ * directory.
+ *
+ * Themes may ship their own scripts alongside their CSS, images and sounds,
+ * by listing them in the theme's info.php:
+ *
+ *   $theme_scripts = array('theme.js');
+ *
+ * Only plain file names are accepted; they are resolved inside the theme
+ * directory. See Horde_Themes_Cache::themeScripts().
+ *
+ * @category  Horde
+ * @copyright 2012-2026 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
+ */
+class Horde_Script_File_ThemeDir extends Horde_Script_File
+{
+    /**
+     * The theme this file belongs to.
+     *
+     * @var string
+     */
+    protected $_theme;
+
+    /**
+     * @param string $file   The script file name.
+     * @param string $theme  The theme name.
+     * @param string $app    The application name. Defaults to the current
+     *                       application.
+     */
+    public function __construct($file, $theme, $app = null)
+    {
+        parent::__construct($file, $app);
+        $this->_theme = $theme;
+    }
+
+    /**
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'path':
+                return $GLOBALS['registry']->get('themesfs', $this->_app) .
+                    '/' . $this->_theme . '/';
+
+            case 'url':
+            case 'url_full':
+                return $this->_url(
+                    $GLOBALS['registry']->get('themesuri', $this->_app) .
+                        '/' . $this->_theme . '/' . $this->_file,
+                    ($name == 'url_full')
+                );
+        }
+
+        return parent::__get($name);
+    }
+}

--- a/lib/Horde/Themes/Cache.php
+++ b/lib/Horde/Themes/Cache.php
@@ -82,6 +82,21 @@ class Horde_Themes_Cache implements Serializable
     protected $_covers;
 
     /**
+     * Cached list of script files the theme ships. Read from the theme's
+     * info.php.
+     *
+     * @var string[]
+     */
+    protected $_scripts;
+
+    /**
+     * Cached declarations read from the theme's info.php.
+     *
+     * @var array
+     */
+    protected $_info;
+
+    /**
      * Constructor.
      *
      * @param string $app    The application name.
@@ -249,23 +264,89 @@ class Horde_Themes_Cache implements Serializable
     protected function _coveredApps()
     {
         if (!isset($this->_covers)) {
-            $theme_covers = [];
-
-            /* Theme names originate from user prefs/options, so guard against
-             * path traversal: only include info.php for a plain directory name
-             * (no separators, no '..'). Anything else inherits everything. */
-            if (preg_match('/^[A-Za-z0-9_-]+$/', (string) $this->_theme)) {
-                global $registry;
-                $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
-                if (is_readable($info)) {
-                    include $info;
-                }
-            }
-
-            $this->_covers = array_map('strtolower', (array) $theme_covers);
+            $info = $this->_themeInfo();
+            $this->_covers = array_map(
+                'strtolower',
+                (array) ($info['theme_covers'] ?? [])
+            );
         }
 
         return $this->_covers;
+    }
+
+    /**
+     * Returns the declarations made by the current theme's info.php.
+     *
+     * @return array  The variables the theme declares, keyed by name. Empty if
+     *                the theme has no info.php (or an unsafe name).
+     */
+    protected function _themeInfo()
+    {
+        if (isset($this->_info)) {
+            return $this->_info;
+        }
+
+        $theme_covers = [];
+        $theme_scripts = [];
+
+        /* Theme names originate from user prefs/options, so guard against
+         * path traversal: only include info.php for a plain directory name
+         * (no separators, no '..'). Anything else declares nothing. */
+        if (preg_match('/^[A-Za-z0-9_-]+$/', (string) $this->_theme)) {
+            global $registry;
+            $info = $registry->get('themesfs', 'horde') . '/' . $this->_theme . '/info.php';
+            if (is_readable($info)) {
+                include $info;
+            }
+        }
+
+        $this->_info = [
+            'theme_covers' => $theme_covers,
+            'theme_scripts' => $theme_scripts,
+        ];
+
+        return $this->_info;
+    }
+
+    /**
+     * Returns the javascript files the current theme ships.
+     *
+     * Themes may ship scripts alongside their CSS, images and sounds, by
+     * listing them in info.php:
+     *
+     *   $theme_scripts = array('theme.js');
+     *
+     * Only plain file names are accepted, and they are resolved inside the
+     * theme directory: a theme cannot pull in a script from an arbitrary path
+     * or an external host. Files that do not exist are skipped.
+     *
+     * Themes without the declaration ship no script, exactly as before.
+     *
+     * @return string[]  Script file names, relative to the theme directory.
+     */
+    public function themeScripts()
+    {
+        if (!isset($this->_scripts)) {
+            $info = $this->_themeInfo();
+            $base = $GLOBALS['registry']->get('themesfs', 'horde') .
+                '/' . $this->_theme . '/';
+            $this->_scripts = [];
+
+            foreach ((array) ($info['theme_scripts'] ?? []) as $script) {
+                /* Plain file names only: no directory separators, no '..'.
+                 * The theme directory is the only place a script may come
+                 * from. */
+                if (!preg_match('/^[A-Za-z0-9_.-]+\.js$/', (string) $script) ||
+                    strpos($script, '..') !== false) {
+                    continue;
+                }
+                if (is_readable($base . $script)) {
+                    $this->_scripts[] = $script;
+                }
+            }
+        }
+
+        return $this->_scripts;
     }
 
     /**


### PR DESCRIPTION
# Let a theme ship its own javascript files

## Summary

Themes can already ship CSS, images and sounds. They cannot ship javascript.
This adds `$theme_scripts` to `info.php`, so a theme can declare the behaviour
that goes with its markup:

```php
$theme_scripts = array('theme.js');
```

The files are resolved inside the theme directory and added to the page
alongside the theme's stylesheets. Themes without the declaration are
unaffected.

## Why

`Horde_Themes_Element` already covers CSS (`Horde_Themes_Css`), images
(`Horde_Themes_Image`) and sounds (`Horde_Themes_Sound`). Javascript is the one
asset class missing, and there is no way to fill the gap from within a theme:
Horde has no JS equivalent of the `cssfiles` hook.

For a theme that only changes colours this does not matter. It does as soon as a
theme restructures the shell, because some things no CSS selector can express —
wrapping a bare text node so it can be styled, or grouping siblings the
application emits as a flat list.

Today the only way to ship such a theme is to ask whoever installs it to add a
hook to their `hooks.php`, an instance configuration file that is not part of
the theme. The theme is then no longer installable as-is: `composer require` it,
enable it, and half of it silently does not load.

## What the patch does

- **`Horde_Themes_Cache::themeScripts()`** — reads `$theme_scripts` from the
  theme's `info.php` and returns the declared files. The `info.php` read is
  factored out of `_coveredApps()` into `_themeInfo()`, so both declarations
  share one guarded include instead of two.
- **`Horde_Script_File_ThemeDir`** — a `Horde_Script_File` that resolves against
  `themesfs`/`themesuri`, mirroring `Horde_Script_File_JsDir` which resolves
  against an app's `js/` directory.
- **`Horde_PageOutput::_addThemeScripts()`** — emits the files, called from
  `header()` right where the theme is already consulted for stylesheets.

Roughly 30 lines of new logic; the rest mirrors code that already exists.

## Scope and safety

**Theme-directory files only.** A declared entry must be a plain `*.js` file
name — no directory separators, no `..`, no URL. A theme cannot pull a script
from an arbitrary path or an external host, so this adds no CSP surface and no
third-party dependency. Unreadable files are skipped rather than emitted as
broken tags.

**No new trust.** Installing a theme already means executing its PHP: `info.php`
is `include`d by `Horde_Themes_Cache` (as of the `$theme_covers` support), and
a theme's CSS is already arbitrary. A theme is trusted code, like an installed
application; letting it ship a script file is strictly less powerful than what
it can already do.

**Theme name guard reused.** Theme names come from user prefs, so `_themeInfo()`
keeps the existing `preg_match('/^[A-Za-z0-9_-]+$/')` guard before including
`info.php`.

**Caching.** `themeScripts()` is derived on demand and is not part of
`__serialize()`, so a cached `Horde_Themes_Cache` recomputes it — same approach
as `_coveredApps()`.

**Backwards compatible.** No declaration means no script, which is the current
behaviour for every existing theme.

## A note for reviewers testing locally

This adds a new class file, so a `composer dump-autoload` is needed before the
patch does anything: without it `_addThemeScripts()` fatals on a missing
`Horde_Script_File_ThemeDir`. Nothing to do in a normal install, where the class
ships with the `horde/core` package.

## Testing

Exercised in a real install, dynamic view, with a theme declaring two scripts.
The install runs Core `e66c4242`; both files this patch touches are
byte-identical there and at the branch point, so the change under test is the
one proposed here.

The declared files are emitted alongside the core scripts and, unlike a
hook-loaded external file, they go through the normal script pipeline:

```
"/js/horde/accesskeys.js?v=5aae26c…",
"/themes/horde/default-new/footer.js?v=5aae26c…",
"/themes/horde/default-new/display-prefs.js?v=5aae26c…",
```

They are versioned like any other script file, so theme javascript takes part in
Horde's cache busting — an external-URL workaround does not, and stays cached in
the browser after the theme is updated.

Themes without `$theme_scripts` (`default`, `dark`) emit no additional script
tags.

The name filter was checked separately against `sub/dir.js`,
`../../etc/passwd.js`, `..js`, `http://evil.tld/x.js`, `style.css`,
`foo.js.php`, `a b.js` and the empty string: all rejected, only plain `*.js`
names accepted.

## Context

Follows the CSS custom property work in horde/base#111, horde/imp#69 and
horde/kronolith#73, and the `$theme_covers` declaration in horde/core#179. Those
made the layout and the calendar colours themable from CSS; this closes the
remaining gap for themes that also need to ship behaviour.
